### PR TITLE
Fix bug due to swiftlint osx jobs ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -758,6 +758,10 @@ jobs:
       run: |
         brew update
         brew remove ruby@3.0
+        export ARCHITECHURE=$(uname -m)
+        if [[ "$ARCHITECHURE" == "x86_64" ]]; then
+          brew remove swiftlint
+        fi
         # workaround for https://github.com/actions/setup-python/issues/577
         for pkg in $(brew list | grep '^python@'); do
           brew unlink "$pkg"


### PR DESCRIPTION
@vgvassilev @maximusron can one of you merge this into the main to fix the issue with osx x86 jobs? I know this fix works as I'm currently using it in my PR on treating all warnings as errors.