### PR TITLE
[ci] Update cppyy test job to match backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1078,6 +1078,7 @@ jobs:
         # Run the tests
         source .venv/bin/activate
         cd cppyy/test
+        
         echo ::group::Prepare For Testing
         make all
         python -m pip install --upgrade pip
@@ -1085,8 +1086,13 @@ jobs:
         python -m pip install pytest-xdist
         python -m pip install numba
         echo ::endgroup::
+        
         echo ::group::Run complete test suite
+        set -o pipefail
         python -m pytest -sv | tee complete_testrun.log 2>&1
+        set +o pipefail
+        echo ::endgroup::
+        
         echo ::group::Crashing Test Logs
         # See if we don't have a crash that went away
         # Comment out all xfails but the ones that have a run=False condition.
@@ -1094,6 +1100,7 @@ jobs:
         python -m pytest -n 1 -m "xfail" --runxfail -sv --max-worker-restart 512 | tee test_crashed.log 2>&1 || true
         git checkout .
         echo ::endgroup::
+        
         echo ::group::XFAIL Test Logs
         # Rewrite all xfails that have a run clause to skipif. This way we will
         # avoid conditionally crashing xfails
@@ -1102,18 +1109,21 @@ jobs:
         python -m pytest --runxfail -sv  | tee test_xfailed.log 2>&1 || true
         git checkout .
         echo ::endgroup::
+        
         echo ::group::Passing Test Logs
-
         # Run the rest of the non-crashing tests.
         declare -i RETCODE=0
-
         set -o pipefail
-        if [[ "${{ matrix.clang-runtime }}" == "17" || "${{ matrix.clang-runtime }}" == "18" ]] && [[ "${{ matrix.os }}" != "macos-14" ]]; then
-          echo "Valgrind reports true for clang-runtime 17 or 18, due to memory leaks with LLVM"
-          valgrind --error-exitcode=1 --suppressions=../etc/valgrind-cppyy-cling.supp python -m pytest -m "not xfail" -v || true
+        if [[ "${{ matrix.os }}" == macos-* ]]; then
+        echo "Skipping Valgrind checks on macOS"
         else
-          echo "Running valgrind on passing tests"
-          valgrind --error-exitcode=1 --suppressions=../etc/valgrind-cppyy-cling.supp python -m pytest -m "not xfail" -v
+            if [[ "${{ matrix.clang-runtime }}" == "17" || "${{ matrix.clang-runtime }}" == "18" ]]; then
+                echo "Valgrind reports true for clang-runtime 17 or 18, due to memory leaks with LLVM"
+                valgrind --error-exitcode=1 --suppressions=../etc/valgrind-cppyy-cling.supp python -m pytest -m "not xfail" -v || true
+            else
+                echo "Running valgrind on passing tests"
+                valgrind --error-exitcode=1 --suppressions=../etc/valgrind-cppyy-cling.supp python -m pytest -m "not xfail" -v
+            fi
         fi
         export RETCODE=+$?
         echo ::endgroup::


### PR DESCRIPTION
- Captures exitcode on complete test run by setting pipefail
- Skips valgrind on OS X