### PR TITLE
[cmake] Modify cmake config file to set correct suffix and prefix for library 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1233,7 +1233,7 @@ jobs:
                 -DCling_DIR=$LLVM_BUILD_DIR/tools/cling         \
                 -DLLVM_DIR=$LLVM_BUILD_DIR/lib/cmake/llvm       \
                 -DClang_DIR=$LLVM_BUILD_DIR/lib/cmake/clang     \
-                -DBUILD_SHARED_LIBS=ON                          \
+                -DBUILD_SHARED_LIBS=OFF                          \
                 -DCODE_COVERAGE=${{ env.CODE_COVERAGE }}        \
                 -DCMAKE_INSTALL_PREFIX=$PREFIX         \
                 -DCMAKE_FIND_ROOT_PATH_MODE_PACKAGE=ON            \

--- a/cmake/CppInterOp/CppInterOpConfig.cmake.in
+++ b/cmake/CppInterOp/CppInterOpConfig.cmake.in
@@ -10,19 +10,20 @@ get_filename_component(CPPINTEROP_INSTALL_PREFIX "${CPPINTEROP_INSTALL_PREFIX}" 
 include(CMakeSystemSpecificInformation)
 
 ### build/install workaround
+if (@BUILD_SHARED_LIBS@)
+  set(__lib_suffix ${CMAKE_SHARED_LIBRARY_SUFFIX})
+  set(__lib_prefix ${CMAKE_SHARED_LIBRARY_PREFIX})
+else()    
+  set(__lib_suffix ${CMAKE_STATIC_LIBRARY_SUFFIX})
+  set(__lib_prefix ${CMAKE_STATIC_LIBRARY_PREFIX})
+endif()
 
 if (IS_DIRECTORY "${CPPINTEROP_INSTALL_PREFIX}/include")
   set(_include "${CPPINTEROP_INSTALL_PREFIX}/include")
-  set(_libs "${CPPINTEROP_INSTALL_PREFIX}/lib/${CMAKE_SHARED_LIBRARY_PREFIX}clangCppInterOp${CMAKE_SHARED_LIBRARY_SUFFIX}")
+  set(_libs "${CPPINTEROP_INSTALL_PREFIX}/lib/${__lib_prefix}clangCppInterOp${__lib_suffix}")
 else()
   set(_include "@CMAKE_CURRENT_SOURCE_DIR@/include")
-  set(_libs "@CMAKE_CURRENT_BINARY_DIR@/lib/${CMAKE_SHARED_LIBRARY_PREFIX}clangCppInterOp${CMAKE_SHARED_LIBRARY_SUFFIX}")
-endif()
-
-if (IS_DIRECTORY "${CPPINTEROP_INSTALL_PREFIX}/lib/cmake/CppInterOp")
-  set(_cmake "${CPPINTEROP_INSTALL_PREFIX}/lib/cmake/CppInterOp")
-else()
-  set(_cmake "@CMAKE_CURRENT_SOURCE_DIR@/cmake/CppInterOp")
+  set(_libs "@CMAKE_CURRENT_BINARY_DIR@/lib/${__lib_prefix}clangCppInterOp${__lib_suffix}")
 endif()
 
 ###
@@ -33,7 +34,11 @@ set(CPPINTEROP_INCLUDE_DIRS "${_include}")
 set(CPPINTEROP_LIBRARIES "${_libs}")
 
 # Provide all our library targets to users.
-add_library(clangCppInterOp SHARED IMPORTED)
+if (@BUILD_SHARED_LIBS@)
+  add_library(clangCppInterOp SHARED IMPORTED)
+else()    
+  add_library(clangCppInterOp STATIC IMPORTED)
+endif()
 set_property(TARGET clangCppInterOp PROPERTY INTERFACE_INCLUDE_DIRECTORIES "${_include}")
 set_property(TARGET clangCppInterOp PROPERTY IMPORTED_LOCATION "${_libs}")
 


### PR DESCRIPTION
The purpose of this PR is to find the modifications to CppInterOp needed so that the wasm build of xeus-cpp in PR https://github.com/compiler-research/xeus-cpp/pull/14 can pass.