### PR TITLE
Implement the ability to swap functions in the JIT.

### DIFF
--- a/include/clang/Interpreter/CppInterOp.h
+++ b/include/clang/Interpreter/CppInterOp.h
@@ -455,6 +455,17 @@ namespace Cpp {
   /// function.
   bool LoadLibrary(const char *lib_path, bool lookup = true);
 
+  /// Inserts or replaces a symbol in the JIT with the one provided. This is
+  /// useful for providing our own implementations of facilities such as printf.
+  ///
+  ///\param[in] linker_mangled_name - the name of the symbol to be inserted or
+  ///           replaced.
+  ///\param[in] address - the new address of the symbol.
+  ///
+  ///\returns true on failure.
+  bool InsertOrReplaceJitSymbol(const char* linker_mangled_name,
+                                uint64_t address);
+
   /// Tries to load provided objects in a string format (prettyprint).
   std::string ObjToString(const char *type, void *obj);
 

--- a/include/clang/Interpreter/CppInterOpInterpreter.h
+++ b/include/clang/Interpreter/CppInterOpInterpreter.h
@@ -154,6 +154,7 @@ public:
   ~Interpreter() {}
 
   operator const clang::Interpreter&() const { return *inner; }
+  operator clang::Interpreter&() { return *inner; }
 
   ///\brief Describes the return result of the different routines that do the
   /// incremental compilation.

--- a/unittests/CppInterOp/CMakeLists.txt
+++ b/unittests/CppInterOp/CMakeLists.txt
@@ -6,6 +6,7 @@ add_cppinterop_unittest(CppInterOpTests
   EnumReflectionTest.cpp
   FunctionReflectionTest.cpp
   InterpreterTest.cpp
+  JitTest.cpp
   ScopeReflectionTest.cpp
   TypeReflectionTest.cpp
   Utils.cpp

--- a/unittests/CppInterOp/JitTest.cpp
+++ b/unittests/CppInterOp/JitTest.cpp
@@ -1,0 +1,32 @@
+#include "Utils.h"
+
+#include "clang/Interpreter/CppInterOp.h"
+
+#include "gtest/gtest.h"
+
+using namespace TestUtils;
+
+static int printf_jit(const char* format, ...) {
+  llvm::errs() << "printf_jit called!\n";
+  return 0;
+}
+
+TEST(JitTest, InsertOrReplaceJitSymbol) {
+  std::vector<Decl*> Decls;
+  std::string code = R"(
+    extern "C" int printf(const char*,...);
+    )";
+
+  GetAllTopLevelDecls(code, Decls);
+
+  EXPECT_FALSE(Cpp::InsertOrReplaceJitSymbol("printf", (uint64_t)&printf_jit));
+
+  testing::internal::CaptureStderr();
+  Cpp::Process("printf(\"Blah\");");
+  std::string cerrs = testing::internal::GetCapturedStderr();
+  EXPECT_STREQ(cerrs.c_str(), "printf_jit called!\n");
+
+  EXPECT_TRUE(
+      Cpp::InsertOrReplaceJitSymbol("non_existent", (uint64_t)&printf_jit));
+  EXPECT_TRUE(Cpp::InsertOrReplaceJitSymbol("non_existent", 0));
+}


### PR DESCRIPTION
This patch allows users of CppInterOp to rewire things like printf to enable rich displays, for example.