### PR TITLE
Update Ubuntu jobs in ci to 24.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,30 +21,30 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: ubu24-x86-gcc12-clang-repl-18
+          - name: ubu24-x86-gcc13-clang-repl-18
             os: ubuntu-24.04
-            compiler: gcc-12
+            compiler: gcc-13
             clang-runtime: '18'
             cling: Off
             cppyy: On
             coverage: true
-          - name: ubu24-x86-gcc12-clang-repl-17
+          - name: ubu24-x86-gcc13-clang-repl-17
             os: ubuntu-24.04
-            compiler: gcc-12
+            compiler: gcc-13
             clang-runtime: '17'
             cling: Off
             cppyy: On
             coverage: true
-          - name: ubu24-x86-gcc12-clang-repl-16
+          - name: ubu24-x86-gcc13-clang-repl-16
             os: ubuntu-24.04
-            compiler: gcc-12
+            compiler: gcc-13
             clang-runtime: '16'
             cling: Off
             cppyy: On
             coverage: true
-          - name: ubu24-x86-gcc9-clang13-cling
+          - name: ubu24-x86-gcc13-clang13-cling
             os: ubuntu-24.04
-            compiler: gcc-9
+            compiler: gcc-13
             clang-runtime: '13'
             cling: On
             cling-version: '1.0'
@@ -469,28 +469,28 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: ubu24-x86-gcc12-clang-repl-18-cppyy
+          - name: ubu24-x86-gcc13-clang-repl-18-cppyy
             os: ubuntu-24.04
-            compiler: gcc-12
+            compiler: gcc-13
             clang-runtime: '18'
             cling: Off
             cppyy: On
             coverage: true
-          - name: ubu24-x86-gcc12-clang-repl-17-cppyy
+          - name: ubu24-x86-gcc13-clang-repl-17-cppyy
             os: ubuntu-24.04
-            compiler: gcc-12
+            compiler: gcc-13
             clang-runtime: '17'
             cling: Off
             cppyy: On
-          - name: ubu24-x86-gcc12-clang-repl-16-cppyy
+          - name: ubu24-x86-gcc13-clang-repl-16-cppyy
             os: ubuntu-24.04
-            compiler: gcc-12
+            compiler: gcc-13
             clang-runtime: '16'
             cling: Off
             cppyy: On
-          - name: ubu24-x86-gcc9-clang13-cling-cppyy
+          - name: ubu24-x86-gcc13-clang13-cling-cppyy
             os: ubuntu-24.04
-            compiler: gcc-9
+            compiler: gcc-13
             clang-runtime: '13'
             cling: On
             cling-version: '1.0'
@@ -1064,27 +1064,27 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: ubu24-x86-gcc12-clang-repl-18-emscripten_wasm
+          - name: ubu24-x86-gcc13-clang-repl-18-emscripten_wasm
             os: ubuntu-24.04
-            compiler: gcc-12
+            compiler: gcc-13
             clang-runtime: '18'
             cling: Off
             micromamba_shell_init: bash
-          - name: ubu24-x86-gcc12-clang-repl-17-emscripten_wasm
+          - name: ubu24-x86-gcc13-clang-repl-17-emscripten_wasm
             os: ubuntu-24.04
-            compiler: gcc-12
+            compiler: gcc-13
             clang-runtime: '17'
             cling: Off
             micromamba_shell_init: bash
-          - name: ubu24-x86-gcc12-clang-repl-16-emscripten_wasm
+          - name: ubu24-x86-gcc13-clang-repl-16-emscripten_wasm
             os: ubuntu-24.04
-            compiler: gcc-12
+            compiler: gcc-13
             clang-runtime: '16'
             cling: Off
             micromamba_shell_init: bash
-          - name: ubu24-x86-gcc9-clang13-cling-emscripten_wasm
+          - name: ubu24-x86-gcc13-clang13-cling-emscripten_wasm
             os: ubuntu-24.04
-            compiler: gcc-9
+            compiler: gcc-13
             clang-runtime: '13'
             cling: On
             cling-version: '1.0'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,29 +21,29 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: ubu22-x86-gcc12-clang-repl-18
-            os: ubuntu-22.04
+          - name: ubu24-x86-gcc12-clang-repl-18
+            os: ubuntu-24.04
             compiler: gcc-12
             clang-runtime: '18'
             cling: Off
             cppyy: On
             coverage: true
