### PR TITLE
Only run clang-tidy-review on request in PR's

### DIFF
--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -1,7 +1,7 @@
 name: clang-tidy-review
 
 on: 
-  pull_request:
+  issue_comment:
     paths:
       - '**.h'
       - '**.cpp'
@@ -12,6 +12,7 @@ concurrency:
 
 jobs:
   review:
+    if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, 'clang-tidy-review') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout PR branch


### PR DESCRIPTION
Prevents the actions bot from spamming PR's with comments. This migrates the clang-tidy-review to be performed only when requested by detecting "clang-tidy-review" in the comment body of the PR.