### PR TITLE
[cmake] Work around a bug in the llvm config.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.13)
 
+include(GNUInstallDirs)
+
 set(CMAKE_MODULE_PATH
   ${CMAKE_MODULE_PATH}
   "${CMAKE_CURRENT_SOURCE_DIR}/cmake"


### PR DESCRIPTION
In short we use variables which require including `GNUInstallDirs` but we are expecting somebody else to include it for us.

See llvm/llvm-project#83802