### PR TITLE
Implement detection of resource and include dirs.

### DIFF
--- a/include/clang/Interpreter/CppInterOp.h
+++ b/include/clang/Interpreter/CppInterOp.h
@@ -444,6 +444,21 @@ namespace Cpp {
   /// Returns the resource-dir path (for headers).
   const char* GetResourceDir();
 
+  /// Uses the underlying clang compiler to detect the resource directory.
+  /// In essence calling clang -print-resource-dir and checks if it ends with
+  /// a compatible to CppInterOp version.
+  ///\param[in] ClangBinaryName - the name (or the full path) of the compiler
+  ///                             to ask.
+  std::string DetectResourceDir(const char* ClangBinaryName = "clang");
+
+  /// Asks the system compiler for its default include paths.
+  ///\param[out] Paths - the list of include paths returned by eg.
+  ///                     `c++ -xc++ -E -v /dev/null 2>&1`
+  ///\param[in] CompilerName - the name (or the full path) of the compiler
+  ///                          binary file.
+  void DetectSystemCompilerIncludePaths(std::vector<std::string>& Paths,
+                                        const char* CompilerName = "c++");
+
   /// Secondary search path for headers, if not found using the
   /// GetResourceDir() function.
   void AddIncludePath(const char *dir);

--- a/unittests/CppInterOp/CMakeLists.txt
+++ b/unittests/CppInterOp/CMakeLists.txt
@@ -18,6 +18,9 @@ target_link_libraries(CppInterOpTests
   clangCppInterOp
   )
 
+set_source_files_properties(InterpreterTest.cpp PROPERTIES COMPILE_DEFINITIONS
+  "LLVM_BINARY_DIR=\"${LLVM_BINARY_DIR}\""
+  )
 export_executable_symbols(CppInterOpTests)
 
 unset(LLVM_LINK_COMPONENTS)


### PR DESCRIPTION
This is useful when deployed CppInterOp needs to create an interpreter. Often the interpreter itself cannot use the clang toolchain logic to discover both the resource-dir and the include paths. This is because CppInterOp is a library and usually put in the `lib` folder whereas the toolchain logic expects things to be relative to the `bin` folder.

In such setups, we can ask CppInterOp to detect the resource directory by asking clang about it. In the same vain, of finding C and C++ headers we can ask the system compiler about the include paths.