### PR TITLE
ForceDeclarationOfImplicitMembers might deserialize

### DIFF
--- a/lib/Interpreter/CppInterOp.cpp
+++ b/lib/Interpreter/CppInterOp.cpp
@@ -734,9 +734,9 @@ namespace Cpp {
       return;
 
     auto* CXXRD = dyn_cast<CXXRecordDecl>(D);
-    #ifdef USE_CLING
-      cling::Interpreter::PushTransactionRAII RAII(&getInterp());
-    #endif // USE_CLING
+#ifdef USE_CLING
+    cling::Interpreter::PushTransactionRAII RAII(&getInterp());
+#endif // USE_CLING
     getSema().ForceDeclarationOfImplicitMembers(CXXRD);
     for (Decl* DI : CXXRD->decls()) {
       if (auto* MD = dyn_cast<DeclType>(DI))

--- a/lib/Interpreter/CppInterOp.cpp
+++ b/lib/Interpreter/CppInterOp.cpp
@@ -734,6 +734,9 @@ namespace Cpp {
       return;
 
     auto* CXXRD = dyn_cast<CXXRecordDecl>(D);
+    #ifdef USE_CLING
+      cling::Interpreter::PushTransactionRAII RAII(&getInterp());
+    #endif // USE_CLING
     getSema().ForceDeclarationOfImplicitMembers(CXXRD);
     for (Decl* DI : CXXRD->decls()) {
       if (auto* MD = dyn_cast<DeclType>(DI))


### PR DESCRIPTION
Add a cling RAII object to annotate the expected deserialization.