### PR TITLE
Reduce cache size

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -365,7 +365,9 @@ jobs:
                 ../llvm
           cmake --build . --target clang clang-repl lld --parallel ${{ env.ncpus }}
         fi
-        cd ../../
+        cd ../
+        rm -rf $(find . -maxdepth 1 ! -name "build" ! -name "llvm" ! -name "clang" ! -name ".")
+        cd ../
 
     - name: Build LLVM/Cling on Windows systems if the cache is invalid
       if: ${{ runner.os == 'windows' && steps.cache.outputs.cache-hit != 'true' }}


### PR DESCRIPTION
@vgvassilev can you clear the cache, and then manually rerun the workflow of this PR? It should pass, while having a reduced llvm cache, based on the workflow in xeus-clang-repl.