### PR TITLE
Fix clang tidy + remove warnings when building

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.10
+          python-version: "3.11"
 
       - name: Install clang-format
         run: |

--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -17,6 +17,11 @@ jobs:
       - name: Checkout PR branch
         uses: actions/checkout@v4
 
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
       - name: Install LLVM and Clang
         uses: KyleMayes/install-llvm-action@v2.0.2
         with:

--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install LLVM and Clang
         uses: KyleMayes/install-llvm-action@v2.0.2
         with:
-          version: "17.0.0"
+          version: "18"
 
       - name: Run clang-tidy
         uses: ZedThree/clang-tidy-review@v0.18.0

--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install LLVM and Clang
         uses: KyleMayes/install-llvm-action@v2.0.2
         with:
-          version: "15.0.0"
+          version: "15.0.7"
 
       - name: Run clang-tidy
         uses: ZedThree/clang-tidy-review@v0.18.0

--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -35,6 +35,7 @@ jobs:
           apt_packages: libxml2,libxml2-dev,libtinfo-dev,zlib1g-dev,libzstd-dev
           split_workflow: true
           cmake_command: >
+            python -m ensurepip --upgrade &&
             pip install cmake lit &&
             cmake --version &&
             cmake . -B build -DCMAKE_BUILD_TYPE="Release"

--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install LLVM and Clang
         uses: KyleMayes/install-llvm-action@v2.0.2
         with:
-          version: "15.0.0"
+          version: "17.0.0"
 
       - name: Run clang-tidy
         uses: ZedThree/clang-tidy-review@v0.18.0

--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -34,6 +34,7 @@ jobs:
           build_dir: build
           apt_packages: libxml2,libxml2-dev,libtinfo-dev,zlib1g-dev,libzstd-dev
           split_workflow: true
+          clang_tidy_version: 17
           cmake_command: >
             pip install cmake lit &&
             cmake --version &&

--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install LLVM and Clang
         uses: KyleMayes/install-llvm-action@v2.0.2
         with:
-          version: "15.0.7"
+          version: "18.1.2"
 
       - name: Run clang-tidy
         uses: ZedThree/clang-tidy-review@v0.18.0

--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install LLVM and Clang
-        uses: KyleMayes/install-llvm-action@v2
+        uses: KyleMayes/install-llvm-action@v2.0.2
         with:
           version: "18.1.3"
 

--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -32,12 +32,10 @@ jobs:
         id: review
         with:
           build_dir: build
-          apt_packages: libxml2,libxml2-dev,libtinfo-dev,zlib1g-dev,libzstd-dev
+          apt_packages: cmake,libxml2,libxml2-dev,libtinfo-dev,zlib1g-dev,libzstd-dev
           split_workflow: true
           cmake_command: >
-            python -m ensurepip --upgrade &&
-            pip install cmake lit &&
-            cmake --version &&
+            pip install lit &&
             cmake . -B build -DCMAKE_BUILD_TYPE="Release"
             -DUSE_CLING=OFF
             -DUSE_REPL=ON

--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -28,7 +28,7 @@ jobs:
           version: "17.0.6"
 
       - name: Run clang-tidy
-        uses: ZedThree/clang-tidy-review@v0.18.0
+        uses: ZedThree/clang-tidy-review@v0.17.0
         id: review
         with:
           build_dir: build

--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -34,7 +34,6 @@ jobs:
           build_dir: build
           apt_packages: libxml2,libxml2-dev,libtinfo-dev,zlib1g-dev,libzstd-dev
           split_workflow: true
-          clang_tidy_version: 17
           cmake_command: >
             cmake . -B build -DCMAKE_BUILD_TYPE="Release"
             -DUSE_CLING=OFF

--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install LLVM and Clang
         uses: KyleMayes/install-llvm-action@v2.0.2
         with:
-          version: "18.1.2"
+          version: "17.0.6"
 
       - name: Run clang-tidy
         uses: ZedThree/clang-tidy-review@v0.18.0

--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -23,7 +23,7 @@ jobs:
           python-version: "3.11"
 
       - name: Install LLVM and Clang
-        uses: KyleMayes/install-llvm-action@v2
+        uses: KyleMayes/install-llvm-action@v2.0.2
         with:
           version: "17.0.6"
 

--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -35,6 +35,8 @@ jobs:
           apt_packages: libxml2,libxml2-dev,libtinfo-dev,zlib1g-dev,libzstd-dev
           split_workflow: true
           cmake_command: >
+            pip install cmake lit &&
+            cmake --version &&
             cmake . -B build -DCMAKE_BUILD_TYPE="Release"
             -DUSE_CLING=OFF
             -DUSE_REPL=ON

--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -23,12 +23,12 @@ jobs:
           python-version: "3.11"
 
       - name: Install LLVM and Clang
