### PR TITLE
Update codecov-action to v4 (node 16 to node 20 migration)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1170,7 +1170,7 @@ jobs:
 
     - name: Upload to codecov.io
       if: ${{ success() && (matrix.coverage == true) }}
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       with:
         file: ./coverage.info
 


### PR DESCRIPTION
An action was missed when upgrading them in https://github.com/compiler-research/CppInterOp/pull/236 due to the migration of node 16 to node 20 in Github actions