### PR TITLE
Make running emscripten_wasm dependent on sucessfull run of build in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -977,6 +977,7 @@ jobs:
       timeout-minutes: 30
 
   emscripten_wasm:
+    needs: [build]
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     strategy:


### PR DESCRIPTION
This PR makes running emscripten_wasm dependent on sucessfull run of build in ci. This should reduce ci resources being used uncessarily, to be used by other PRs in the organisation.