### PR TITLE
Remove unneeded installation of dependencies for Ubuntu wasm jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1195,15 +1195,6 @@ jobs:
           echo "ncpus=$(nproc --all)" >> $GITHUB_ENV
         fi
 
-    - name: Install deps on Linux
-      if: runner.os == 'Linux'
-      run: |
-        # Install deps
-        sudo apt-get update
-        sudo apt-get install git g++ debhelper devscripts gnupg python3 valgrind
-        sudo apt-get autoremove
-        sudo apt-get clean
-
     - name: install mamba
       uses: mamba-org/setup-micromamba@main
       with:


### PR DESCRIPTION
This part of the ci seems unneeded. Its removal will speed up the wasm Ubuntu jobs.