### PR TITLE
Run wasm build unconditionally in the ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1063,7 +1063,7 @@ jobs:
       timeout-minutes: 30
 
   emscripten_wasm:
-    needs: [cppinterop_and_cppyy_build]
+    needs: [build_cache]
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     strategy:

--- a/environment-wasm.yml
+++ b/environment-wasm.yml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   - zlib
   - nlohmann_json
-  - xeus-lite
+  - xeus-lite <2.0
   - xeus >=3.0.5,<4.0
   - xtl >=0.7,<0.8
   - cpp-argparse


### PR DESCRIPTION
Fixes https://github.com/compiler-research/CppInterOp/issues/274
This PR will change it so the wasm builds in the ci occur regardless of the outcome of the non wasm jobs. The reason the dependence was there previously was due to build times being large, but this is no longer the case.