### PR TITLE
Re-enable win tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -684,7 +684,6 @@ jobs:
         echo "CPLUS_INCLUDE_PATH=$CPLUS_INCLUDE_PATH" >> $GITHUB_ENV
 
     - name: Build and Test/Install CppInterOp on Windows systems
-      continue-on-error: true
       if: ${{ runner.os == 'windows' }}
       run: |
         #FIXME: Windows CppInterOp tests expected to fail

--- a/unittests/CppInterOp/DynamicLibraryManagerTest.cpp
+++ b/unittests/CppInterOp/DynamicLibraryManagerTest.cpp
@@ -17,7 +17,11 @@ std::string GetExecutablePath(const char* Argv0) {
   return llvm::sys::fs::getMainExecutable(Argv0, MainAddr);
 }
 
+#ifdef _WIN32
+TEST(DynamicLibraryManagerTest, DISABLED_Sanity) {
+#else
 TEST(DynamicLibraryManagerTest, Sanity) {
+#endif // _WIN32
   EXPECT_TRUE(Cpp::CreateInterpreter());
   EXPECT_FALSE(Cpp::GetFunctionAddress("ret_zero"));
 

--- a/unittests/CppInterOp/FunctionReflectionTest.cpp
+++ b/unittests/CppInterOp/FunctionReflectionTest.cpp
@@ -553,7 +553,11 @@ TEST(FunctionReflectionTest, IsStaticMethod) {
   EXPECT_TRUE(Cpp::IsStaticMethod(SubDecls[2]));
 }
 
+#ifdef _WIN32
+TEST(FunctionReflectionTest, DISABLED_GetFunctionAddress) {
+#else
 TEST(FunctionReflectionTest, GetFunctionAddress) {
+#endif // _WIN32
   std::vector<Decl*> Decls, SubDecls;
   std::string code = "int f1(int i) { return i * i; }";
 
@@ -613,8 +617,11 @@ TEST(FunctionReflectionTest, JitCallAdvanced) {
   Cpp::Destruct(object, Decls[1]);
 }
 
-
+#ifdef _WIN32
+TEST(FunctionReflectionTest, DISABLED_GetFunctionCallWrapper) {
+#else
 TEST(FunctionReflectionTest, GetFunctionCallWrapper) {
+#endif // _WIN32
   std::vector<Decl*> Decls;
   std::string code = R"(
     int f1(int i) { return i * i; }
@@ -777,7 +784,11 @@ TEST(FunctionReflectionTest, GetFunctionArgDefault) {
   EXPECT_EQ(Cpp::GetFunctionArgDefault(Decls[1], 2), "34126");
 }
 
+#ifdef _WIN32
+TEST(FunctionReflectionTest, DISABLED_Construct) {
+#else
 TEST(FunctionReflectionTest, Construct) {
+#endif // _WIN32
   Cpp::CreateInterpreter();
 
   Interp->declare(R"(
@@ -811,7 +822,11 @@ TEST(FunctionReflectionTest, Construct) {
   EXPECT_EQ(output, "Constructor Executed");
 }
 
+#ifdef _WIN32
+TEST(FunctionReflectionTest, DISABLED_Destruct) {
+#else
 TEST(FunctionReflectionTest, Destruct) {
+#endif // _WIN32
   Cpp::CreateInterpreter();
 
   Interp->declare(R"(

--- a/unittests/CppInterOp/InterpreterTest.cpp
+++ b/unittests/CppInterOp/InterpreterTest.cpp
@@ -53,7 +53,11 @@ TEST(InterpreterTest, Evaluate) {
   EXPECT_FALSE(HadError) ;
 }
 
+#ifdef _WIN32
+TEST(InterpreterTest, DISABLED_Process) {
+#else
 TEST(InterpreterTest, Process) {
+#endif // _WIN32
   Cpp::CreateInterpreter();
   EXPECT_TRUE(Cpp::Process("") == 0);
   EXPECT_TRUE(Cpp::Process("int a = 12;") == 0);
@@ -85,11 +89,11 @@ TEST(InterpreterTest, CreateInterpreter) {
   EXPECT_FALSE(Cpp::GetNamed("cppUnknown"));
 }
 
-#ifdef LLVM_BINARY_DIR
+#if defined(LLVM_BINARY_DIR) && !defined(_WIN32)
 TEST(InterpreterTest, DetectResourceDir) {
 #else
 TEST(InterpreterTest, DISABLED_DetectResourceDir) {
-#endif // LLVM_BINARY_DIR
+#endif // LLVM_BINARY_DIR || !_WIN32
   Cpp::CreateInterpreter();
   EXPECT_STRNE(Cpp::DetectResourceDir().c_str(), Cpp::GetResourceDir());
   llvm::SmallString<256> Clang(LLVM_BINARY_DIR);
@@ -98,7 +102,11 @@ TEST(InterpreterTest, DISABLED_DetectResourceDir) {
   EXPECT_STREQ(DetectedPath.c_str(), Cpp::GetResourceDir());
 }
 
+#ifdef _WIN32
+TEST(InterpreterTest, DISABLED_DetectSystemCompilerIncludePaths) {
+#else
 TEST(InterpreterTest, DetectSystemCompilerIncludePaths) {
+#endif // _WIN32
   std::vector<std::string> includes;
   Cpp::DetectSystemCompilerIncludePaths(includes);
   EXPECT_FALSE(includes.empty());


### PR DESCRIPTION
@mcbarton, @fsfod, do you have a clue why, although gtest is passing, on windows we get:

```
  2/2 Test #2: cppinterop-DynamicLibraryManagerTests ...   Passed    0.02 sec
  
  100% tests passed, 0 tests failed out of 2
  
  Label Time Summary:
  DEPENDS    =  13.82 sec*proc (2 tests)
  
  Total Test time (real) =  13.94 sec
  Building Custom Rule D:/a/CppInterOp/CppInterOp/unittests/CMakeLists.txt
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Microsoft\VC\v170\Microsoft.CppCommon.targets(254,5): error MSB8066: Custom build for 'D:\a\CppInterOp\CppInterOp\build\CMakeFiles\f59abe5bb8dc1f8e4095ecae6605a895\check-cppinterop.rule;D:\a\CppInterOp\CppInterOp\unittests\CMakeLists.txt' exited with code -1. [D:\a\CppInterOp\CppInterOp\build\unittests\check-cppinterop.vcxproj]
```

More [here](https://github.com/compiler-research/CppInterOp/actions/runs/8306429799/job/22734502469#step:21:605).

