### PR TITLE
Enable template features

### DIFF
--- a/include/clang/Interpreter/CppInterOp.h
+++ b/include/clang/Interpreter/CppInterOp.h
@@ -246,7 +246,7 @@ namespace Cpp {
   /// passed as a parameter, and if the parent is not passed, 
   /// then global scope will be assumed.
   CPPINTEROP_API TCppScope_t GetScope(const std::string& name,
-                                      TCppScope_t parent = 0);
+                                      TCppScope_t parent = nullptr);
 
   /// When the namespace is known, then the parent doesn't need
   /// to be specified. This will probably be phased-out in
@@ -286,11 +286,11 @@ namespace Cpp {
 
   /// Gets a list of all the Methods that are in the Class that is
   /// supplied as a parameter.
-  CPPINTEROP_API std::vector<TCppFunction_t> GetClassMethods(TCppScope_t klass);
+  CPPINTEROP_API void GetClassMethods(TCppScope_t klass, std::vector<TCppFunction_t> &methods);
 
   ///\returns Template function pointer list to add proxies for
   /// un-instantiated/non-overloaded templated methods
-  std::vector<TCppFunction_t> GetTemplatedFuncs(TCppScope_t klass);
+  CPPINTEROP_API void GetFunctionTemplatedDecls(TCppScope_t klass, std::vector<TCppFunction_t> &methods);
 
   ///\returns if a class has a default constructor.
   CPPINTEROP_API bool HasDefaultConstructor(TCppScope_t scope);
@@ -333,10 +333,10 @@ namespace Cpp {
   /// This function performs a lookup to check if there is a
   /// templated function of that type.
   CPPINTEROP_API bool ExistsFunctionTemplate(const std::string& name,
-                                             TCppScope_t parent = 0);
+                                             TCppScope_t parent = nullptr);
 
   CPPINTEROP_API std::vector<TCppFunction_t>
-  GetTemplatedMethods(const std::string& name, TCppScope_t parent = 0,
+  GetTemplatedMethods(const std::string& name, TCppScope_t parent = nullptr,
                       const std::string& filter = "");
 
   CPPINTEROP_API TCppIndex_t GetNumTemplatedMethods(TCppScope_t scope,
@@ -550,7 +550,7 @@ namespace Cpp {
   };
   /// Builds a template instantiation for a given templated declaration.
   CPPINTEROP_API TCppScope_t InstantiateTemplate(TCppScope_t tmpl,
-                                                 TemplateArgInfo* template_args,
+                                                 const TemplateArgInfo* template_args,
                                                  size_t template_args_size);
 
   /// Returns the class template instantiation arguments of \c templ_instance.
@@ -567,9 +567,9 @@ namespace Cpp {
   // Find best template match based on explicit template parameters and arg
   // types
   CPPINTEROP_API TCppFunction_t
-  BestTemplateFunctionMatch(std::vector<TCppFunction_t> candidates,
-                            std::vector<TemplateArgInfo> explicit_types,
-                            std::vector<TemplateArgInfo> arg_types);
+  BestTemplateFunctionMatch(const std::vector<TCppFunction_t>& candidates,
+                            const std::vector<TemplateArgInfo>& explicit_types,
+                            const std::vector<TemplateArgInfo>& arg_types);
 
   CPPINTEROP_API std::vector<std::string> GetAllCppNames(TCppScope_t scope);
 

--- a/include/clang/Interpreter/CppInterOp.h
+++ b/include/clang/Interpreter/CppInterOp.h
@@ -284,13 +284,19 @@ namespace Cpp {
   CPPINTEROP_API int64_t GetBaseClassOffset(TCppScope_t derived,
                                             TCppScope_t base);
 
-  /// Gets a list of all the Methods that are in the Class that is
+  /// Sets a list of all the Methods that are in the Class that is
   /// supplied as a parameter.
-  CPPINTEROP_API void GetClassMethods(TCppScope_t klass, std::vector<TCppFunction_t> &methods);
+  ///\param[in] klass - Pointer to the scope/class under which the methods have
+  ///           to be retrieved
+  ///\param[out] methods - Vector of methods in the class
+  CPPINTEROP_API void GetClassMethods(TCppScope_t klass,
+                                      std::vector<TCppFunction_t>& methods);
 
   ///\returns Template function pointer list to add proxies for
   /// un-instantiated/non-overloaded templated methods
-  CPPINTEROP_API void GetFunctionTemplatedDecls(TCppScope_t klass, std::vector<TCppFunction_t> &methods);
+  CPPINTEROP_API void
+  GetFunctionTemplatedDecls(TCppScope_t klass,
+                            std::vector<TCppFunction_t>& methods);
 
   ///\returns if a class has a default constructor.
   CPPINTEROP_API bool HasDefaultConstructor(TCppScope_t scope);
@@ -335,8 +341,15 @@ namespace Cpp {
   CPPINTEROP_API bool ExistsFunctionTemplate(const std::string& name,
                                              TCppScope_t parent = nullptr);
 
-  CPPINTEROP_API std::vector<TCppFunction_t>
-  GetTemplatedMethods(const std::string& name, TCppScope_t parent = nullptr);
+  /// Sets a list of all the Templated Methods that are in the Class that is
+  /// supplied as a parameter.
+  ///\param[in] name - method name
+  ///\param[in] parent - Pointer to the scope/class under which the methods have
+  ///           to be retrieved
+  ///\param[out] funcs - vector of function pointers matching the name
+  CPPINTEROP_API void
+  GetClassTemplatedMethods(const std::string& name, TCppScope_t parent,
+                           std::vector<TCppFunction_t>& funcs);
 
   /// Checks if the provided parameter is a method.
   CPPINTEROP_API bool IsMethod(TCppConstFunction_t method);
@@ -542,11 +555,24 @@ namespace Cpp {
       : m_Type(type), m_IntegralValue(integral_value) {}
   };
   /// Builds a template instantiation for a given templated declaration.
-  CPPINTEROP_API TCppScope_t InstantiateTemplate(TCppScope_t tmpl,
-                                                 const TemplateArgInfo* template_args,
-                                                 size_t template_args_size);
+  /// Offers a single interface for instantiation of class, function and
+  /// variable templates
+  ///
+  ///\param[in] tmpl - Uninstantiated template class/function
+  ///\param[in] template_args - Pointer to vector of template arguments stored
+  ///           in the \c TemplateArgInfo struct
+  ///\param[in] template_args_size - Size of the vector of template arguments
+  ///           passed as \c template_args
+  ///
+  ///\returns Instantiated templated class/function/variable pointer
+  CPPINTEROP_API TCppScope_t
+  InstantiateTemplate(TCppScope_t tmpl, const TemplateArgInfo* template_args,
+                      size_t template_args_size);
 
-  /// Returns the class template instantiation arguments of \c templ_instance.
+  /// Sets the class template instantiation arguments of \c templ_instance.
+  ///
+  ///\param[in] templ_instance - Pointer to the template instance
+  ///\param[out] args - Vector of instantiation arguments
   CPPINTEROP_API void
   GetClassTemplateInstantiationArgs(TCppScope_t templ_instance,
                                     std::vector<TemplateArgInfo>& args);
@@ -557,8 +583,15 @@ namespace Cpp {
   CPPINTEROP_API TCppFunction_t
   InstantiateTemplateFunctionFromString(const char* function_template);
 
-  // Find best template match based on explicit template parameters and arg
-  // types
+  /// Finds best template match based on explicit template parameters and
+  /// argument types
+  ///
+  ///\param[in] candidates - Vector of suitable candidates that come under the
+  ///           parent scope and have the same name (obtained using
+  ///           GetClassTemplatedMethods)
+  ///\param[in] explicit_types - set of expicitly instantiated template types
+  ///\param[in] arg_types - set of argument types
+  ///\returns Instantiated function pointer
   CPPINTEROP_API TCppFunction_t
   BestTemplateFunctionMatch(const std::vector<TCppFunction_t>& candidates,
                             const std::vector<TemplateArgInfo>& explicit_types,

--- a/include/clang/Interpreter/CppInterOp.h
+++ b/include/clang/Interpreter/CppInterOp.h
@@ -336,9 +336,8 @@ namespace Cpp {
                                              TCppScope_t parent = nullptr);
 
   CPPINTEROP_API std::vector<TCppFunction_t>
-  GetTemplatedMethods(const std::string& name, TCppScope_t parent = nullptr,
-                      const std::string& filter = "");
-                      
+  GetTemplatedMethods(const std::string& name, TCppScope_t parent = nullptr);
+
   /// Checks if the provided parameter is a method.
   CPPINTEROP_API bool IsMethod(TCppConstFunction_t method);
 

--- a/include/clang/Interpreter/CppInterOp.h
+++ b/include/clang/Interpreter/CppInterOp.h
@@ -292,8 +292,11 @@ namespace Cpp {
   CPPINTEROP_API void GetClassMethods(TCppScope_t klass,
                                       std::vector<TCppFunction_t>& methods);
 
-  ///\returns Template function pointer list to add proxies for
-  /// un-instantiated/non-overloaded templated methods
+  /// Template function pointer list to add proxies for un-instantiated/
+  /// non-overloaded templated methods
+  ///\param[in] klass - Pointer to the scope/class under which the methods have
+  ///           to be retrieved
+  ///\param[out] methods - Vector of methods in the class
   CPPINTEROP_API void
   GetFunctionTemplatedDecls(TCppScope_t klass,
                             std::vector<TCppFunction_t>& methods);

--- a/include/clang/Interpreter/CppInterOp.h
+++ b/include/clang/Interpreter/CppInterOp.h
@@ -338,13 +338,7 @@ namespace Cpp {
   CPPINTEROP_API std::vector<TCppFunction_t>
   GetTemplatedMethods(const std::string& name, TCppScope_t parent = nullptr,
                       const std::string& filter = "");
-
-  CPPINTEROP_API TCppIndex_t GetNumTemplatedMethods(TCppScope_t scope,
-                                                    bool accept_namespace);
-
-  CPPINTEROP_API std::string GetTemplatedMethodName(TCppScope_t scope,
-                                                    TCppIndex_t imeth);
-
+                      
   /// Checks if the provided parameter is a method.
   CPPINTEROP_API bool IsMethod(TCppConstFunction_t method);
 

--- a/include/clang/Interpreter/CppInterOp.h
+++ b/include/clang/Interpreter/CppInterOp.h
@@ -288,6 +288,10 @@ namespace Cpp {
   /// supplied as a parameter.
   CPPINTEROP_API std::vector<TCppFunction_t> GetClassMethods(TCppScope_t klass);
 
+  ///\returns Template function pointer list to add proxies for
+  /// un-instantiated/non-overloaded templated methods
+  std::vector<TCppFunction_t> GetTemplatedFuncs(TCppScope_t klass);
+
   ///\returns if a class has a default constructor.
   CPPINTEROP_API bool HasDefaultConstructor(TCppScope_t scope);
 
@@ -330,6 +334,16 @@ namespace Cpp {
   /// templated function of that type.
   CPPINTEROP_API bool ExistsFunctionTemplate(const std::string& name,
                                              TCppScope_t parent = 0);
+
+  CPPINTEROP_API std::vector<TCppFunction_t>
+  GetTemplatedMethods(const std::string& name, TCppScope_t parent = 0,
+                      const std::string& filter = "");
+
+  CPPINTEROP_API TCppIndex_t GetNumTemplatedMethods(TCppScope_t scope,
+                                                    bool accept_namespace);
+
+  CPPINTEROP_API std::string GetTemplatedMethodName(TCppScope_t scope,
+                                                    TCppIndex_t imeth);
 
   /// Checks if the provided parameter is a method.
   CPPINTEROP_API bool IsMethod(TCppConstFunction_t method);
@@ -549,6 +563,13 @@ namespace Cpp {
   ///\returns the instantiated function template declaration.
   CPPINTEROP_API TCppFunction_t
   InstantiateTemplateFunctionFromString(const char* function_template);
+
+  // Find best template match based on explicit template parameters and arg
+  // types
+  CPPINTEROP_API TCppFunction_t
+  BestTemplateFunctionMatch(std::vector<TCppFunction_t> candidates,
+                            std::vector<TemplateArgInfo> explicit_types,
+                            std::vector<TemplateArgInfo> arg_types);
 
   CPPINTEROP_API std::vector<std::string> GetAllCppNames(TCppScope_t scope);
 

--- a/lib/Interpreter/CppInterOp.cpp
+++ b/lib/Interpreter/CppInterOp.cpp
@@ -739,8 +739,6 @@ namespace Cpp {
       }
     }
   }
-  
-  
 
   void GetFunctionTemplatedDecls(TCppScope_t klass, std::vector<TCppFunction_t> &methods) {
     if (!klass) return;
@@ -762,8 +760,6 @@ namespace Cpp {
       }
     }
   }
-  
-  
 
   bool HasDefaultConstructor(TCppScope_t scope) {
     auto *D = (clang::Decl *) scope;
@@ -975,8 +971,7 @@ namespace Cpp {
   }
 
   std::vector<TCppFunction_t> GetTemplatedMethods(const std::string& name,
-                                                  TCppScope_t parent,
-                                                  const std::string& filter) {
+                                                  TCppScope_t parent) {
 
     auto* D = (Decl*)parent;
 

--- a/lib/Interpreter/CppInterOp.cpp
+++ b/lib/Interpreter/CppInterOp.cpp
@@ -1004,29 +1004,7 @@ namespace Cpp {
 
     return {};
   }
-
-  TCppIndex_t GetNumTemplatedMethods(TCppScope_t scope, bool accept_namespace) {
-    if (!accept_namespace && IsNamespace(scope))
-      return (TCppIndex_t)0; // Enforce lazy
-
-    std::vector<TCppFunction_t> mc; 
-    GetFunctionTemplatedDecls(scope, mc);
-    TCppIndex_t res = 0;
-
-    for (auto method : mc) {
-      res += IsTemplatedFunction(method) ? 1 : 0;
-    }
-    return res;
-  }
-
-  std::string GetTemplatedMethodName(TCppScope_t scope, TCppIndex_t imeth) {
-    std::vector<TCppFunction_t> mc; 
-    GetFunctionTemplatedDecls(scope, mc);
-    auto* D = (FunctionTemplateDecl*)mc[imeth];
-
-    return D->getNameAsString();
-  }
-
+  
   TCppFunction_t
   BestTemplateFunctionMatch(const std::vector<TCppFunction_t>& candidates,
                             const std::vector<TemplateArgInfo>& explicit_types,

--- a/lib/Interpreter/CppInterOp.cpp
+++ b/lib/Interpreter/CppInterOp.cpp
@@ -993,10 +993,10 @@ namespace Cpp {
       if (func->getNumParams() != arg_types.size())
         continue;
 
-      // TODO : first score based on the type similarity before forcing
+      // FIXME : first score based on the type similarity before forcing
       // instantiation try instantiating
-      TCppFunction_t instantiated = InstantiateTemplate(
-          candidate, arg_types.data(), arg_types.size());
+      TCppFunction_t instantiated =
+          InstantiateTemplate(candidate, arg_types.data(), arg_types.size());
       if (instantiated)
         return instantiated;
 

--- a/unittests/CppInterOp/FunctionReflectionTest.cpp
+++ b/unittests/CppInterOp/FunctionReflectionTest.cpp
@@ -487,14 +487,14 @@ TEST(FunctionReflectionTest, ExistsFunctionTemplate) {
   EXPECT_FALSE(Cpp::ExistsFunctionTemplate("f", Decls[2]));
 }
 
-// TEST(ScopeReflectionTest, InstantiateTemplateFunctionFromString) {
-//   Cpp::CreateInterpreter();
-//   std::string code = R"(#include <memory>)";
-//   Interp->process(code);
-//   const char* str = "std::make_unique<int,int>";
-//   auto* Instance1 = (Decl*)Cpp::InstantiateTemplateFunctionFromString(str);
-//   EXPECT_TRUE(Instance1);
-// }
+TEST(FunctionReflectionTest, InstantiateTemplateFunctionFromString) {
+  Cpp::CreateInterpreter();
+  std::string code = R"(#include <memory>)";
+  Interp->process(code);
+  const char* str = "std::make_unique<int,int>";
+  auto* Instance1 = (Decl*)Cpp::InstantiateTemplateFunctionFromString(str);
+  EXPECT_TRUE(Instance1);
+}
 
 TEST(FunctionReflectionTest, InstantiateFunctionTemplate) {
   std::vector<Decl*> Decls;

--- a/unittests/CppInterOp/FunctionReflectionTest.cpp
+++ b/unittests/CppInterOp/FunctionReflectionTest.cpp
@@ -47,7 +47,8 @@ TEST(FunctionReflectionTest, GetClassMethods) {
     return Cpp::GetFunctionSignature(method);
   };
 
-  auto methods0 = Cpp::GetClassMethods(Decls[0]);
+  std::vector<Cpp::TCppFunction_t> methods0;
+  Cpp::GetClassMethods(Decls[0], methods0);
 
   EXPECT_EQ(methods0.size(), 11);
   EXPECT_EQ(get_method_name(methods0[0]), "int A::f1(int a, int b)");
@@ -62,7 +63,8 @@ TEST(FunctionReflectionTest, GetClassMethods) {
   EXPECT_EQ(get_method_name(methods0[9]), "inline constexpr A &A::operator=(A &&)");
   EXPECT_EQ(get_method_name(methods0[10]), "inline A::~A()");
 
-  auto methods1 = Cpp::GetClassMethods(Decls[1]);
+  std::vector<Cpp::TCppFunction_t> methods1;
+  Cpp::GetClassMethods(Decls[1], methods1);
   EXPECT_EQ(methods0.size(), methods1.size());
   EXPECT_EQ(methods0[0], methods1[0]);
   EXPECT_EQ(methods0[1], methods1[1]);
@@ -70,7 +72,8 @@ TEST(FunctionReflectionTest, GetClassMethods) {
   EXPECT_EQ(methods0[3], methods1[3]);
   EXPECT_EQ(methods0[4], methods1[4]);
 
-  auto methods2 = Cpp::GetClassMethods(Decls[2]);
+  std::vector<Cpp::TCppFunction_t> methods2;
+  Cpp::GetClassMethods(Decls[2], methods2);
 
   EXPECT_EQ(methods2.size(), 6);
   EXPECT_EQ(get_method_name(methods2[0]), "B::B(int n)");
@@ -80,7 +83,8 @@ TEST(FunctionReflectionTest, GetClassMethods) {
   EXPECT_EQ(get_method_name(methods2[4]), "inline B &B::operator=(const B &)");
   EXPECT_EQ(get_method_name(methods2[5]), "inline B &B::operator=(B &&)");
 
-  auto methods3 = Cpp::GetClassMethods(Decls[3]);
+  std::vector<Cpp::TCppFunction_t> methods3;
+  Cpp::GetClassMethods(Decls[3], methods3);
 
   EXPECT_EQ(methods3.size(), 9);
   EXPECT_EQ(get_method_name(methods3[0]), "B::B(int n)");
@@ -93,10 +97,12 @@ TEST(FunctionReflectionTest, GetClassMethods) {
   EXPECT_EQ(get_method_name(methods3[8]), "inline C::~C()");
 
   // Should not crash.
-  auto methods4 = Cpp::GetClassMethods(Decls[4]);
+  std::vector<Cpp::TCppFunction_t> methods4;
+  Cpp::GetClassMethods(Decls[4], methods4);
   EXPECT_EQ(methods4.size(), 0);
 
-  auto methods5 = Cpp::GetClassMethods(nullptr);
+  std::vector<Cpp::TCppFunction_t> methods5;
+  Cpp::GetClassMethods(nullptr, methods5);
   EXPECT_EQ(methods5.size(), 0);
 }
 
@@ -112,7 +118,8 @@ TEST(FunctionReflectionTest, ConstructorInGetClassMethods) {
   GetAllTopLevelDecls(code, Decls);
 
   auto has_constructor = [](Decl *D) {
-    auto methods = Cpp::GetClassMethods(D);
+    std::vector<Cpp::TCppFunction_t> methods;
+    Cpp::GetClassMethods(D, methods);
     for (auto method : methods) {
       if (Cpp::IsConstructor(method))
         return true;

--- a/unittests/CppInterOp/FunctionReflectionTest.cpp
+++ b/unittests/CppInterOp/FunctionReflectionTest.cpp
@@ -117,7 +117,7 @@ TEST(FunctionReflectionTest, ConstructorInGetClassMethods) {
 
   GetAllTopLevelDecls(code, Decls);
 
-  auto has_constructor = [](Decl *D) {
+  auto has_constructor = [](Decl* D) {
     std::vector<Cpp::TCppFunction_t> methods;
     Cpp::GetClassMethods(D, methods);
     for (auto method : methods) {

--- a/unittests/CppInterOp/ScopeReflectionTest.cpp
+++ b/unittests/CppInterOp/ScopeReflectionTest.cpp
@@ -879,7 +879,8 @@ TEST(ScopeReflectionTest, InstantiateTemplate) {
   EXPECT_TRUE(TA3_0.getAsType()->isIntegerType());
   EXPECT_TRUE(Cpp::IsRecordType(TA3_1.getAsType().getAsOpaquePtr()));
 
-  auto Inst3_methods = Cpp::GetClassMethods(Instance3);
+  std::vector<Cpp::TCppFunction_t> Inst3_methods;
+  Cpp::GetClassMethods(Instance3, Inst3_methods);
   EXPECT_EQ(Cpp::GetFunctionSignature(Inst3_methods[0]),
             "C1<int>::C1(const C0<int> &val)");
 


### PR DESCRIPTION
This PR consolidates interfaces in CppInterOp that allows:

- Exposes information required for template function scope proxy creation -  arg types, method counts, names
- Perform template function lookups using `clang::LookupResult`
- Updates existing interfaces to also handle FunctionTemplateDecl*
- Improves the instantiation process
- Enables auto instantiation and a basic overload selection mechanism in `BestTemplateFunctionMatch`
