### PR TITLE
Fix number of processors environment variable Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,8 +212,8 @@ jobs:
       run: |
         echo "BUILD_TYPE=Release" >> $env:GITHUB_ENV
         echo "CODE_COVERAGE=0" >>  $env:GITHUB_ENV
-        echo "ncpus=%NUMBER_OF_PROCESSORS%" 
-        echo "ncpus=%NUMBER_OF_PROCESSORS%" >> $GITHUB_ENV
+        $env:ncpus=$([Environment]::ProcessorCount) 
+        echo "ncpus=$env:ncpus" >> $env:GITHUB_ENV
 
     - name: Setup compiler on Linux
       if: ${{ runner.os == 'Linux' && steps.cache.outputs.cache-hit != 'true' }}
@@ -671,8 +671,8 @@ jobs:
       run: |
         echo "BUILD_TYPE=Release" >> $env:GITHUB_ENV
         echo "CODE_COVERAGE=0" >>  $env:GITHUB_ENV
-        echo "ncpus=%NUMBER_OF_PROCESSORS%" 
-        echo "ncpus=%NUMBER_OF_PROCESSORS%" >> $GITHUB_ENV
+        $env:ncpus=$([Environment]::ProcessorCount) 
+        echo "ncpus=$env:ncpus" >> $env:GITHUB_ENV
 
     - name: Setup compiler on Linux
       if: runner.os == 'Linux'

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ cmake --build . --target clang clang-repl --parallel $(nproc --all)
 ```
 On Windows you would do this by executing the following
 ```
-$env:ncpus = %NUMBER_OF_PROCESSORS%
+$env:ncpus = $([Environment]::ProcessorCount)
 mkdir build 
 cd build 
 cmake   -DLLVM_ENABLE_PROJECTS=clang                  `


### PR DESCRIPTION
The envirnoment variable for the number of processors on Windows was previous not being calculated correctly, or outputted to the Github envirnoment. This means non of the Windows builds previously were building in parallel. This PR should fix this.