### PR TITLE
[Symbol Names] Workaround: Mangle names for macOS

### DIFF
--- a/lib/Interpreter/CppInterOp.cpp
+++ b/lib/Interpreter/CppInterOp.cpp
@@ -2661,7 +2661,13 @@ namespace Cpp {
     // Let's inject it.
     SymbolMap::iterator It;
     llvm::orc::SymbolMap InjectedSymbols;
-    auto Name = ES.intern(linker_mangled_name);
+    auto& DL = compat::getExecutionEngine(I)->getDataLayout();
+    char GlobalPrefix = DL.getGlobalPrefix();
+    std::string tmp(linker_mangled_name);
+    if (GlobalPrefix != '\0') {
+      tmp = std::string(1, GlobalPrefix) + tmp;
+    }
+    auto Name = ES.intern(tmp);
     InjectedSymbols[Name] =
 #if CLANG_VERSION_MAJOR < 17
         JITEvaluatedSymbol(address,

--- a/unittests/CppInterOp/FunctionReflectionTest.cpp
+++ b/unittests/CppInterOp/FunctionReflectionTest.cpp
@@ -592,11 +592,7 @@ TEST(FunctionReflectionTest, IsVirtualMethod) {
   EXPECT_FALSE(Cpp::IsVirtualMethod(Decls[0]));
 }
 
-#ifdef __APPLE__
-TEST(FunctionReflectionTest, DISABLED_JitCallAdvanced) {
-#else
 TEST(FunctionReflectionTest, JitCallAdvanced) {
-#endif
   std::vector<Decl*> Decls;
   std::string code = R"(
       typedef struct _name {
@@ -617,11 +613,8 @@ TEST(FunctionReflectionTest, JitCallAdvanced) {
   Cpp::Destruct(object, Decls[1]);
 }
 
-#ifdef __APPLE__
-TEST(FunctionReflectionTest, DISABLED_GetFunctionCallWrapper) {
-#else
+
 TEST(FunctionReflectionTest, GetFunctionCallWrapper) {
-#endif
   std::vector<Decl*> Decls;
   std::string code = R"(
     int f1(int i) { return i * i; }
@@ -784,11 +777,7 @@ TEST(FunctionReflectionTest, GetFunctionArgDefault) {
   EXPECT_EQ(Cpp::GetFunctionArgDefault(Decls[1], 2), "34126");
 }
 
-#ifdef __APPLE__
-TEST(FunctionReflectionTest, DISABLED_Construct) {
-#else
 TEST(FunctionReflectionTest, Construct) {
-#endif
   Cpp::CreateInterpreter();
 
   Interp->declare(R"(
@@ -822,11 +811,7 @@ TEST(FunctionReflectionTest, Construct) {
   EXPECT_EQ(output, "Constructor Executed");
 }
 
-#ifdef __APPLE__
-TEST(FunctionReflectionTest, DISABLED_Destruct) {
-#else
 TEST(FunctionReflectionTest, Destruct) {
-#endif
   Cpp::CreateInterpreter();
 
   Interp->declare(R"(

--- a/unittests/CppInterOp/InterpreterTest.cpp
+++ b/unittests/CppInterOp/InterpreterTest.cpp
@@ -49,11 +49,7 @@ TEST(InterpreterTest, Evaluate) {
   EXPECT_FALSE(HadError) ;
 }
 
-#ifdef __APPLE__ //Fails for Cling Tests
-TEST(InterpreterTest, DISABLED_Process) {
-#else
 TEST(InterpreterTest, Process) {  
-#endif
   Cpp::CreateInterpreter();
   EXPECT_TRUE(Cpp::Process("") == 0);
   EXPECT_TRUE(Cpp::Process("int a = 12;") == 0);

--- a/unittests/CppInterOp/JitTest.cpp
+++ b/unittests/CppInterOp/JitTest.cpp
@@ -11,11 +11,7 @@ static int printf_jit(const char* format, ...) {
   return 0;
 }
 
-#ifdef __APPLE__
-TEST(JitTest, DISABLED_InsertOrReplaceJitSymbol) {
-#else
 TEST(JitTest, InsertOrReplaceJitSymbol) {
-#endif
   std::vector<Decl*> Decls;
   std::string code = R"(
     extern "C" int printf(const char*,...);

--- a/unittests/CppInterOp/ScopeReflectionTest.cpp
+++ b/unittests/CppInterOp/ScopeReflectionTest.cpp
@@ -99,11 +99,8 @@ TEST(ScopeReflectionTest, SizeOf) {
   EXPECT_EQ(Cpp::SizeOf(Decls[7]), (size_t)16);
 }
 
-#ifdef __APPLE__
-TEST(ScopeReflectionTest, DISABLED_IsBuiltin) {
-#else
+
 TEST(ScopeReflectionTest, IsBuiltin) {
-#endif
   // static std::set<std::string> g_builtins =
   // {"bool", "char", "signed char", "unsigned char", "wchar_t", "short", "unsigned short",
   //  "int", "unsigned int", "long", "unsigned long", "long long", "unsigned long long",
@@ -433,11 +430,7 @@ TEST(ScopeReflectionTest, GetScopefromCompleteName) {
   EXPECT_EQ(Cpp::GetQualifiedName(Cpp::GetScopeFromCompleteName("N1::N2::C::S")), "N1::N2::C::S");
 }
 
-#ifdef __APPLE__
-TEST(ScopeReflectionTest, DISABLED_GetNamed) {
-#else
 TEST(ScopeReflectionTest, GetNamed) {
-#endif
   std::string code = R"(namespace N1 {
                         namespace N2 {
                           class C {
@@ -761,11 +754,7 @@ TEST(ScopeReflectionTest, InstantiateNNTPClassTemplate) {
                                                 /*type_size*/ args1.size()));
 }
 
-#ifdef __APPLE__
-TEST(ScopeReflectionTest, DISABLED_InstantiateTemplateFunctionFromString) {
-#else
 TEST(ScopeReflectionTest, InstantiateTemplateFunctionFromString) {
-#endif
   Cpp::CreateInterpreter();
   std::string code = R"(#include <memory>)";
   Interp->process(code);
@@ -905,11 +894,8 @@ TEST(ScopeReflectionTest, GetClassTemplateInstantiationArgs) {
   EXPECT_TRUE(instance_types.size() == 0);
 }
 
-#ifdef __APPLE__
-TEST(ScopeReflectionTest, DISABLED_IncludeVector) {
-#else
+
 TEST(ScopeReflectionTest, IncludeVector) {
-#endif
   std::string code = R"(
     #include <vector>
     #include <iostream>

--- a/unittests/CppInterOp/TypeReflectionTest.cpp
+++ b/unittests/CppInterOp/TypeReflectionTest.cpp
@@ -522,11 +522,7 @@ TEST(TypeReflectionTest, IsPODType) {
   EXPECT_FALSE(Cpp::IsPODType(0));
 }
 
-#ifdef __APPLE__
-TEST(TypeReflectionTest, DISABLED_IsSmartPtrType) {
-#else
 TEST(TypeReflectionTest, IsSmartPtrType) {
-#endif
   Cpp::CreateInterpreter();
 
   Interp->declare(R"(


### PR DESCRIPTION
- Prepend `_` before looking for symbols
- Currently the interface is not unified and solutions like a global prefix would work better.