### PR TITLE
Fix usage of InstantiateTemplate

### DIFF
--- a/unittests/CppInterOp/ScopeReflectionTest.cpp
+++ b/unittests/CppInterOp/ScopeReflectionTest.cpp
@@ -807,7 +807,7 @@ TEST(ScopeReflectionTest, InstantiateTemplateFunctionFromString) {
   EXPECT_TRUE(Instance1);
 }
 
-TEST(ScopeReflectionTest, InstantiateClassTemplate) {
+TEST(ScopeReflectionTest, InstantiateTemplate) {
   std::vector<Decl *> Decls;
   std::string code = R"(
     template<typename T>


### PR DESCRIPTION
renames missed name change in ScopeReflectionTest (PR #128)