-        uses: KyleMayes/install-llvm-action@v2.0.2
+        uses: KyleMayes/install-llvm-action@v2
         with:
           version: "17.0.6"
 
       - name: Run clang-tidy
-        uses: ZedThree/clang-tidy-review@v0.17.0
+        uses: ZedThree/clang-tidy-review@v0.18.0
         id: review
         with:
           build_dir: build

--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -27,6 +27,9 @@ jobs:
         with:
           version: "16.0.0"
 
+      - name: install lit
+        run: pip install lit
+        
       - name: Run clang-tidy
         uses: ZedThree/clang-tidy-review@v0.18.0
         id: review
@@ -35,7 +38,6 @@ jobs:
           apt_packages: cmake,libxml2,libxml2-dev,libtinfo-dev,zlib1g-dev,libzstd-dev
           split_workflow: true
           cmake_command: >
-            pip install lit &&
             cmake . -B build -DCMAKE_BUILD_TYPE="Release"
             -DUSE_CLING=OFF
             -DUSE_REPL=ON

--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -36,8 +36,6 @@ jobs:
           split_workflow: true
           clang_tidy_version: 17
           cmake_command: >
-            pip install cmake lit &&
-            cmake --version &&
             cmake . -B build -DCMAKE_BUILD_TYPE="Release"
             -DUSE_CLING=OFF
             -DUSE_REPL=ON

--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install LLVM and Clang
         uses: KyleMayes/install-llvm-action@v2.0.2
         with:
-          version: "18.1.3"
+          version: "15.0.0"
 
       - name: Run clang-tidy
         uses: ZedThree/clang-tidy-review@v0.18.0

--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install LLVM and Clang
         uses: KyleMayes/install-llvm-action@v2.0.2
         with:
-          version: "17.0.6"
+          version: "16.0.0"
 
       - name: Run clang-tidy
         uses: ZedThree/clang-tidy-review@v0.18.0

--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install LLVM and Clang
         uses: KyleMayes/install-llvm-action@v2.0.2
         with:
-          version: "18"
+          version: "15.0.0"
 
       - name: Run clang-tidy
         uses: ZedThree/clang-tidy-review@v0.18.0

--- a/lib/Interpreter/Compatibility.h
+++ b/lib/Interpreter/Compatibility.h
@@ -10,6 +10,11 @@
 #include "clang/Basic/Version.h"
 #include "clang/Config/config.h"
 
+#if LLVM_VERSION_MAJOR < 18
+#define starts_with startswith
+#define ends_with endswith
+#endif
+
 #if CLANG_VERSION_MAJOR >= 18
 #include "clang/Interpreter/CodeCompletion.h"
 #endif

--- a/lib/Interpreter/CppInterOp.cpp
+++ b/lib/Interpreter/CppInterOp.cpp
@@ -316,9 +316,9 @@ namespace Cpp {
       // Add quick checks for the std smart prts to cover most of the cases.
       std::string typeString = GetTypeAsString(type);
       llvm::StringRef tsRef(typeString);
-      if (tsRef.startswith("std::unique_ptr") ||
-          tsRef.startswith("std::shared_ptr") ||
-          tsRef.startswith("std::weak_ptr"))
+      if (tsRef.starts_with("std::unique_ptr") ||
+          tsRef.starts_with("std::shared_ptr") ||
+          tsRef.starts_with("std::weak_ptr"))
         return true;
       return isSmartPointer(RT);
     }

--- a/lib/Interpreter/DynamicLibraryManager.cpp
+++ b/lib/Interpreter/DynamicLibraryManager.cpp
@@ -323,7 +323,7 @@ namespace Cpp {
       foundName = lookupLibMaybeAddExt(libStem, RPath, RunPath, libLoader);
       if (foundName.empty()) {
         StringRef libStemName = llvm::sys::path::filename(libStem);
-        if (!libStemName.startswith("lib")) {
+        if (!libStemName.starts_with("lib")) {
           // try with "lib" prefix:
           foundName = lookupLibMaybeAddExt(
              libStem.str().insert(libStem.size()-libStemName.size(), "lib"),

--- a/lib/Interpreter/Paths.cpp
+++ b/lib/Interpreter/Paths.cpp
@@ -413,7 +413,7 @@ bool SplitPaths(llvm::StringRef PathStr,
   }
 
   // Trim trailing sep in case of A:B:C:D:
-  if (!PathStr.empty() && PathStr.endswith(Delim))
+  if (!PathStr.empty() && PathStr.ends_with(Delim))
     PathStr = PathStr.substr(0, PathStr.size()-Delim.size());
 
   if (!PathStr.empty()) {


### PR DESCRIPTION
@vgvassilev This is the PR to correct the bug introduced in clang tidy workflow in https://github.com/compiler-research/CppInterOp/pull/269, found in https://github.com/vgvassilev/clad/pull/883 . Once it is has been found to work in Clad this can be merged immediately.