### PR TITLE
Add missing dependencies for LLVM_LINK_LLVM_DYLIB

### DIFF
--- a/lib/Interpreter/CMakeLists.txt
+++ b/lib/Interpreter/CMakeLists.txt
@@ -76,6 +76,12 @@ if (LLVM_LINK_LLVM_DYLIB)
     FrontendHLSL
     LTO
     )
+  # We will need to append the missing dependencies to pull in the right
+  # LLVM library dependencies. 
+  list(APPEND link_libs
+    clangCodeGen
+    clangStaticAnalyzerCore
+    )
 endif(LLVM_LINK_LLVM_DYLIB)
 
 add_llvm_library(clangCppInterOp


### PR DESCRIPTION
This should fix the failures in the clangdev conda package and CppInterOp.