-          - name: ubu22-x86-gcc12-clang-repl-17
-            os: ubuntu-22.04
+          - name: ubu24-x86-gcc12-clang-repl-17
+            os: ubuntu-24.04
             compiler: gcc-12
             clang-runtime: '17'
             cling: Off
             cppyy: On
             coverage: true
-          - name: ubu22-x86-gcc12-clang-repl-16
-            os: ubuntu-22.04
+          - name: ubu24-x86-gcc12-clang-repl-16
+            os: ubuntu-24.04
             compiler: gcc-12
             clang-runtime: '16'
             cling: Off
             cppyy: On
             coverage: true
-          - name: ubu22-x86-gcc9-clang13-cling
-            os: ubuntu-22.04
+          - name: ubu24-x86-gcc9-clang13-cling
+            os: ubuntu-24.04
             compiler: gcc-9
             clang-runtime: '13'
             cling: On
@@ -469,27 +469,27 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: ubu22-x86-gcc12-clang-repl-18-cppyy
-            os: ubuntu-22.04
+          - name: ubu24-x86-gcc12-clang-repl-18-cppyy
+            os: ubuntu-24.04
             compiler: gcc-12
             clang-runtime: '18'
             cling: Off
             cppyy: On
             coverage: true
-          - name: ubu22-x86-gcc12-clang-repl-17-cppyy
-            os: ubuntu-22.04
+          - name: ubu24-x86-gcc12-clang-repl-17-cppyy
+            os: ubuntu-24.04
             compiler: gcc-12
             clang-runtime: '17'
             cling: Off
             cppyy: On
-          - name: ubu22-x86-gcc12-clang-repl-16-cppyy
-            os: ubuntu-22.04
+          - name: ubu24-x86-gcc12-clang-repl-16-cppyy
+            os: ubuntu-24.04
             compiler: gcc-12
             clang-runtime: '16'
             cling: Off
             cppyy: On
-          - name: ubu22-x86-gcc9-clang13-cling-cppyy
-            os: ubuntu-22.04
+          - name: ubu24-x86-gcc9-clang13-cling-cppyy
+            os: ubuntu-24.04
             compiler: gcc-9
             clang-runtime: '13'
             cling: On
@@ -1064,26 +1064,26 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: ubu22-x86-gcc12-clang-repl-18-emscripten_wasm
-            os: ubuntu-22.04
+          - name: ubu24-x86-gcc12-clang-repl-18-emscripten_wasm
+            os: ubuntu-24.04
             compiler: gcc-12
             clang-runtime: '18'
             cling: Off
             micromamba_shell_init: bash
-          - name: ubu22-x86-gcc12-clang-repl-17-emscripten_wasm
-            os: ubuntu-22.04
+          - name: ubu24-x86-gcc12-clang-repl-17-emscripten_wasm
+            os: ubuntu-24.04
             compiler: gcc-12
             clang-runtime: '17'
             cling: Off
             micromamba_shell_init: bash
-          - name: ubu22-x86-gcc12-clang-repl-16-emscripten_wasm
-            os: ubuntu-22.04
+          - name: ubu24-x86-gcc12-clang-repl-16-emscripten_wasm
+            os: ubuntu-24.04
             compiler: gcc-12
             clang-runtime: '16'
             cling: Off
             micromamba_shell_init: bash
-          - name: ubu22-x86-gcc9-clang13-cling-emscripten_wasm
-            os: ubuntu-22.04
+          - name: ubu24-x86-gcc9-clang13-cling-emscripten_wasm
+            os: ubuntu-24.04
             compiler: gcc-9
             clang-runtime: '13'
             cling: On

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   precheckin:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout PR branch
         uses: actions/checkout@v4

--- a/.github/workflows/clang-tidy-review-post.yml
+++ b/.github/workflows/clang-tidy-review-post.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Post review comments

--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   review:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout PR branch
         uses: actions/checkout@v4


### PR DESCRIPTION
This PR will upgrade the Ubuntu used in the ci to 24.04 . It shouldn't hopefully cause any new errors, but we shall have to wait for it to do a full run to be sure. This a copy of https://github.com/compiler-research/CppInterOp/pull/286 , but without the merge conflict due to he micromamba PR merge.
Fixes https://github.com/compiler-research/CppInterOp/issues/265

