### PR TITLE
Update clang format and clang tidy

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -15,24 +15,29 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout PR branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
+
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.7
+          python-version: 3.10
+
       - name: Install clang-format
         run: |
           curl https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-          echo "deb https://apt.llvm.org/jammy/ llvm-toolchain-jammy-15 main" | sudo tee -a /etc/apt/sources.list
+          os_codename="`cat /etc/os-release | grep UBUNTU_CODENAME | cut -d = -f 2`"
+          echo "deb https://apt.llvm.org/${os_codename}/ llvm-toolchain-${os_codename}-18 main" | sudo tee -a /etc/apt/sources.list
           sudo apt update
-          sudo apt install -y clang-format-15
+          sudo apt install -y clang-format-18
+
       - name: Download git-clang-format
         run: |
           wget https://raw.githubusercontent.com/llvm/llvm-project/main/clang/tools/clang-format/git-clang-format
           chmod +x git-clang-format
+
       - name: Run git-clang-format
         run: |
           PR_BASE=$(git rev-list ${{ github.event.pull_request.head.sha }} ^${{ github.event.pull_request.base.sha }} | tail --lines 1 | xargs -I {} git rev-parse {}~1)
@@ -41,10 +46,10 @@ jobs:
           -c color.ui=always \
           -c diff.wsErrorHighlight=all \
           -c color.diff.whitespace='red reverse' \
-          clang-format-15 --diff --binary clang-format-15 --commit $PR_BASE -- include/ lib/ || \
+          clang-format-18 --diff --binary clang-format-18 --commit $PR_BASE -- include/ lib/ || \
           (echo "Please run the following git-clang-format locally to fix the formatting: \n
                 git-clang-format HEAD~\n
                 for multiple commits we should place the formatting changes in the related commit with:\n
-                \t\tgit rebase -i -x \"git-clang-format-15 main && git commit -a --allow-empty --fixup=HEAD\" --strategy-option=theirs origin/main\n
+                \t\tgit rebase -i -x \"git-clang-format-18 main && git commit -a --allow-empty --fixup=HEAD\" --strategy-option=theirs origin/main\n
                 \t\t Then inspect the results with: git log --oneline\n
                 \t\t Then squash without poluting the history with: git rebase --autosquash -i main\n" && exit 1)

--- a/.github/workflows/clang-tidy-review-post.yml
+++ b/.github/workflows/clang-tidy-review-post.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: Post review comments
         id: post-review
-        uses: ZedThree/clang-tidy-review/post@v0.13.2
+        uses: ZedThree/clang-tidy-review/post@v0.18.0
         with:
           max_comments: 10
 

--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -15,15 +15,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout PR branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install LLVM and Clang
-        uses: KyleMayes/install-llvm-action@v1
+        uses: KyleMayes/install-llvm-action@v2
         with:
-          version: "16.0.0"
+          version: "18.1.3"
 
       - name: Run clang-tidy
-        uses: ZedThree/clang-tidy-review@v0.13.2
+        uses: ZedThree/clang-tidy-review@v0.18.0
         id: review
         with:
           build_dir: build
@@ -40,4 +40,4 @@ jobs:
             -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
 
       - name: Upload artifacts
-        uses: ZedThree/clang-tidy-review/upload@v0.13.1
+        uses: ZedThree/clang-tidy-review/upload@v0.18.0


### PR DESCRIPTION
Ths updates the workflows for clang format and clang tidy. This is update the actions to use new versions of llvm components, and to use new action versions due to warnings.