### PR TITLE
Consolidate the template instantiation logic.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -29,6 +29,7 @@ Checks: >
   -readability-function-cognitive-complexity,
   -readability-redundant-access-specifiers,
   -cppcoreguidelines-avoid-magic-numbers,
+  -cppcoreguidelines-init-variables
   -cppcoreguidelines-pro-bounds-pointer-arithmetic,
   -cppcoreguidelines-pro-type-member-init,
   -llvm-namespace-comment

--- a/include/clang/Interpreter/CppInterOp.h
+++ b/include/clang/Interpreter/CppInterOp.h
@@ -534,9 +534,10 @@ namespace Cpp {
     TemplateArgInfo(TCppScope_t type, const char* integral_value = nullptr)
       : m_Type(type), m_IntegralValue(integral_value) {}
   };
-  CPPINTEROP_API TCppScope_t
-  InstantiateClassTemplate(TCppScope_t tmpl, TemplateArgInfo* template_args,
-                           size_t template_args_size);
+  /// Builds a template instantiation for a given templated declaration.
+  CPPINTEROP_API TCppScope_t InstantiateTemplate(TCppScope_t tmpl,
+                                                 TemplateArgInfo* template_args,
+                                                 size_t template_args_size);
 
   /// Returns the class template instantiation arguments of \c templ_instance.
   CPPINTEROP_API void

--- a/unittests/CppInterOp/FunctionReflectionTest.cpp
+++ b/unittests/CppInterOp/FunctionReflectionTest.cpp
@@ -709,8 +709,8 @@ TEST(FunctionReflectionTest, GetFunctionCallWrapper) {
   ASTContext& C = Interp->getCI()->getASTContext();
 
   std::vector<Cpp::TemplateArgInfo> argument = {C.IntTy.getAsOpaquePtr()};
-  auto Instance1 = Cpp::InstantiateClassTemplate(Decls1[0], argument.data(),
-                                                 /*type_size*/ argument.size());
+  auto Instance1 = Cpp::InstantiateTemplate(Decls1[0], argument.data(),
+                                            /*type_size*/ argument.size());
   EXPECT_TRUE(isa<ClassTemplateSpecializationDecl>((Decl*)Instance1));
   auto* CTSD1 = static_cast<ClassTemplateSpecializationDecl*>(Instance1);
   auto* Add_D = Cpp::GetNamed("Add",CTSD1);


### PR DESCRIPTION
This patch offers a single interface for instantiation of class, function and variable templates. That would simplify user code where we do not need to care what is the underlying template pattern (most of the time).