### PR TITLE
Update Ubuntu jobs in ci to Ubuntu 24.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,29 +21,29 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: ubu22-x86-gcc12-clang-repl-18
-            os: ubuntu-22.04
+          - name: ubu24-x86-gcc12-clang-repl-18
+            os: ubuntu-24.04
             compiler: gcc-12
             clang-runtime: '18'
             cling: Off
             cppyy: On
             coverage: true
-          - name: ubu22-x86-gcc12-clang-repl-17
-            os: ubuntu-22.04
+          - name: ubu24-x86-gcc12-clang-repl-17
+            os: ubuntu-24.04
             compiler: gcc-12
             clang-runtime: '17'
             cling: Off
             cppyy: On
             coverage: true
-          - name: ubu22-x86-gcc12-clang-repl-16
-            os: ubuntu-22.04
+          - name: ubu24-x86-gcc12-clang-repl-16
+            os: ubuntu-24.04
             compiler: gcc-12
             clang-runtime: '16'
             cling: Off
             cppyy: On
             coverage: true
-          - name: ubu22-x86-gcc9-clang13-cling
-            os: ubuntu-22.04
+          - name: ubu24-x86-gcc9-clang13-cling
+            os: ubuntu-24.04
             compiler: gcc-9
             clang-runtime: '13'
             cling: On
@@ -469,27 +469,27 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: ubu22-x86-gcc12-clang-repl-18-cppyy
-            os: ubuntu-22.04
+          - name: ubu24-x86-gcc12-clang-repl-18-cppyy
+            os: ubuntu-24.04
             compiler: gcc-12
             clang-runtime: '18'
             cling: Off
             cppyy: On
             coverage: true
-          - name: ubu22-x86-gcc12-clang-repl-17-cppyy
-            os: ubuntu-22.04
+          - name: ubu24-x86-gcc12-clang-repl-17-cppyy
+            os: ubuntu-24.04
             compiler: gcc-12
             clang-runtime: '17'
             cling: Off
             cppyy: On
-          - name: ubu22-x86-gcc12-clang-repl-16-cppyy
-            os: ubuntu-22.04
+          - name: ubu24-x86-gcc12-clang-repl-16-cppyy
+            os: ubuntu-24.04
             compiler: gcc-12
             clang-runtime: '16'
             cling: Off
             cppyy: On
-          - name: ubu22-x86-gcc9-clang13-cling-cppyy
-            os: ubuntu-22.04
+          - name: ubu24-x86-gcc9-clang13-cling-cppyy
+            os: ubuntu-24.04
             compiler: gcc-9
             clang-runtime: '13'
             cling: On
@@ -1067,23 +1067,23 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: ubu22-x86-gcc12-clang-repl-18-emscripten_wasm
-            os: ubuntu-22.04
+          - name: ubu24-x86-gcc12-clang-repl-18-emscripten_wasm
+            os: ubuntu-24.04
             compiler: gcc-12
             clang-runtime: '18'
             cling: Off
-          - name: ubu22-x86-gcc12-clang-repl-17-emscripten_wasm
-            os: ubuntu-22.04
+          - name: ubu24-x86-gcc12-clang-repl-17-emscripten_wasm
+            os: ubuntu-24.04
             compiler: gcc-12
             clang-runtime: '17'
             cling: Off
-          - name: ubu22-x86-gcc12-clang-repl-16-emscripten_wasm
-            os: ubuntu-22.04
+          - name: ubu24-x86-gcc12-clang-repl-16-emscripten_wasm
+            os: ubuntu-24.04
             compiler: gcc-12
             clang-runtime: '16'
             cling: Off
-          - name: ubu22-x86-gcc9-clang13-cling-emscripten_wasm
-            os: ubuntu-22.04
+          - name: ubu24-x86-gcc9-clang13-cling-emscripten_wasm
+            os: ubuntu-24.04
             compiler: gcc-9
             clang-runtime: '13'
             cling: On

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   precheckin:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout PR branch
         uses: actions/checkout@v4

--- a/.github/workflows/clang-tidy-review-post.yml
+++ b/.github/workflows/clang-tidy-review-post.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Post review comments

--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   review:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout PR branch
         uses: actions/checkout@v4


### PR DESCRIPTION
This PR will upgrade the Ubuntu used in the ci to 24.04 . It shouldn't hopefully cause any new errors, but we shall have to wait for it to do a full run to be sure.
Fixes https://github.com/compiler-research/CppInterOp/issues/265