### PR TITLE
Implement a slow string-based function template instantiation.

### DIFF
--- a/include/clang/Interpreter/InterOp.h
+++ b/include/clang/Interpreter/InterOp.h
@@ -471,6 +471,13 @@ namespace InterOp {
   /// Returns the class template instantiation arguments of \c templ_instance.
   void GetClassTemplateInstantiationArgs(TCppScope_t templ_instance,
                                          std::vector<TemplateArgInfo> &args);
+
+  /// Instantiates a function template from a given string representation. This
+  /// function also does overload resolution.
+  ///\returns the instantiated function template declaration.
+  TCppFunction_t
+  InstantiateTemplateFunctionFromString(const char* function_template);
+
   std::vector<std::string> GetAllCppNames(TCppScope_t scope);
 
   void DumpScope(TCppScope_t scope);

--- a/unittests/InterOp/ScopeReflectionTest.cpp
+++ b/unittests/InterOp/ScopeReflectionTest.cpp
@@ -704,6 +704,15 @@ TEST(ScopeReflectionTest, InstantiateNNTPClassTemplate) {
                                                 /*type_size*/ args1.size()));
 }
 
+TEST(ScopeReflectionTest, InstantiateTemplateFunctionFromString) {
+  InterOp::CreateInterpreter();
+  std::string code = R"(#include <memory>)";
+  Interp->process(code);
+  const char* str = "std::make_unique<int,int>";
+  auto* Instance1 = (Decl*)InterOp::InstantiateTemplateFunctionFromString(str);
+  EXPECT_TRUE(Instance1);
+}
+
 TEST(ScopeReflectionTest, InstantiateClassTemplate) {
   std::vector<Decl *> Decls;
   std::string code = R"(


### PR DESCRIPTION
This routine should be used only in cases where we cannot do anything else. It takes the string and tries to force the compiler to instantiate by requesting the address to the function.