### PR TITLE
Windows test fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -373,6 +373,55 @@ option(CPPINTEROP_ENABLE_DOXYGEN "Use doxygen to generate CppInterOp interal API
 option(CPPINTEROP_ENABLE_SPHINX "Use sphinx to generage CppInterOp user documentation")
 option(CPPINTEROP_ENABLE_TESTING "Enables the testing infrastructure." ON)
 
+if(MSVC)
+
+  set(MSVC_EXPORTLIST
+   ??_7type_info@@6B@
+   ?nothrow@std@@3Unothrow_t@1@B
+   _Init_thread_header
+   _Init_thread_footer
+   ??_7type_info@@6B@
+   ?_Facet_Register@std@@YAXPEAV_Facet_base@1@@Z
+  )
+
+  set(MSVC_EXPORTLIST ${MSVC_EXPORTLIST}
+   ??2@YAPEAX_K@Z
+   ??3@YAXPEAX@Z
+   ??3@YAXPEAX_K@Z
+   ??_U@YAPEAX_K@Z
+   ??_V@YAXPEAX@Z
+   ??_V@YAXPEAX_K@Z
+   ??2@YAPEAX_KAEBUnothrow_t@std@@@Z
+   ??_U@YAPEAX_KAEBUnothrow_t@std@@@Z
+   ??6?$basic_ostream@DU?$char_traits@D@std@@@std@@QEAAAEAV01@H@Z
+   ??6?$basic_ostream@DU?$char_traits@D@std@@@std@@QEAAAEAV01@M@Z
+   ??6?$basic_ostream@DU?$char_traits@D@std@@@std@@QEAAAEAV01@N@Z
+   ??6?$basic_ostream@DU?$char_traits@D@std@@@std@@QEAAAEAV01@PEBX@Z
+   ??6?$basic_ostream@DU?$char_traits@D@std@@@std@@QEAAAEAV01@P6AAEAV01@AEAV01@@Z@Z
+   ??$?6U?$char_traits@D@std@@@std@@YAAEAV?$basic_ostream@DU?$char_traits@D@std@@@0@AEAV10@D@Z
+   ??$?6U?$char_traits@D@std@@@std@@YAAEAV?$basic_ostream@DU?$char_traits@D@std@@@0@AEAV10@PEBD@Z
+   ?_Facet_Register@std@@YAXPEAV_Facet_base@1@@Z
+  )
+
+  if(MSVC_VERSION LESS 1914)
+    set(MSVC_EXPORTLIST ${MSVC_EXPORTLIST} ??3@YAXPAX0@Z ??_V@YAXPAX0@Z)
+  endif()
+
+  if(MSVC_VERSION GREATER_EQUAL 1936)
+    set(MSVC_EXPORTLIST ${MSVC_EXPORTLIST}
+        __std_find_trivial_1
+        __std_find_trivial_2
+        __std_find_trivial_4
+        __std_find_trivial_8
+    )
+  endif()
+
+foreach(sym ${MSVC_EXPORTLIST})
+  set(MSVC_EXPORTS "${MSVC_EXPORTS} /EXPORT:${sym}")
+endforeach(sym ${MSVC_EXPORTLIST})
+
+endif()
+
 if (CPPINTEROP_INCLUDE_DOCS)
   add_subdirectory(docs)
 endif()

--- a/lib/Interpreter/CppInterOp.cpp
+++ b/lib/Interpreter/CppInterOp.cpp
@@ -2463,6 +2463,10 @@ namespace Cpp {
     std::vector<const char *> ClingArgv = {"-resource-dir", ResourceDir.c_str(),
                                            "-std=c++14"};
     ClingArgv.insert(ClingArgv.begin(), MainExecutableName.c_str());
+#ifdef _WIN32
+    // FIXME : Workaround Sema::PushDeclContext assert on windows
+    ClingArgv.push_back("-fno-delayed-template-parsing");
+#endif
     ClingArgv.insert(ClingArgv.end(), Args.begin(), Args.end());
     // To keep the Interpreter creation interface between cling and clang-repl
     // to some extent compatible we should put Args and GpuArgs together. On the

--- a/lib/Interpreter/DynamicLibraryManagerSymbol.cpp
+++ b/lib/Interpreter/DynamicLibraryManagerSymbol.cpp
@@ -911,8 +911,17 @@ namespace Cpp {
         // All the symbols are already flagged as exported. 
         // We cannot really ignore symbols based on flags as we do on unix.
         StringRef Name;
-        if (I->getSymbolName(Name))
+        auto Err = I->getSymbolName(Name);
+
+        if (Err) {
+          std::string Message;
+          handleAllErrors(std::move(Err), [&](llvm::ErrorInfoBase& EIB) {
+            Message += EIB.message() + "; ";
+          });
+          LLVM_DEBUG(dbgs() << "Dyld::BuildBloomFilter: Failed to read symbol "
+                            << Message << "\n");
           continue;
+        }
         if (Name.empty())
           continue;
 

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -26,6 +26,7 @@ function(add_cppinterop_unittest name)
 
 if(WIN32)
   target_link_libraries(${name} PUBLIC ${ARG_LIBRARIES} ${gtest_libs})
+  set_property(TARGET ${name} APPEND_STRING PROPERTY LINK_FLAGS "${MSVC_EXPORTS}")
 else()
   target_link_libraries(${name} PUBLIC ${ARG_LIBRARIES} ${gtest_libs} pthread)
 endif()

--- a/unittests/CppInterOp/EnumReflectionTest.cpp
+++ b/unittests/CppInterOp/EnumReflectionTest.cpp
@@ -124,7 +124,12 @@ TEST(EnumReflectionTest, GetIntegerTypeFromEnumScope) {
   EXPECT_EQ(Cpp::GetTypeAsString(Cpp::GetIntegerTypeFromEnumScope(Decls[1])), "char");
   EXPECT_EQ(Cpp::GetTypeAsString(Cpp::GetIntegerTypeFromEnumScope(Decls[2])), "int");
   EXPECT_EQ(Cpp::GetTypeAsString(Cpp::GetIntegerTypeFromEnumScope(Decls[3])), "long long");
+#ifdef _WIN32
+  EXPECT_EQ(Cpp::GetTypeAsString(Cpp::GetIntegerTypeFromEnumScope(Decls[4])),
+            "int");
+#else
   EXPECT_EQ(Cpp::GetTypeAsString(Cpp::GetIntegerTypeFromEnumScope(Decls[4])), "unsigned int");
+#endif
   EXPECT_EQ(Cpp::GetTypeAsString(Cpp::GetIntegerTypeFromEnumScope(Decls[5])),"NULL TYPE");
 }
 
@@ -180,7 +185,11 @@ TEST(EnumReflectionTest, GetIntegerTypeFromEnumType) {
   EXPECT_EQ(get_int_type_from_enum_var(Decls[7]), "char");
   EXPECT_EQ(get_int_type_from_enum_var(Decls[8]), "int");
   EXPECT_EQ(get_int_type_from_enum_var(Decls[9]), "long long");
+#ifdef _WIN32
+  EXPECT_EQ(get_int_type_from_enum_var(Decls[10]), "int");
+#else
   EXPECT_EQ(get_int_type_from_enum_var(Decls[10]), "unsigned int");
+#endif
   EXPECT_EQ(get_int_type_from_enum_var(Decls[11]), "NULL TYPE"); // When a non Enum Type variable is used 
 }
 


### PR DESCRIPTION
Not all tests pass yet, but they shouldn't crash early with a fatal assert from Clang any more. The library tests could fail in assert builds before because an Error value for a from a Coff symbol in Dyld::BuildBloomFilter was not handled, those errors were actually revealing another issue that search path to load shared libraries to find symbols should be much more restricted instead of PATH environment variable. 
I also added the exporting of some MSVC runtime symbols based on the code from Clings cmake files to try and fix STL symbol errors, but tests still fail because of missing emulated TLS symbols `__emutls_get_address and __emutls_v._Init_thread_epoch` .

Current failing tests are:
```
 EnumReflectionTest.GetIntegerTypeFromEnumScope
 EnumReflectionTest.GetIntegerTypeFromEnumType
 FunctionReflectionTest.GetFunctionAddress
 FunctionReflectionTest.Construct
 FunctionReflectionTest.Destruct
```
