### PR TITLE
Speed up coverage job ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -782,7 +782,7 @@ jobs:
       run: |
         sudo apt install lcov
         echo "CODE_COVERAGE=1" >> $GITHUB_ENV
-        echo "BUILD_TYPE=Debug" >> $GITHUB_ENV
+        echo "BUILD_TYPE=RelWithDebInfo" >> $GITHUB_ENV
 
     - name: Build and Test/Install CppInterOp on Unix systems
       if: ${{ runner.os != 'windows' }}


### PR DESCRIPTION
Given when coverage is turned on CppInterOp is built with debug options, when cppyy makes use of it its tests run much slower. This PR should fix this issue, by rebuilding CppInterOp as a Release version with no debug options once the coverage report has been uploaded. It takes extra time to build CppInterOp again, but this should be much less time then how much longer it takes to run the cppyy tests when CppInterOp is built with debug options.