### PR TITLE
Add a libclang-style C API and improve type safety

### DIFF
--- a/include/clang-c/CXCppInterOp.h
+++ b/include/clang-c/CXCppInterOp.h
@@ -59,7 +59,7 @@ TInterp_t clang_interpreter_takeInterpreterAsPtr(CXInterpreter I);
 /**
  * Undo N previous incremental inputs.
  */
-CXErrorCode clang_interpreter_Undo(CXInterpreter I, unsigned int N);
+enum CXErrorCode clang_interpreter_Undo(CXInterpreter I, unsigned int N);
 
 /**
  * Dispose of the given interpreter context.

--- a/include/clang-c/CXCppInterOp.h
+++ b/include/clang-c/CXCppInterOp.h
@@ -5,8 +5,8 @@
 #include "clang-c/CXErrorCode.h"
 #include "clang-c/CXString.h"
 #include "clang-c/ExternC.h"
+#include "clang-c/Index.h"
 #include "clang-c/Platform.h"
-#include "llvm-c/LLJIT.h"
 
 #include <stdbool.h>
 #include <stddef.h>
@@ -256,19 +256,10 @@ clang_interpreter_getFunctionAddressFromMangledName(CXInterpreter I,
  */
 
 /**
- * Describes the kind of entity that a type refers to.
- */
-enum CXQualTypeKind {
-  CXQualType_Unexposed = 0,
-  CXQualType_Invalid = 1,
-  // reserved for future use
-};
-
-/**
  * An opaque pointer representing a type.
  */
 typedef struct {
-  enum CXQualTypeKind kind;
+  enum CXTypeKind kind;
   void* data;
   const void* meta;
 } CXQualType;

--- a/include/clang-c/CXCppInterOp.h
+++ b/include/clang-c/CXCppInterOp.h
@@ -1,0 +1,935 @@
+// NOLINTBEGIN()
+#ifndef LLVM_CLANG_C_CXCPPINTEROP_H
+#define LLVM_CLANG_C_CXCPPINTEROP_H
+
+#include "clang-c/CXErrorCode.h"
+#include "clang-c/CXString.h"
+#include "clang-c/ExternC.h"
+#include "clang-c/Platform.h"
+#include "llvm-c/LLJIT.h"
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+LLVM_CLANG_C_EXTERN_C_BEGIN
+
+/**
+ * \defgroup CPPINTEROP_INTERPRETER_MANIP Interpreter manipulations
+ *
+ * @{
+ */
+
+/**
+ * An opaque pointer representing an interpreter context.
+ */
+typedef struct CXInterpreterImpl* CXInterpreter;
+
+/**
+ * Create a Clang interpreter instance from the given arguments.
+ *
+ * \param argv The arguments that would be passed to the interpreter.
+ *
+ * \param argc The number of arguments in \c argv.
+ *
+ * \returns a \c CXInterpreter.
+ */
+CXInterpreter clang_createInterpreter(const char* const* argv, int argc);
+
+typedef void* TInterp_t;
+
+/**
+ * Bridge between C API and C++ API.
+ *
+ * \returns a \c CXInterpreter.
+ */
+CXInterpreter clang_createInterpreterFromPtr(TInterp_t I);
+
+/**
+ * Returns a \c TInterp_t.
+ */
+TInterp_t clang_interpreter_getInterpreterAsPtr(CXInterpreter I);
+
+/**
+ * Dispose of the given interpreter context.
+ */
+void clang_interpreter_dispose(CXInterpreter I);
+
+/**
+ * Describes the return result of the different routines that do the incremental
+ * compilation.
+ */
+typedef enum {
+  /**
+   * The compilation was successful.
+   */
+  CXInterpreter_Success = 0,
+  /**
+   * The compilation failed.
+   */
+  CXInterpreter_Failure = 1,
+  /**
+   * More more input is expected.
+   */
+  CXInterpreter_MoreInputExpected = 2,
+} CXInterpreter_CompilationResult;
+
+/**
+ * Add a search path to the interpreter.
+ *
+ * \param I The interpreter.
+ *
+ * \param dir The directory to add.
+ *
+ * \param isUser Whether the directory is a user directory.
+ *
+ * \param prepend Whether to prepend the directory to the search path.
+ */
+void clang_interpreter_addSearchPath(CXInterpreter I, const char* dir,
+                                     bool isUser, bool prepend);
+
+/**
+ * Get the resource directory.
+ */
+const char* clang_interpreter_getResourceDir(CXInterpreter I);
+
+/**
+ * Add an include path.
+ *
+ * \param I The interpreter.
+ *
+ * \param dir The directory to add.
+ */
+void clang_interpreter_addIncludePath(CXInterpreter I, const char* dir);
+
+/**
+ * Declares a code snippet in \c code and does not execute it.
+ *
+ * \param I The interpreter.
+ *
+ * \param code The code snippet to declare.
+ *
+ * \param silent Whether to suppress the diagnostics or not
+ *
+ * \returns a \c CXErrorCode.
+ */
+enum CXErrorCode clang_interpreter_declare(CXInterpreter I, const char* code,
+                                           bool silent);
+
+/**
+ * Declares and executes a code snippet in \c code.
+ *
+ * \param I The interpreter.
+ *
+ * \param code The code snippet to execute.
+ *
+ * \returns a \c CXErrorCode.
+ */
+enum CXErrorCode clang_interpreter_process(CXInterpreter I, const char* code);
+
+/**
+ * An opaque pointer representing a lightweight struct that is used for carrying
+ * execution results.
+ */
+typedef void* CXValue;
+
+/**
+ * Create a CXValue.
+ *
+ * \returns a \c CXValue.
+ */
+CXValue clang_createValue();
+
+/**
+ * Dispose of the given CXValue.
+ *
+ * \param V The CXValue to dispose.
+ */
+void clang_value_dispose(CXValue V);
+
+/**
+ * Declares, executes and stores the execution result to \c V.
+ *
+ * \param[in] I The interpreter.
+ *
+ * \param[in] code The code snippet to evaluate.
+ *
+ * \param[out] V The value to store the execution result.
+ *
+ * \returns a \c CXErrorCode.
+ */
+enum CXErrorCode clang_interpreter_evaluate(CXInterpreter I, const char* code,
+                                            CXValue V);
+
+/**
+ * Looks up the library if access is enabled.
+ *
+ * \param I The interpreter.
+ *
+ * \param lib_name The name of the library to lookup.
+ *
+ * \returns the path to the library.
+ */
+CXString clang_interpreter_lookupLibrary(CXInterpreter I, const char* lib_name);
+
+/**
+ * Finds \c lib_stem considering the list of search paths and loads it by
+ * calling dlopen.
+ *
+ * \param I The interpreter.
+ *
+ * \param lib_stem The stem of the library to load.
+ *
+ * \param lookup Whether to lookup the library or not.
+ *
+ * \returns a \c CXInterpreter_CompilationResult.
+ */
+CXInterpreter_CompilationResult
+clang_interpreter_loadLibrary(CXInterpreter I, const char* lib_stem,
+                              bool lookup);
+
+/**
+ * Finds \c lib_stem considering the list of search paths and unloads it by
+ * calling dlclose.
+ *
+ * \param I The interpreter.
+ *
+ * \param lib_stem The stem of the library to unload.
+ */
+void clang_interpreter_unloadLibrary(CXInterpreter I, const char* lib_stem);
+
+/**
+ * Scans all libraries on the library search path for a given potentially
+ * mangled symbol name.
+ *
+ * \param I The interpreter.
+ *
+ * \param mangled_name The mangled name of the symbol to search for.
+ *
+ * \param search_system Whether to search the system paths or not.
+ *
+ * \returns the path to the first library that contains the symbol definition.
+ */
+CXString clang_interpreter_searchLibrariesForSymbol(CXInterpreter I,
+                                                    const char* mangled_name,
+                                                    bool search_system);
+
+/**
+ * Inserts or replaces a symbol in the JIT with the one provided. This is useful
+ * for providing our own implementations of facilities such as printf.
+ *
+ * \param I The interpreter.
+ *
+ * \param linker_mangled_name The name of the symbol to be inserted or replaced.
+ *
+ * \param address The new address of the symbol.
+ *
+ * \returns true on failure.
+ */
+bool clang_interpreter_insertOrReplaceJitSymbol(CXInterpreter I,
+                                                const char* linker_mangled_name,
+                                                uint64_t address);
+
+typedef void* CXFuncAddr;
+
+/**
+ * Get the function address from the given mangled name.
+ *
+ * \param I The interpreter.
+ *
+ * \param mangled_name The mangled name of the function.
+ *
+ * \returns the address of the function given its potentially mangled name.
+ */
+CXFuncAddr
+clang_interpreter_getFunctionAddressFromMangledName(CXInterpreter I,
+                                                    const char* mangled_name);
+
+/**
+ * @}
+ */
+
+/**
+ * \defgroup CPPINTEROP_TYPE_MANIP Type manipulations
+ *
+ * @{
+ */
+
+/**
+ * Describes the kind of entity that a type refers to.
+ */
+enum CXQualTypeKind {
+  CXQualType_Unexposed = 0,
+  CXQualType_Invalid = 1,
+  // reserved for future use
+};
+
+/**
+ * An opaque pointer representing a type.
+ */
+typedef struct {
+  enum CXQualTypeKind kind;
+  void* data;
+  const void* meta;
+} CXQualType;
+
+/**
+ * Checks if it is a "built-in" or a "complex" type.
+ */
+bool clang_qualtype_isBuiltin(CXQualType type);
+
+/**
+ * Checks if the passed value is an enum type or not.
+ */
+bool clang_qualtype_isEnumType(CXQualType type);
+
+/**
+ * We assume that smart pointer types define both operator* and operator->.
+ */
+bool clang_qualtype_isSmartPtrType(CXQualType type);
+
+/**
+ * Checks if the provided parameter is a Record (struct).
+ */
+bool clang_scope_isRecordType(CXQualType type);
+
+/**
+ * Checks if the provided parameter is a Plain Old Data Type (POD).
+ */
+bool clang_scope_isPODType(CXQualType type);
+
+/**
+ * For the given "type", this function gets the integer type that the enum
+ * represents, so that you can store it properly in your specific language.
+ */
+CXQualType clang_qualtype_getIntegerTypeFromEnumType(CXQualType type);
+
+/**
+ * Gets the pure, Underlying Type (as opposed to the Using Type).
+ */
+CXQualType clang_qualtype_getUnderlyingType(CXQualType type);
+
+/**
+ * Gets the Type (passed as a parameter) as a String value.
+ */
+CXString clang_qualtype_getTypeAsString(CXQualType type);
+
+/**
+ * Gets the Canonical Type string from the std string. A canonical type
+ * is the type with any typedef names, syntactic sugars or modifiers stripped
+ * out of it.
+ */
+CXQualType clang_qualtype_getCanonicalType(CXQualType type);
+
+/**
+ * Used to either get the built-in type of the provided string, or
+ * use the name to lookup the actual type.
+ */
+CXQualType clang_qualtype_getType(const char* name);
+
+/**
+ * Returns the complex of the provided type.
+ */
+CXQualType clang_qualtype_getComplexType(CXQualType eltype);
+
+/**
+ * Gets the size of the "type" that is passed in to this function.
+ */
+size_t clang_qualtype_getSizeOfType(CXQualType type);
+
+/**
+ * Checks if a C++ type derives from another.
+ */
+bool clang_qualtype_isTypeDerivedFrom(CXQualType derived, CXQualType base);
+
+/**
+ * @}
+ */
+
+/**
+ * \defgroup CPPINTEROP_SCOPE_MANIP Scope manipulations
+ *
+ * @{
+ */
+
+/**
+ * Describes the kind of entity that a scope refers to.
+ */
+enum CXScopeKind {
+  CXScope_Unexposed = 0,
+  CXScope_Invalid = 1,
+  /** The global scope. */
+  CXScope_Global = 2,
+  /** Namespaces. */
+  CXScope_Namespace = 3,
+  /** Function, methods, constructor etc. */
+  CXScope_Function = 4,
+  /** Variables. */
+  CXScope_Variable = 5,
+  /** Enum Constants. */
+  CXScope_EnumConstant = 6,
+  /** Fields. */
+  CXScope_Field = 7,
+  // reserved for future use
+};
+
+/**
+ * An opaque pointer representing a variable, typedef, function, struct, etc.
+ */
+typedef struct {
+  enum CXScopeKind kind;
+  void* data;
+  const void* meta;
+} CXScope;
+
+// for debugging purposes
+void clang_scope_dump(CXScope S);
+
+/**
+ * This will convert a class into its type, so for example, you can use it to
+ * declare variables in it.
+ */
+CXQualType clang_scope_getTypeFromScope(CXScope S);
+
+/**
+ * Checks if the given class represents an aggregate type.
+ *
+ * \returns true if the \c scope supports aggregate initialization.
+ */
+bool clang_scope_isAggregate(CXScope S);
+
+/**
+ * Checks if the scope is a namespace or not.
+ */
+bool clang_scope_isNamespace(CXScope S);
+
+/**
+ * Checks if the scope is a class or not.
+ */
+bool clang_scope_isClass(CXScope S);
+
+/**
+ * Checks if the class definition is present, or not. Performs a template
+ * instantiation if necessary.
+ */
+bool clang_scope_isComplete(CXScope S);
+
+/**
+ * Get the size of the given type.
+ */
+size_t clang_scope_sizeOf(CXScope S);
+
+/**
+ * Checks if it is a templated class.
+ */
+bool clang_scope_isTemplate(CXScope S);
+
+/**
+ * Checks if it is a class template specialization class.
+ */
+bool clang_scope_isTemplateSpecialization(CXScope S);
+
+/**
+ * Checks if \c handle introduces a typedef name via \c typedef or \c using.
+ */
+bool clang_scope_isTypedefed(CXScope S);
+
+bool clang_scope_isAbstract(CXScope S);
+
+/**
+ * Checks if it is an enum name (EnumDecl represents an enum name).
+ */
+bool clang_scope_isEnumScope(CXScope S);
+
+/**
+ * Checks if it is an enum's value (EnumConstantDecl represents each enum
+ * constant that is defined).
+ */
+bool clang_scope_isEnumConstant(CXScope S);
+
+/**
+ * Extracts enum declarations from a specified scope and stores them in vector
+ */
+CXStringSet* clang_scope_getEnums(CXScope S);
+
+/**
+ * For the given "class", get the integer type that the enum represents, so that
+ * you can store it properly in your specific language.
+ */
+CXQualType clang_scope_getIntegerTypeFromEnumScope(CXScope S);
+
+typedef struct {
+  CXScope* Scopes;
+  size_t Count;
+} CXScopeSet;
+
+/**
+ * Free the given scope set.
+ */
+void clang_disposeScopeSet(CXScopeSet* set);
+
+/**
+ * Gets a list of all the enum constants for an enum.
+ */
+CXScopeSet* clang_scope_getEnumConstants(CXScope S);
+
+/**
+ * Gets the enum name when an enum constant is passed.
+ */
+CXQualType clang_scope_getEnumConstantType(CXScope S);
+
+/**
+ * Gets the index value (0,1,2, etcetera) of the enum constant that was passed
+ * into this function.
+ */
+size_t clang_scope_getEnumConstantValue(CXScope S);
+
+/**
+ * Checks if the passed value is a variable.
+ */
+bool clang_scope_isVariable(CXScope S);
+
+/**
+ * Gets the name of any named decl (a class, namespace, variable, or a
+ * function).
+ */
+CXString clang_scope_getName(CXScope S);
+
+/**
+ * This is similar to clang_scope_getName() function, but besides the name, it
+ * also gets the template arguments.
+ */
+CXString clang_scope_getCompleteName(CXScope S);
+
+/**
+ * Gets the "qualified" name (including the namespace) of any
+ * named decl (a class, namespace, variable, or a function).
+ */
+CXString clang_scope_getQualifiedName(CXScope S);
+
+/**
+ * This is similar to clang_scope_getQualifiedName() function, but besides
+ * the "qualified" name (including the namespace), it also gets the template
+ * arguments.
+ */
+CXString clang_scope_getQualifiedCompleteName(CXScope S);
+
+/**
+ * Gets the list of namespaces utilized in the supplied scope.
+ */
+CXScopeSet* clang_scope_getUsingNamespaces(CXScope S);
+
+/**
+ * Gets the global scope of the whole interpreter instance.
+ */
+CXScope clang_scope_getGlobalScope(CXInterpreter I);
+
+/**
+ * Strips the typedef and returns the underlying class, and if the underlying
+ * decl is not a class it returns the input unchanged.
+ */
+CXScope clang_scope_getUnderlyingScope(CXScope S);
+
+/**
+ * Gets the namespace or class (by stripping typedefs) for the name passed as a
+ * parameter. \c parent is mandatory, the global scope should be used as
+ * the default value.
+ */
+CXScope clang_scope_getScope(const char* name, CXScope parent);
+
+/**
+ *  This function performs a lookup within the specified parent,
+ * a specific named entity (functions, enums, etcetera).
+ */
+CXScope clang_scope_getNamed(const char* name, CXScope parent);
+
+/**
+ * Gets the parent of the scope that is passed as a parameter.
+ */
+CXScope clang_scope_getParentScope(CXScope parent);
+
+/**
+ * Gets the scope of the type that is passed as a parameter.
+ */
+CXScope clang_scope_getScopeFromType(CXQualType type);
+
+/**
+ * Gets the number of Base Classes for the Derived Class that
+ * is passed as a parameter.
+ */
+size_t clang_scope_getNumBases(CXScope S);
+
+/**
+ * Gets a specific Base Class using its index. Typically
+ * clang_scope_getNumBases() is used to get the number of Base Classes, and then
+ * that number can be used to iterate through the index value to get each
+ * specific base class.
+ */
+CXScope clang_scope_getBaseClass(CXScope S, size_t ibase);
+
+/**
+ * Checks if the supplied Derived Class is a sub-class of the provided Base
+ * Class.
+ */
+bool clang_scope_isSubclass(CXScope derived, CXScope base);
+
+/**
+ * Each base has its own offset in a Derived Class. This offset can be
+ * used to get to the Base Class fields.
+ */
+int64_t clang_scope_getBaseClassOffset(CXScope derived, CXScope base);
+
+/**
+ * Gets a list of all the Methods that are in the Class that is supplied as a
+ * parameter.
+ */
+CXScopeSet* clang_scope_getClassMethods(CXScope S);
+
+/**
+ * Template function pointer list to add proxies for
+ * un-instantiated/non-overloaded templated methods.
+ */
+CXScopeSet* clang_scope_getFunctionTemplatedDecls(CXScope S);
+
+/**
+ * Checks if a class has a default constructor.
+ */
+bool clang_scope_hasDefaultConstructor(CXScope S);
+
+/**
+ * Returns the default constructor of a class, if any.
+ */
+CXScope clang_scope_getDefaultConstructor(CXScope S);
+
+/**
+ * Returns the class destructor, if any.
+ */
+CXScope clang_scope_getDestructor(CXScope S);
+
+/**
+ * Looks up all the functions that have the name that is passed as a parameter
+ * in this function.
+ */
+CXScopeSet* clang_scope_getFunctionsUsingName(CXScope S, const char* name);
+
+/**
+ * Gets the return type of the provided function.
+ */
+CXQualType clang_scope_getFunctionReturnType(CXScope func);
+
+/**
+ * Gets the number of Arguments for the provided function.
+ */
+size_t clang_scope_getFunctionNumArgs(CXScope func);
+
+/**
+ * Gets the number of Required Arguments for the provided function.
+ */
+size_t clang_scope_getFunctionRequiredArgs(CXScope func);
+
+/**
+ * For each Argument of a function, you can get the Argument Type by providing
+ * the Argument Index, based on the number of arguments from the
+ * clang_scope_getFunctionNumArgs() function.
+ */
+CXQualType clang_scope_getFunctionArgType(CXScope func, size_t iarg);
+
+/**
+ * Returns a stringified version of a given function signature in the form:
+ * void N::f(int i, double d, long l = 0, char ch = 'a').
+ */
+CXString clang_scope_getFunctionSignature(CXScope func);
+
+/**
+ * Checks if a function was marked as \c =delete.
+ */
+bool clang_scope_isFunctionDeleted(CXScope func);
+
+/**
+ * Checks if a function is a templated function.
+ */
+bool clang_scope_isTemplatedFunction(CXScope func);
+
+/**
+ * This function performs a lookup to check if there is a templated function of
+ * that type. \c parent is mandatory, the global scope should be used as the
+ * default value.
+ */
+bool clang_scope_existsFunctionTemplate(const char* name, CXScope parent);
+
+/**
+ * Gets a list of all the Templated Methods that are in the Class that is
+ * supplied as a parameter.
+ */
+CXScopeSet* clang_scope_getClassTemplatedMethods(const char* name,
+                                                 CXScope parent);
+
+/**
+ * Checks if the provided parameter is a method.
+ */
+bool clang_scope_isMethod(CXScope method);
+
+/**
+ * Checks if the provided parameter is a 'Public' method.
+ */
+bool clang_scope_isPublicMethod(CXScope method);
+
+/**
+ * Checks if the provided parameter is a 'Protected' method.
+ */
+bool clang_scope_isProtectedMethod(CXScope method);
+
+/**
+ * Checks if the provided parameter is a 'Private' method.
+ */
+bool clang_scope_isPrivateMethod(CXScope method);
+
+/**
+ * Checks if the provided parameter is a 'Private' method.
+ */
+bool clang_scope_isPrivateMethod(CXScope method);
+
+/**
+ * Checks if the provided parameter is a Constructor.
+ */
+bool clang_scope_isConstructor(CXScope method);
+
+/**
+ * Checks if the provided parameter is a Destructor.
+ */
+bool clang_scope_isDestructor(CXScope method);
+
+/**
+ * Checks if the provided parameter is a 'Static' method.
+ */
+bool clang_scope_isStaticMethod(CXScope method);
+
+/**
+ * Returns the address of the function given its function declaration.
+ */
+CXFuncAddr clang_scope_getFunctionAddress(CXScope method);
+
+/**
+ * Checks if the provided parameter is a 'Virtual' method.
+ */
+bool clang_scope_isVirtualMethod(CXScope method);
+
+/**
+ * Checks if a function declared is of const type or not.
+ */
+bool clang_scope_isConstMethod(CXScope method);
+
+/**
+ * Returns the default argument value as string.
+ */
+CXString clang_scope_getFunctionArgDefault(CXScope func, size_t param_index);
+
+/**
+ * Returns the argument name of function as string.
+ */
+CXString clang_scope_getFunctionArgName(CXScope func, size_t param_index);
+
+typedef struct {
+  void* Type;
+  const char* IntegralValue;
+} CXTemplateArgInfo;
+
+/**
+ * Builds a template instantiation for a given templated declaration.
+ * Offers a single interface for instantiation of class, function and variable
+ * templates.
+ *
+ * \param[in] tmpl The uninstantiated template class/function.
+ *
+ * \param[in] template_args The pointer to vector of template arguments stored
+ * in the \c TemplateArgInfo struct
+ *
+ * \param[in] template_args_size The size of the vector of template arguments
+ * passed as \c template_args
+ *
+ * \returns a \c CXScope representing the instantiated templated
+ * class/function/variable.
+ */
+CXScope clang_scope_instantiateTemplate(CXScope tmpl,
+                                        CXTemplateArgInfo* template_args,
+                                        size_t template_args_size);
+
+/**
+ * Gets all the Fields/Data Members of a Class. For now, it only gets non-static
+ * data members but in a future update, it may support getting static data
+ * members as well.
+ */
+CXScopeSet* clang_scope_getDatamembers(CXScope S);
+
+/**
+ * This is a Lookup function to be used specifically for data members.
+ * \c parent is mandatory, the global scope should be used as the default value.
+ */
+CXScope clang_scope_lookupDatamember(const char* name, CXScope parent);
+
+/**
+ * Gets the type of the variable that is passed as a parameter.
+ */
+CXQualType clang_scope_getVariableType(CXScope var);
+
+/**
+ * Gets the address of the variable, you can use it to get the value stored in
+ * the variable.
+ */
+intptr_t clang_scope_getVariableOffset(CXScope var);
+
+/**
+ * Checks if the provided variable is a 'Public' variable.
+ */
+bool clang_scope_isPublicVariable(CXScope var);
+
+/**
+ * Checks if the provided variable is a 'Protected' variable.
+ */
+bool clang_scope_isProtectedVariable(CXScope var);
+
+/**
+ * Checks if the provided variable is a 'Private' variable.
+ */
+bool clang_scope_isPrivateVariable(CXScope var);
+
+/**
+ * Checks if the provided variable is a 'Static' variable.
+ */
+bool clang_scope_isStaticVariable(CXScope var);
+
+/**
+ * Checks if the provided variable is a 'Const' variable.
+ */
+bool clang_scope_isConstVariable(CXScope var);
+
+/**
+ * @}
+ */
+
+/**
+ * \defgroup CPPINTEROP_OBJECT_MANIP Object manipulations
+ *
+ * @{
+ */
+
+/**
+ * An opaque pointer representing the object of a given type (\c CXScope).
+ */
+typedef void* CXObject;
+
+/**
+ * Allocates memory for the given type.
+ */
+CXObject clang_allocate(CXScope S);
+
+/**
+ * Deallocates memory for a given class.
+ */
+void clang_deallocate(CXObject address);
+
+/**
+ * Creates an object of class \c scope and calls its default constructor. If \c
+ * arena is set it uses placement new.
+ */
+CXObject clang_construct(CXScope scope, void* arena);
+
+/**
+ * Calls the destructor of object of type \c type. When withFree is true it
+ * calls operator delete/free.
+ *
+ * \param I The interpreter.
+ *
+ * \param This The object to destruct.
+ *
+ * \param type The type of the object.
+ *
+ * \param withFree Whether to call operator delete/free or not.
+ */
+void clang_destruct(CXObject This, CXScope S, bool withFree);
+
+/**
+ * @}
+ */
+
+/**
+ * \defgroup CPPINTEROP_JITCALL_MANIP JitCall manipulations
+ *
+ * @{
+ */
+
+/**
+ * An opaque pointer representing CppInterOp's JitCall, a class modeling
+ * function calls for functions produced by the interpreter in compiled code.
+ */
+typedef struct CXJitCallImpl* CXJitCall;
+
+/**
+ * Dispose of the given CXJitCall.
+ *
+ * \param J The CXJitCall to dispose.
+ */
+void clang_jitcall_dispose(CXJitCall J);
+
+/**
+ * The kind of the JitCall.
+ */
+typedef enum {
+  CXJitCall_Unknown = 0,
+  CXJitCall_GenericCall = 1,
+  CXJitCall_DestructorCall = 2,
+} CXJitCallKind;
+
+/**
+ * Get the kind of the given CXJitCall.
+ *
+ * \param J The CXJitCall.
+ *
+ * \returns the kind of the given CXJitCall.
+ */
+CXJitCallKind clang_jitcall_getKind(CXJitCall J);
+
+/**
+ * Check if the given CXJitCall is valid.
+ *
+ * \param J The CXJitCall.
+ *
+ * \returns true if the given CXJitCall is valid.
+ */
+bool clang_jitcall_isValid(CXJitCall J);
+
+typedef struct {
+  void** data;
+  size_t numArgs;
+} CXJitCallArgList;
+
+/**
+ * Makes a call to a generic function or method.
+ *
+ * \param[in] J The CXJitCall.
+ *
+ * \param[in] result The location where the return result will be placed.
+ *
+ * \param[in] args The arguments to pass to the invocation.
+ *
+ * \param[in] self The 'this pointer' of the object.
+ */
+void clang_jitcall_invoke(CXJitCall J, void* result, CXJitCallArgList args,
+                          void* self);
+
+/**
+ * Creates a trampoline function by using the interpreter and returns a uniform
+ * interface to call it from compiled code.
+ *
+ * \returns a \c CXJitCall.
+ */
+CXJitCall clang_jitcall_makeFunctionCallable(CXScope func);
+
+/**
+ * @}
+ */
+
+LLVM_CLANG_C_EXTERN_C_END
+
+#endif // LLVM_CLANG_C_CXCPPINTEROP_H
+       // NOLINTEND()

--- a/include/clang-c/CXCppInterOp.h
+++ b/include/clang-c/CXCppInterOp.h
@@ -51,6 +51,12 @@ CXInterpreter clang_createInterpreterFromPtr(TInterp_t I);
 TInterp_t clang_interpreter_getInterpreterAsPtr(CXInterpreter I);
 
 /**
+ * Similar to \c clang_interpreter_getInterpreterAsPtr() but it takes the
+ * ownership.
+ */
+TInterp_t clang_interpreter_takeInterpreterAsPtr(CXInterpreter I);
+
+/**
  * Dispose of the given interpreter context.
  */
 void clang_interpreter_dispose(CXInterpreter I);

--- a/include/clang-c/CXCppInterOp.h
+++ b/include/clang-c/CXCppInterOp.h
@@ -325,7 +325,7 @@ CXQualType clang_qualtype_getCanonicalType(CXQualType type);
  * Used to either get the built-in type of the provided string, or
  * use the name to lookup the actual type.
  */
-CXQualType clang_qualtype_getType(const char* name);
+CXQualType clang_qualtype_getType(CXInterpreter I, const char* name);
 
 /**
  * Returns the complex of the provided type.
@@ -678,11 +678,6 @@ bool clang_scope_isPublicMethod(CXScope method);
  * Checks if the provided parameter is a 'Protected' method.
  */
 bool clang_scope_isProtectedMethod(CXScope method);
-
-/**
- * Checks if the provided parameter is a 'Private' method.
- */
-bool clang_scope_isPrivateMethod(CXScope method);
 
 /**
  * Checks if the provided parameter is a 'Private' method.

--- a/include/clang-c/CXCppInterOp.h
+++ b/include/clang-c/CXCppInterOp.h
@@ -57,6 +57,11 @@ TInterp_t clang_interpreter_getInterpreterAsPtr(CXInterpreter I);
 TInterp_t clang_interpreter_takeInterpreterAsPtr(CXInterpreter I);
 
 /**
+ * Undo N previous incremental inputs.
+ */
+CXErrorCode clang_interpreter_Undo(CXInterpreter I, unsigned int N);
+
+/**
  * Dispose of the given interpreter context.
  */
 void clang_interpreter_dispose(CXInterpreter I);
@@ -144,7 +149,7 @@ typedef void* CXValue;
  *
  * \returns a \c CXValue.
  */
-CXValue clang_createValue();
+CXValue clang_createValue(void);
 
 /**
  * Dispose of the given CXValue.

--- a/include/clang-c/CXCppInterOp.h
+++ b/include/clang-c/CXCppInterOp.h
@@ -358,21 +358,19 @@ bool clang_qualtype_isTypeDerivedFrom(CXQualType derived, CXQualType base);
  * Describes the kind of entity that a scope refers to.
  */
 enum CXScopeKind {
-  CXScope_Unexposed = 0,
-  CXScope_Invalid = 1,
-  /** The global scope. */
-  CXScope_Global = 2,
-  /** Namespaces. */
-  CXScope_Namespace = 3,
-  /** Function, methods, constructor etc. */
-  CXScope_Function = 4,
-  /** Variables. */
-  CXScope_Variable = 5,
-  /** Enum Constants. */
-  CXScope_EnumConstant = 6,
-  /** Fields. */
-  CXScope_Field = 7,
-  // reserved for future use
+  CXScope_Unexposed = 1, // FIXME: merge with CXCursorKind?
+  CXScope_Typedef = 20,
+  CXScope_Namespace = 22,
+  CXScope_ClassTemplate = 31,
+  CXScope_TypeAlias = 36,
+  CXScope_Invalid = 70,
+  CXScope_TranslationUnit = 350,
+
+  CXScope_Record,
+  CXScope_Function,
+  CXScope_Variable,
+  CXScope_EnumConstant,
+  CXScope_Field,
 };
 
 /**
@@ -834,8 +832,6 @@ CXObject clang_construct(CXScope scope, void* arena);
 /**
  * Calls the destructor of object of type \c type. When withFree is true it
  * calls operator delete/free.
- *
- * \param I The interpreter.
  *
  * \param This The object to destruct.
  *

--- a/include/clang-c/CXCppInterOp.h
+++ b/include/clang-c/CXCppInterOp.h
@@ -831,6 +831,23 @@ void clang_deallocate(CXObject address);
 CXObject clang_construct(CXScope scope, void* arena);
 
 /**
+ * Creates a trampoline function and makes a call to a generic function or
+ * method.
+ *
+ * \param func The function or method to call.
+ *
+ * \param result The location where the return result will be placed.
+ *
+ * \param args The arguments to pass to the invocation.
+ *
+ * \param n The number of arguments.
+ *
+ * \param self The 'this pointer' of the object.
+ */
+void clang_invoke(CXScope func, void* result, void** args, size_t n,
+                  void* self);
+
+/**
  * Calls the destructor of object of type \c type. When withFree is true it
  * calls operator delete/free.
  *
@@ -841,80 +858,6 @@ CXObject clang_construct(CXScope scope, void* arena);
  * \param withFree Whether to call operator delete/free or not.
  */
 void clang_destruct(CXObject This, CXScope S, bool withFree);
-
-/**
- * @}
- */
-
-/**
- * \defgroup CPPINTEROP_JITCALL_MANIP JitCall manipulations
- *
- * @{
- */
-
-/**
- * An opaque pointer representing CppInterOp's JitCall, a class modeling
- * function calls for functions produced by the interpreter in compiled code.
- */
-typedef struct CXJitCallImpl* CXJitCall;
-
-/**
- * Creates a trampoline function by using the interpreter and returns a uniform
- * interface to call it from compiled code.
- *
- * \returns a \c CXJitCall.
- */
-CXJitCall clang_jitcall_create(CXScope func);
-
-/**
- * Dispose of the given CXJitCall.
- *
- * \param J The CXJitCall to dispose.
- */
-void clang_jitcall_dispose(CXJitCall J);
-
-/**
- * The kind of the JitCall.
- */
-typedef enum {
-  CXJitCall_Unknown = 0,
-  CXJitCall_GenericCall = 1,
-  CXJitCall_DestructorCall = 2,
-} CXJitCallKind;
-
-/**
- * Get the kind of the given CXJitCall.
- *
- * \param J The CXJitCall.
- *
- * \returns the kind of the given CXJitCall.
- */
-CXJitCallKind clang_jitcall_getKind(CXJitCall J);
-
-/**
- * Check if the given CXJitCall is valid.
- *
- * \param J The CXJitCall.
- *
- * \returns true if the given CXJitCall is valid.
- */
-bool clang_jitcall_isValid(CXJitCall J);
-
-/**
- * Makes a call to a generic function or method.
- *
- * \param J The CXJitCall.
- *
- * \param result The location where the return result will be placed.
- *
- * \param args The arguments to pass to the invocation.
- *
- * \param n The number of arguments.
- *
- * \param self The 'this pointer' of the object.
- */
-void clang_jitcall_invoke(CXJitCall J, void* result, void** args,
-                          unsigned int n, void* self);
 
 /**
  * @}

--- a/include/clang-c/CXCppInterOp.h
+++ b/include/clang-c/CXCppInterOp.h
@@ -817,7 +817,7 @@ typedef void* CXObject;
 /**
  * Allocates memory for the given type.
  */
-CXObject clang_allocate(CXScope S);
+CXObject clang_allocate(unsigned int n);
 
 /**
  * Deallocates memory for a given class.

--- a/include/clang/Interpreter/CppInterOp.h
+++ b/include/clang/Interpreter/CppInterOp.h
@@ -78,6 +78,8 @@ namespace Cpp {
   class JitCall {
   public:
     friend CPPINTEROP_API JitCall MakeFunctionCallable(TCppConstFunction_t);
+    friend JitCall MakeFunctionCallableImpl(TInterp_t I,
+                                            TCppConstFunction_t func);
     enum Kind : char {
       kUnknown = 0,
       kGenericCall,
@@ -262,16 +264,16 @@ namespace Cpp {
 
   /// This is similar to GetName() function, but besides
   /// the name, it also gets the template arguments.
-  CPPINTEROP_API std::string GetCompleteName(TCppType_t klass);
+  CPPINTEROP_API std::string GetCompleteName(TCppScope_t klass);
 
   /// Gets the "qualified" name (including the namespace) of any
   /// named decl (a class, namespace, variable, or a function).
-  CPPINTEROP_API std::string GetQualifiedName(TCppType_t klass);
+  CPPINTEROP_API std::string GetQualifiedName(TCppScope_t klass);
 
   /// This is similar to GetQualifiedName() function, but besides
   /// the "qualified" name (including the namespace), it also
   /// gets the template arguments.
-  CPPINTEROP_API std::string GetQualifiedCompleteName(TCppType_t klass);
+  CPPINTEROP_API std::string GetQualifiedCompleteName(TCppScope_t klass);
 
   /// Gets the list of namespaces utilized in the supplied scope.
   CPPINTEROP_API std::vector<TCppScope_t> GetUsingNamespaces(TCppScope_t scope);
@@ -307,13 +309,13 @@ namespace Cpp {
 
   /// Gets the number of Base Classes for the Derived Class that
   /// is passed as a parameter.
-  CPPINTEROP_API TCppIndex_t GetNumBases(TCppType_t klass);
+  CPPINTEROP_API TCppIndex_t GetNumBases(TCppScope_t klass);
 
   /// Gets a specific Base Class using its index. Typically GetNumBases()
   /// is used to get the number of Base Classes, and then that number
   /// can be used to iterate through the index value to get each specific
   /// base class.
-  CPPINTEROP_API TCppScope_t GetBaseClass(TCppType_t klass, TCppIndex_t ibase);
+  CPPINTEROP_API TCppScope_t GetBaseClass(TCppScope_t klass, TCppIndex_t ibase);
 
   /// Checks if the supplied Derived Class is a sub-class of the
   /// provided Base Class.

--- a/lib/Interpreter/CMakeLists.txt
+++ b/lib/Interpreter/CMakeLists.txt
@@ -97,6 +97,7 @@ endif(LLVM_LINK_LLVM_DYLIB)
 add_llvm_library(clangCppInterOp
   DISABLE_LLVM_LINK_LLVM_DYLIB
   CppInterOp.cpp
+  CXCppInterOp.cpp
   ${DLM}
   LINK_LIBS
   ${link_libs}

--- a/lib/Interpreter/CXCppInterOp.cpp
+++ b/lib/Interpreter/CXCppInterOp.cpp
@@ -460,8 +460,9 @@ CXScopeSet* clang_scope_getEnumConstants(CXScope S) {
   Set->Count = std::distance(ED->enumerator_begin(), ED->enumerator_end());
   Set->Scopes = new CXScope[Set->Count]; // NOLINT(*-owning-memory)
   for (auto En : llvm::enumerate(ED->enumerators())) {
-    Set->Scopes[En.index()] =
-        makeCXScope(getMeta(S), En.value(), CXScope_EnumConstant);
+    auto Idx = En.index();
+    auto Val = En.value();
+    Set->Scopes[Idx] = makeCXScope(getMeta(S), Val, CXScope_EnumConstant);
   }
 
   return Set;
@@ -573,8 +574,10 @@ CXScopeSet* clang_scope_getUsingNamespaces(CXScope S) {
                              DC->using_directives().end());
   Set->Scopes = new CXScope[Set->Count]; // NOLINT(*-owning-memory)
   for (auto En : llvm::enumerate(DC->using_directives())) {
-    Set->Scopes[En.index()] = makeCXScope(
-        getMeta(S), En.value()->getNominatedNamespace(), CXScope_Namespace);
+    auto Idx = En.index();
+    auto Val = En.value();
+    Set->Scopes[Idx] = makeCXScope(getMeta(S), Val->getNominatedNamespace(),
+                                   CXScope_Namespace);
   }
 
   return Set;
@@ -753,8 +756,9 @@ CXScopeSet* clang_scope_getClassMethods(CXScope S) {
   Set->Count = Methods.size();
   Set->Scopes = new CXScope[Set->Count]; // NOLINT(*-owning-memory)
   for (auto En : llvm::enumerate(Methods)) {
-    Set->Scopes[En.index()] =
-        makeCXScope(getMeta(S), En.value(), CXScope_Function);
+    auto Idx = En.index();
+    auto Val = En.value();
+    Set->Scopes[Idx] = makeCXScope(getMeta(S), Val, CXScope_Function);
   }
 
   return Set;
@@ -790,8 +794,9 @@ CXScopeSet* clang_scope_getFunctionTemplatedDecls(CXScope S) {
   Set->Count = Methods.size();
   Set->Scopes = new CXScope[Set->Count]; // NOLINT(*-owning-memory)
   for (auto En : llvm::enumerate(Methods)) {
-    Set->Scopes[En.index()] =
-        makeCXScope(getMeta(S), En.value(), CXScope_Function);
+    auto Idx = En.index();
+    auto Val = En.value();
+    Set->Scopes[Idx] = makeCXScope(getMeta(S), Val, CXScope_Function);
   }
 
   return Set;
@@ -859,8 +864,9 @@ CXScopeSet* clang_scope_getFunctionsUsingName(CXScope S, const char* name) {
   Set->Count = Funcs.size();
   Set->Scopes = new CXScope[Set->Count]; // NOLINT(*-owning-memory)
   for (auto En : llvm::enumerate(Funcs)) {
-    Set->Scopes[En.index()] =
-        makeCXScope(getMeta(S), En.value(), CXScope_Function);
+    auto Idx = En.index();
+    auto Val = En.value();
+    Set->Scopes[Idx] = makeCXScope(getMeta(S), Val, CXScope_Function);
   }
 
   return Set;
@@ -1008,8 +1014,9 @@ CXScopeSet* clang_scope_getClassTemplatedMethods(const char* name,
   Set->Count = Funcs.size();
   Set->Scopes = new CXScope[Set->Count]; // NOLINT(*-owning-memory)
   for (auto En : llvm::enumerate(Funcs)) {
-    Set->Scopes[En.index()] =
-        makeCXScope(getMeta(parent), En.value(), CXScope_Function);
+    auto Idx = En.index();
+    auto Val = En.value();
+    Set->Scopes[Idx] = makeCXScope(getMeta(parent), Val, CXScope_Function);
   }
 
   return Set;
@@ -1128,8 +1135,9 @@ CXScopeSet* clang_scope_getDatamembers(CXScope S) {
   Set->Count = std::distance(CXXRD->field_begin(), CXXRD->field_end());
   Set->Scopes = new CXScope[Set->Count]; // NOLINT(*-owning-memory)
   for (auto En : llvm::enumerate(CXXRD->fields())) {
-    Set->Scopes[En.index()] =
-        makeCXScope(getMeta(S), En.value(), CXScope_Function);
+    auto Idx = En.index();
+    auto Val = En.value();
+    Set->Scopes[Idx] = makeCXScope(getMeta(S), Val, CXScope_Function);
   }
 
   return Set;

--- a/lib/Interpreter/CXCppInterOp.cpp
+++ b/lib/Interpreter/CXCppInterOp.cpp
@@ -70,7 +70,7 @@ TInterp_t clang_interpreter_takeInterpreterAsPtr(CXInterpreter I) {
   return static_cast<CXInterpreterImpl*>(I)->Interp.release();
 }
 
-CXErrorCode clang_interpreter_Undo(CXInterpreter I, unsigned int N) {
+enum CXErrorCode clang_interpreter_Undo(CXInterpreter I, unsigned int N) {
   return getInterpreter(I)->Undo(N) ? CXError_Failure : CXError_Success;
 }
 

--- a/lib/Interpreter/CXCppInterOp.cpp
+++ b/lib/Interpreter/CXCppInterOp.cpp
@@ -461,7 +461,7 @@ CXScopeSet* clang_scope_getEnumConstants(CXScope S) {
   Set->Scopes = new CXScope[Set->Count]; // NOLINT(*-owning-memory)
   for (auto En : llvm::enumerate(ED->enumerators())) {
     auto Idx = En.index();
-    auto Val = En.value();
+    auto* Val = En.value();
     Set->Scopes[Idx] = makeCXScope(getMeta(S), Val, CXScope_EnumConstant);
   }
 
@@ -575,7 +575,7 @@ CXScopeSet* clang_scope_getUsingNamespaces(CXScope S) {
   Set->Scopes = new CXScope[Set->Count]; // NOLINT(*-owning-memory)
   for (auto En : llvm::enumerate(DC->using_directives())) {
     auto Idx = En.index();
-    auto Val = En.value();
+    auto* Val = En.value();
     Set->Scopes[Idx] = makeCXScope(getMeta(S), Val->getNominatedNamespace(),
                                    CXScope_Namespace);
   }
@@ -757,7 +757,7 @@ CXScopeSet* clang_scope_getClassMethods(CXScope S) {
   Set->Scopes = new CXScope[Set->Count]; // NOLINT(*-owning-memory)
   for (auto En : llvm::enumerate(Methods)) {
     auto Idx = En.index();
-    auto Val = En.value();
+    auto* Val = En.value();
     Set->Scopes[Idx] = makeCXScope(getMeta(S), Val, CXScope_Function);
   }
 
@@ -795,7 +795,7 @@ CXScopeSet* clang_scope_getFunctionTemplatedDecls(CXScope S) {
   Set->Scopes = new CXScope[Set->Count]; // NOLINT(*-owning-memory)
   for (auto En : llvm::enumerate(Methods)) {
     auto Idx = En.index();
-    auto Val = En.value();
+    auto* Val = En.value();
     Set->Scopes[Idx] = makeCXScope(getMeta(S), Val, CXScope_Function);
   }
 
@@ -865,7 +865,7 @@ CXScopeSet* clang_scope_getFunctionsUsingName(CXScope S, const char* name) {
   Set->Scopes = new CXScope[Set->Count]; // NOLINT(*-owning-memory)
   for (auto En : llvm::enumerate(Funcs)) {
     auto Idx = En.index();
-    auto Val = En.value();
+    auto* Val = En.value();
     Set->Scopes[Idx] = makeCXScope(getMeta(S), Val, CXScope_Function);
   }
 
@@ -1015,7 +1015,7 @@ CXScopeSet* clang_scope_getClassTemplatedMethods(const char* name,
   Set->Scopes = new CXScope[Set->Count]; // NOLINT(*-owning-memory)
   for (auto En : llvm::enumerate(Funcs)) {
     auto Idx = En.index();
-    auto Val = En.value();
+    auto* Val = En.value();
     Set->Scopes[Idx] = makeCXScope(getMeta(parent), Val, CXScope_Function);
   }
 
@@ -1136,7 +1136,7 @@ CXScopeSet* clang_scope_getDatamembers(CXScope S) {
   Set->Scopes = new CXScope[Set->Count]; // NOLINT(*-owning-memory)
   for (auto En : llvm::enumerate(CXXRD->fields())) {
     auto Idx = En.index();
-    auto Val = En.value();
+    auto* Val = En.value();
     Set->Scopes[Idx] = makeCXScope(getMeta(S), Val, CXScope_Function);
   }
 

--- a/lib/Interpreter/CXCppInterOp.cpp
+++ b/lib/Interpreter/CXCppInterOp.cpp
@@ -1,0 +1,1316 @@
+#include "clang-c/CXCppInterOp.h"
+#include "Compatibility.h"
+#include "clang/AST/CXXInheritance.h"
+#include "clang/AST/Decl.h"
+#include "clang/AST/DeclCXX.h"
+#include "clang/AST/Mangle.h"
+#include "clang/AST/RecordLayout.h"
+#include "clang/AST/Type.h"
+#include "clang/Frontend/CompilerInstance.h"
+#include "clang/Interpreter/CppInterOp.h"
+#include "clang/Sema/Lookup.h"
+#include "clang/Sema/Sema.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ExecutionEngine/Orc/LLJIT.h"
+#include "llvm/Support/Casting.h"
+#include <cstring>
+#include <iterator>
+#include "clang-c/CXString.h"
+
+CXString makeCXString(const std::string& S) {
+  CXString Str;
+  if (S.empty()) {
+    Str.data = "";
+    Str.private_flags = 0; // CXS_Unmanaged
+  } else {
+    Str.data = strdup(S.c_str());
+    Str.private_flags = 1; // CXS_Malloc
+  }
+  return Str;
+}
+
+CXStringSet* makeCXStringSet(const std::vector<std::string>& Strs) {
+  CXStringSet* Set = new CXStringSet;
+  Set->Count = Strs.size();
+  Set->Strings = new CXString[Set->Count];
+  for (auto [Idx, Val] : llvm::enumerate(Strs)) {
+    Set->Strings[Idx] = makeCXString(Val);
+  }
+  return Set;
+}
+
+struct CXInterpreterImpl {
+  std::unique_ptr<compat::Interpreter> Interp;
+  // reserved for future use
+};
+
+static inline compat::Interpreter* getInterpreter(const CXInterpreterImpl* I) {
+  assert(I && "Invalid interpreter");
+  return I->Interp.get();
+}
+
+CXInterpreter clang_createInterpreter(const char* const* argv, int argc) {
+  auto* I = new CXInterpreterImpl();
+  I->Interp = std::make_unique<compat::Interpreter>(argc, argv);
+  // reserved for future use
+  return I;
+}
+
+CXInterpreter clang_createInterpreterFromPtr(TInterp_t I) {
+  auto* II = new CXInterpreterImpl();
+  II->Interp.reset(reinterpret_cast<compat::Interpreter*>(I)); // NOLINT(*-cast)
+  return II;
+}
+
+TInterp_t clang_interpreter_getInterpreterAsPtr(CXInterpreter I) {
+  return reinterpret_cast<TInterp_t>(getInterpreter(I)); // NOLINT(*-cast)
+}
+
+void clang_interpreter_dispose(CXInterpreter I) {
+  delete static_cast<CXInterpreterImpl*>(I); // NOLINT(*-owning-memory)
+}
+
+void clang_interpreter_addSearchPath(CXInterpreter I, const char* dir,
+                                     bool isUser, bool prepend) {
+  auto* interp = getInterpreter(I);
+  interp->getDynamicLibraryManager()->addSearchPath(dir, isUser, prepend);
+}
+
+void clang_interpreter_addIncludePath(CXInterpreter I, const char* dir) {
+  getInterpreter(I)->AddIncludePath(dir);
+}
+
+const char* clang_interpreter_getResourceDir(CXInterpreter I) {
+  auto* interp = getInterpreter(I);
+  return interp->getCI()->getHeaderSearchOpts().ResourceDir.c_str();
+}
+
+enum CXErrorCode clang_interpreter_declare(CXInterpreter I, const char* code,
+                                           bool silent) {
+  auto* interp = getInterpreter(I);
+  auto& diag = interp->getSema().getDiagnostics();
+
+  bool is_silent_old = diag.getSuppressAllDiagnostics();
+
+  diag.setSuppressAllDiagnostics(silent);
+  auto result = interp->declare(code);
+  diag.setSuppressAllDiagnostics(is_silent_old);
+
+  if (result)
+    return CXError_Failure;
+
+  return CXError_Success;
+}
+
+enum CXErrorCode clang_interpreter_process(CXInterpreter I, const char* code) {
+  auto result = getInterpreter(I)->process(code);
+  if (result)
+    return CXError_Failure;
+
+  return CXError_Success;
+}
+
+CXValue clang_createValue() {
+#ifdef USE_CLING
+  auto val = std::make_unique<cling::Value>();
+#else
+  auto val = std::make_unique<clang::Value>();
+#endif // USE_CLING
+
+  return val.release();
+}
+
+void clang_value_dispose(CXValue V) {
+#ifdef USE_CLING
+  delete static_cast<cling::Value*>(V); // NOLINT(*-owning-memory)
+#else
+  delete static_cast<clang::Value*>(V); // NOLINT(*-owning-memory)
+#endif // USE_CLING
+}
+
+enum CXErrorCode clang_interpreter_evaluate(CXInterpreter I, const char* code,
+                                            CXValue V) {
+#ifdef USE_CLING
+  auto* val = static_cast<cling::Value*>(V);
+#else
+  auto* val = static_cast<clang::Value*>(V);
+#endif // USE_CLING
+
+  auto result = getInterpreter(I)->evaluate(code, *val);
+  if (result)
+    return CXError_Failure;
+
+  return CXError_Success;
+}
+
+CXString clang_interpreter_lookupLibrary(CXInterpreter I,
+                                         const char* lib_name) {
+  auto* interp = getInterpreter(I);
+  return makeCXString(
+      interp->getDynamicLibraryManager()->lookupLibrary(lib_name));
+}
+
+CXInterpreter_CompilationResult
+clang_interpreter_loadLibrary(CXInterpreter I, const char* lib_stem,
+                              bool lookup) {
+  auto* interp = getInterpreter(I);
+  return static_cast<CXInterpreter_CompilationResult>(
+      interp->loadLibrary(lib_stem, lookup));
+}
+
+void clang_interpreter_unloadLibrary(CXInterpreter I, const char* lib_stem) {
+  auto* interp = getInterpreter(I);
+  interp->getDynamicLibraryManager()->unloadLibrary(lib_stem);
+}
+
+CXString clang_interpreter_searchLibrariesForSymbol(CXInterpreter I,
+                                                    const char* mangled_name,
+                                                    bool search_system) {
+  auto* interp = getInterpreter(I);
+  return makeCXString(
+      interp->getDynamicLibraryManager()->searchLibrariesForSymbol(
+          mangled_name, search_system));
+}
+
+namespace Cpp {
+bool InsertOrReplaceJitSymbolImpl(compat::Interpreter& I,
+                                  const char* linker_mangled_name,
+                                  uint64_t address);
+} // namespace Cpp
+
+bool clang_interpreter_insertOrReplaceJitSymbol(CXInterpreter I,
+                                                const char* linker_mangled_name,
+                                                uint64_t address) {
+  return Cpp::InsertOrReplaceJitSymbolImpl(*getInterpreter(I),
+                                           linker_mangled_name, address);
+}
+
+CXFuncAddr
+clang_interpreter_getFunctionAddressFromMangledName(CXInterpreter I,
+                                                    const char* mangled_name) {
+  auto* interp = getInterpreter(I);
+  auto FDAorErr = compat::getSymbolAddress(*interp, mangled_name);
+  if (llvm::Error Err = FDAorErr.takeError())
+    llvm::consumeError(std::move(Err)); // nullptr if missing
+  else
+    return llvm::jitTargetAddressToPointer<void*>(*FDAorErr);
+
+  return nullptr;
+}
+
+static inline CXQualType
+makeCXQualType(const CXInterpreterImpl* I, clang::QualType Ty,
+               CXQualTypeKind K = CXQualType_Unexposed) {
+  assert(I && "Invalid interpreter");
+  return CXQualType{K, Ty.getAsOpaquePtr(), reinterpret_cast<const void*>(I)};
+}
+
+static inline clang::QualType getType(CXQualType Ty) {
+  return clang::QualType::getFromOpaquePtr(Ty.data);
+}
+
+static inline const CXInterpreterImpl* getMeta(CXQualType Ty) {
+  return reinterpret_cast<const CXInterpreterImpl*>(Ty.meta);
+}
+
+static inline compat::Interpreter* getInterpreter(CXQualType Ty) {
+  return getInterpreter(reinterpret_cast<const CXInterpreterImpl*>(Ty.meta));
+}
+
+bool clang_qualtype_isBuiltin(CXQualType type) {
+  return Cpp::IsBuiltin(type.data);
+}
+
+bool clang_qualtype_isEnumType(CXQualType type) {
+  return getType(type)->isEnumeralType();
+}
+
+bool clang_qualtype_isSmartPtrType(CXQualType type) {
+  return Cpp::IsSmartPtrType(type.data);
+}
+
+bool clang_scope_isRecordType(CXQualType type) {
+  return getType(type)->isRecordType();
+}
+
+bool clang_scope_isPODType(CXQualType type) {
+  clang::QualType QT = getType(type);
+  if (QT.isNull())
+    return false;
+  return QT.isPODType(getInterpreter(type)->getSema().getASTContext());
+}
+
+CXQualType clang_qualtype_getIntegerTypeFromEnumType(CXQualType type) {
+  void* Ptr = Cpp::GetIntegerTypeFromEnumType(type.data);
+  return makeCXQualType(getMeta(type), clang::QualType::getFromOpaquePtr(Ptr));
+}
+
+CXQualType clang_qualtype_getUnderlyingType(CXQualType type) {
+  clang::QualType QT = getType(type);
+  QT = QT->getCanonicalTypeUnqualified();
+
+  // Recursively remove array dimensions
+  while (QT->isArrayType())
+    QT = clang::QualType(QT->getArrayElementTypeNoTypeQual(), 0);
+
+  // Recursively reduce pointer depth till we are left with a pointerless
+  // type.
+  for (auto PT = QT->getPointeeType(); !PT.isNull();
+       PT = QT->getPointeeType()) {
+    QT = PT;
+  }
+  QT = QT->getCanonicalTypeUnqualified();
+  return makeCXQualType(getMeta(type), QT);
+}
+
+CXString clang_qualtype_getTypeAsString(CXQualType type) {
+  clang::QualType QT = getType(type);
+  auto& C = getInterpreter(type)->getSema().getASTContext();
+  clang::PrintingPolicy Policy = C.getPrintingPolicy();
+  Policy.Bool = true;               // Print bool instead of _Bool.
+  Policy.SuppressTagKeyword = true; // Do not print `class std::string`.
+  return makeCXString(compat::FixTypeName(QT.getAsString(Policy)));
+}
+
+CXQualType clang_qualtype_getCanonicalType(CXQualType type) {
+  clang::QualType QT = getType(type);
+  if (QT.isNull())
+    return makeCXQualType(getMeta(type), clang::QualType(), CXQualType_Invalid);
+
+  return makeCXQualType(getMeta(type), QT.getCanonicalType());
+}
+
+namespace Cpp {
+clang::QualType GetType(const std::string& name, clang::Sema& sema);
+} // namespace Cpp
+
+CXQualType clang_qualtype_getType(CXInterpreter I, const char* name) {
+  auto& S = getInterpreter(I)->getSema();
+  clang::QualType QT = Cpp::GetType(std::string(name), S);
+  if (QT.isNull())
+    return makeCXQualType(I, QT, CXQualType_Invalid);
+
+  return makeCXQualType(I, QT);
+}
+
+CXQualType clang_qualtype_getComplexType(CXQualType eltype) {
+  auto& C = getInterpreter(eltype)->getSema().getASTContext();
+  return makeCXQualType(getMeta(eltype), C.getComplexType(getType(eltype)));
+}
+
+static inline CXScope makeCXScope(const CXInterpreterImpl* I, clang::Decl* D,
+                                  CXScopeKind K = CXScope_Unexposed) {
+  assert(I && "Invalid interpreter");
+  return CXScope{K, D, reinterpret_cast<const void*>(I)};
+}
+
+size_t clang_qualtype_getSizeOfType(CXQualType type) {
+  clang::QualType QT = getType(type);
+  if (const clang::TagType* TT = QT->getAs<clang::TagType>())
+    return clang_scope_sizeOf(makeCXScope(getMeta(type), TT->getDecl()));
+
+  // FIXME: Can we get the size of a non-tag type?
+  auto* I = getInterpreter(type);
+  auto TI = I->getSema().getASTContext().getTypeInfo(QT);
+  size_t TypeSize = TI.Width;
+  return TypeSize / 8;
+}
+
+bool clang_qualtype_isTypeDerivedFrom(CXQualType derived, CXQualType base) {
+  auto* I = getInterpreter(derived);
+  auto& SM = I->getSema().getSourceManager();
+  auto fakeLoc = SM.getLocForStartOfFile(SM.getMainFileID());
+  auto derivedType = getType(derived);
+  auto baseType = getType(base);
+
+#ifdef USE_CLING
+  cling::Interpreter::PushTransactionRAII RAII(I);
+#endif
+  return I->getSema().IsDerivedFrom(fakeLoc, derivedType, baseType);
+}
+
+static inline bool isNull(CXScope S) { return !S.data; }
+
+static inline clang::Decl* getDecl(CXScope S) {
+  return static_cast<clang::Decl*>(S.data);
+}
+
+static inline const CXInterpreterImpl* getMeta(CXScope S) {
+  return reinterpret_cast<const CXInterpreterImpl*>(S.meta);
+}
+
+static inline CXScopeKind kind(CXScope S) { return S.kind; }
+
+static inline compat::Interpreter* getInterpreter(CXScope S) {
+  return getInterpreter(reinterpret_cast<const CXInterpreterImpl*>(S.meta));
+}
+
+void clang_scope_dump(CXScope S) { getDecl(S)->dump(); }
+
+CXQualType clang_scope_getTypeFromScope(CXScope S) {
+  if (isNull(S))
+    return makeCXQualType(getMeta(S), clang::QualType(), CXQualType_Invalid);
+
+  auto* D = getDecl(S);
+  if (const auto* VD = llvm::dyn_cast<clang::ValueDecl>(D))
+    return makeCXQualType(getMeta(S), VD->getType());
+
+  auto& Ctx = getInterpreter(S)->getCI()->getASTContext();
+  return makeCXQualType(getMeta(S),
+                        Ctx.getTypeDeclType(llvm::cast<clang::TypeDecl>(D)));
+}
+
+bool clang_scope_isAggregate(CXScope S) { return Cpp::IsAggregate(S.data); }
+
+bool clang_scope_isNamespace(CXScope S) {
+  return llvm::isa<clang::NamespaceDecl>(getDecl(S));
+}
+
+bool clang_scope_isClass(CXScope S) {
+  return llvm::isa<clang::CXXRecordDecl>(getDecl(S));
+}
+
+bool clang_scope_isComplete(CXScope S) {
+  if (isNull(S))
+    return false;
+
+  auto* D = getDecl(S);
+  if (llvm::isa<clang::ClassTemplateSpecializationDecl>(D)) {
+    clang::QualType QT = getType(clang_scope_getTypeFromScope(S));
+    const auto* CI = getInterpreter(S)->getCI();
+    auto& S = CI->getSema();
+    auto& SM = S.getSourceManager();
+    clang::SourceLocation fakeLoc = SM.getLocForStartOfFile(SM.getMainFileID());
+    return S.isCompleteType(fakeLoc, QT);
+  }
+
+  if (auto* CXXRD = llvm::dyn_cast<clang::CXXRecordDecl>(D))
+    return CXXRD->hasDefinition();
+  else if (auto* TD = llvm::dyn_cast<clang::TagDecl>(D))
+    return TD->getDefinition();
+
+  // Everything else is considered complete.
+  return true;
+}
+
+size_t clang_scope_sizeOf(CXScope S) {
+  if (!clang_scope_isComplete(S))
+    return 0;
+
+  if (auto* RD = llvm::dyn_cast<clang::RecordDecl>(getDecl(S))) {
+    clang::ASTContext& Context = RD->getASTContext();
+    const clang::ASTRecordLayout& Layout = Context.getASTRecordLayout(RD);
+    return Layout.getSize().getQuantity();
+  }
+
+  return 0;
+}
+
+bool clang_scope_isTemplate(CXScope S) {
+  return llvm::isa_and_nonnull<clang::TemplateDecl>(getDecl(S));
+}
+
+bool clang_scope_isTemplateSpecialization(CXScope S) {
+  return llvm::isa_and_nonnull<clang::ClassTemplateSpecializationDecl>(
+      getDecl(S));
+}
+
+bool clang_scope_isTypedefed(CXScope S) {
+  return llvm::isa_and_nonnull<clang::TypedefNameDecl>(getDecl(S));
+}
+
+bool clang_scope_isAbstract(CXScope S) {
+  if (auto* CXXRD = llvm::dyn_cast_or_null<clang::CXXRecordDecl>(getDecl(S)))
+    return CXXRD->isAbstract();
+  return false;
+}
+
+bool clang_scope_isEnumScope(CXScope S) {
+  return llvm::isa_and_nonnull<clang::EnumDecl>(getDecl(S));
+}
+
+bool clang_scope_isEnumConstant(CXScope S) {
+  return llvm::isa_and_nonnull<clang::EnumConstantDecl>(getDecl(S));
+}
+
+CXStringSet* clang_scope_getEnums(CXScope S) {
+  std::vector<std::string> EnumNames;
+  Cpp::GetEnums(S.data, EnumNames);
+  return makeCXStringSet(EnumNames);
+}
+
+CXQualType clang_scope_getIntegerTypeFromEnumScope(CXScope S) {
+  auto* ED = llvm::dyn_cast_or_null<clang::EnumDecl>(getDecl(S));
+  if (ED)
+    return makeCXQualType(getMeta(S), ED->getIntegerType());
+
+  return makeCXQualType(getMeta(S), clang::QualType(), CXQualType_Invalid);
+}
+
+void clang_disposeScopeSet(CXScopeSet* set) {
+  delete[] set->Scopes;
+  delete set;
+}
+
+CXScopeSet* clang_scope_getEnumConstants(CXScope S) {
+  auto* ED = llvm::dyn_cast_or_null<clang::EnumDecl>(getDecl(S));
+  if (!ED || ED->enumerators().empty())
+    return nullptr;
+
+  CXScopeSet* Set = new CXScopeSet;
+  Set->Count = std::distance(ED->enumerator_begin(), ED->enumerator_end());
+  Set->Scopes = new CXScope[Set->Count];
+  for (auto [Idx, Val] : llvm::enumerate(ED->enumerators())) {
+    Set->Scopes[Idx] = makeCXScope(getMeta(S), Val, CXScope_EnumConstant);
+  }
+
+  return Set;
+}
+
+CXQualType clang_scope_getEnumConstantType(CXScope S) {
+  if (isNull(S))
+    return makeCXQualType(getMeta(S), clang::QualType(), CXQualType_Invalid);
+
+  auto* ECD = llvm::dyn_cast_or_null<clang::EnumConstantDecl>(getDecl(S));
+  if (ECD)
+    return makeCXQualType(getMeta(S), ECD->getType());
+
+  return makeCXQualType(getMeta(S), clang::QualType(), CXQualType_Invalid);
+}
+
+size_t clang_scope_getEnumConstantValue(CXScope S) {
+  auto* ECD = llvm::dyn_cast_or_null<clang::EnumConstantDecl>(getDecl(S));
+  if (ECD) {
+    const llvm::APSInt& Val = ECD->getInitVal();
+    return Val.getExtValue();
+  }
+  return 0;
+}
+
+bool clang_scope_isVariable(CXScope S) {
+  return llvm::isa_and_nonnull<clang::VarDecl>(getDecl(S));
+}
+
+CXString clang_scope_getName(CXScope S) {
+  auto* D = getDecl(S);
+
+  if (llvm::isa_and_nonnull<clang::TranslationUnitDecl>(D))
+    return makeCXString("");
+
+  if (auto* ND = llvm::dyn_cast_or_null<clang::NamedDecl>(D))
+    return makeCXString(ND->getNameAsString());
+
+  return makeCXString("<unnamed>");
+}
+
+CXString clang_scope_getCompleteName(CXScope S) {
+  auto& C = getInterpreter(S)->getSema().getASTContext();
+  auto* D = getDecl(S);
+
+  if (auto* ND = llvm::dyn_cast_or_null<clang::NamedDecl>(D)) {
+    if (auto* TD = llvm::dyn_cast<clang::TagDecl>(ND)) {
+      std::string type_name;
+      clang::QualType QT = C.getTagDeclType(TD);
+      clang::PrintingPolicy Policy = C.getPrintingPolicy();
+      Policy.SuppressUnwrittenScope = true;
+      Policy.SuppressScope = true;
+      Policy.AnonymousTagLocations = false;
+      QT.getAsStringInternal(type_name, Policy);
+
+      return makeCXString(type_name);
+    }
+
+    return makeCXString(ND->getNameAsString());
+  }
+
+  if (llvm::isa_and_nonnull<clang::TranslationUnitDecl>(D))
+    return makeCXString("");
+
+  return makeCXString("<unnamed>");
+}
+
+CXString clang_scope_getQualifiedName(CXScope S) {
+  auto* D = getDecl(S);
+  if (auto* ND = llvm::dyn_cast_or_null<clang::NamedDecl>(D))
+    return makeCXString(ND->getQualifiedNameAsString());
+
+  if (llvm::isa_and_nonnull<clang::TranslationUnitDecl>(D))
+    return makeCXString("");
+
+  return makeCXString("<unnamed>");
+}
+
+CXString clang_scope_getQualifiedCompleteName(CXScope S) {
+  auto& C = getInterpreter(S)->getSema().getASTContext();
+  auto* D = getDecl(S);
+
+  if (auto* ND = llvm::dyn_cast_or_null<clang::NamedDecl>(D)) {
+    if (auto* TD = llvm::dyn_cast<clang::TagDecl>(ND)) {
+      std::string type_name;
+      clang::QualType QT = C.getTagDeclType(TD);
+      QT.getAsStringInternal(type_name, C.getPrintingPolicy());
+
+      return makeCXString(type_name);
+    }
+
+    return makeCXString(ND->getQualifiedNameAsString());
+  }
+
+  if (llvm::isa_and_nonnull<clang::TranslationUnitDecl>(D)) {
+    return makeCXString("");
+  }
+
+  return makeCXString("<unnamed>");
+}
+
+CXScopeSet* clang_scope_getUsingNamespaces(CXScope S) {
+  auto* DC = llvm::dyn_cast_or_null<clang::DeclContext>(getDecl(S));
+  if (!DC || DC->using_directives().empty())
+    return nullptr;
+
+  CXScopeSet* Set = new CXScopeSet;
+  Set->Count = std::distance(DC->using_directives().begin(),
+                             DC->using_directives().end());
+  Set->Scopes = new CXScope[Set->Count];
+  for (auto [Idx, Val] : llvm::enumerate(DC->using_directives())) {
+    Set->Scopes[Idx] = makeCXScope(getMeta(S), Val->getNominatedNamespace(),
+                                   CXScope_Namespace);
+  }
+
+  return Set;
+}
+
+CXScope clang_scope_getGlobalScope(CXInterpreter I) {
+  auto& C = getInterpreter(I)->getSema().getASTContext();
+  auto* DC = C.getTranslationUnitDecl();
+  return makeCXScope(I, DC, CXScope_Global);
+}
+
+CXScope clang_scope_getUnderlyingScope(CXScope S) {
+  auto* TND = llvm::dyn_cast_or_null<clang::TypedefNameDecl>(getDecl(S));
+  if (!TND)
+    return makeCXScope(getMeta(S), nullptr, CXScope_Invalid);
+
+  clang::QualType QT = TND->getUnderlyingType();
+  auto D = Cpp::GetScopeFromType(QT.getAsOpaquePtr());
+  if (!D)
+    return makeCXScope(getMeta(S), nullptr, CXScope_Invalid);
+
+  return makeCXScope(getMeta(S), static_cast<clang::Decl*>(D));
+}
+
+CXScope clang_scope_getScope(const char* name, CXScope parent) {
+  auto S = clang_scope_getNamed(name, parent);
+  if (kind(S) == CXScope_Invalid)
+    return S;
+
+  clang::NamedDecl* ND = llvm::dyn_cast<clang::NamedDecl>(getDecl(S));
+  if (llvm::isa<clang::NamespaceDecl>(ND) || llvm::isa<clang::RecordDecl>(ND) ||
+      llvm::isa<clang::ClassTemplateDecl>(ND) ||
+      llvm::isa<clang::TypedefNameDecl>(ND)) {
+    return makeCXScope(getMeta(S), ND->getCanonicalDecl());
+  }
+
+  return S;
+}
+
+CXScope clang_scope_getNamed(const char* name, CXScope parent) {
+  clang::DeclContext* Within = 0;
+  if (kind(parent) != CXScope_Invalid) {
+    auto US = clang_scope_getUnderlyingScope(parent);
+    if (kind(US) != CXScope_Invalid)
+      Within = llvm::dyn_cast<clang::DeclContext>(getDecl(US));
+  }
+
+  auto& sema = getInterpreter(parent)->getSema();
+  auto* ND = Cpp::Cpp_utils::Lookup::Named(&sema, std::string(name), Within);
+  if (ND && ND != (clang::NamedDecl*)-1) {
+    return makeCXScope(getMeta(parent), ND->getCanonicalDecl());
+  }
+
+  return makeCXScope(getMeta(parent), nullptr, CXScope_Invalid);
+}
+
+CXScope clang_scope_getParentScope(CXScope parent) {
+  auto* D = getDecl(parent);
+
+  if (llvm::isa_and_nonnull<clang::TranslationUnitDecl>(D))
+    return makeCXScope(getMeta(parent), nullptr, CXScope_Invalid);
+
+  auto* ParentDC = D->getDeclContext();
+
+  if (!ParentDC)
+    return makeCXScope(getMeta(parent), nullptr, CXScope_Invalid);
+
+  auto* CD = clang::Decl::castFromDeclContext(ParentDC)->getCanonicalDecl();
+
+  return makeCXScope(getMeta(parent), CD);
+}
+
+CXScope clang_scope_getScopeFromType(CXQualType type) {
+  auto* D = Cpp::GetScopeFromType(type.data);
+  return makeCXScope(getMeta(type), static_cast<clang::Decl*>(D));
+}
+
+size_t clang_scope_getNumBases(CXScope S) {
+  auto* D = getDecl(S);
+
+  if (auto* CXXRD = llvm::dyn_cast_or_null<clang::CXXRecordDecl>(D)) {
+    if (CXXRD->hasDefinition())
+      return CXXRD->getNumBases();
+  }
+
+  return 0;
+}
+
+CXScope clang_scope_getBaseClass(CXScope S, size_t ibase) {
+  auto* D = getDecl(S);
+  auto* CXXRD = llvm::dyn_cast_or_null<clang::CXXRecordDecl>(D);
+  if (!CXXRD || CXXRD->getNumBases() <= ibase)
+    return makeCXScope(getMeta(S), nullptr, CXScope_Invalid);
+
+  auto type = (CXXRD->bases_begin() + ibase)->getType();
+  if (auto RT = type->getAs<clang::RecordType>())
+    return makeCXScope(getMeta(S), RT->getDecl());
+
+  return makeCXScope(getMeta(S), nullptr, CXScope_Invalid);
+}
+
+bool clang_scope_isSubclass(CXScope derived, CXScope base) {
+  if (isNull(derived) || isNull(base))
+    return false;
+
+  auto* D = getDecl(derived);
+  auto* B = getDecl(base);
+
+  if (D == B)
+    return true;
+
+  if (!llvm::isa<clang::CXXRecordDecl>(D) ||
+      !llvm::isa<clang::CXXRecordDecl>(B))
+    return false;
+
+  return clang_qualtype_isTypeDerivedFrom(clang_scope_getTypeFromScope(derived),
+                                          clang_scope_getTypeFromScope(base));
+}
+
+namespace Cpp {
+unsigned ComputeBaseOffset(const clang::ASTContext& Context,
+                           const clang::CXXRecordDecl* DerivedRD,
+                           const clang::CXXBasePath& Path);
+} // namespace Cpp
+
+int64_t clang_scope_getBaseClassOffset(CXScope derived, CXScope base) {
+  auto* D = getDecl(derived);
+  auto* B = getDecl(base);
+
+  if (D == B)
+    return 0;
+
+  assert(D || B);
+
+  if (!llvm::isa<clang::CXXRecordDecl>(D) ||
+      !llvm::isa<clang::CXXRecordDecl>(B))
+    return -1;
+
+  auto* DCXXRD = llvm::cast<clang::CXXRecordDecl>(D);
+  auto* BCXXRD = llvm::cast<clang::CXXRecordDecl>(B);
+  clang::CXXBasePaths Paths(/*FindAmbiguities=*/false, /*RecordPaths=*/true,
+                            /*DetectVirtual=*/false);
+  DCXXRD->isDerivedFrom(BCXXRD, Paths);
+
+  auto* I = getInterpreter(derived);
+  return Cpp::ComputeBaseOffset(I->getSema().getASTContext(), DCXXRD,
+                                Paths.front());
+}
+
+CXScopeSet* clang_scope_getClassMethods(CXScope S) {
+  if (kind(S) == CXScope_Invalid)
+    return nullptr;
+
+  auto US = clang_scope_getUnderlyingScope(S);
+  if (kind(US) == CXScope_Invalid || !clang_scope_isClass(US))
+    return nullptr;
+
+  auto* CXXRD = llvm::dyn_cast<clang::CXXRecordDecl>(getDecl(US));
+
+  auto* I = getInterpreter(S);
+#ifdef USE_CLING
+  cling::Interpreter::PushTransactionRAII RAII(I);
+#endif // USE_CLING
+  I->getSema().ForceDeclarationOfImplicitMembers(CXXRD);
+  llvm::SmallVector<clang::CXXMethodDecl*> Methods;
+  for (clang::Decl* DI : CXXRD->decls()) {
+    if (auto* MD = llvm::dyn_cast<clang::CXXMethodDecl>(DI)) {
+      Methods.push_back(MD);
+    } else if (auto* USD = llvm::dyn_cast<clang::UsingShadowDecl>(DI)) {
+      auto* MD = llvm::dyn_cast<clang::CXXMethodDecl>(USD->getTargetDecl());
+      if (MD)
+        Methods.push_back(MD);
+    }
+  }
+
+  CXScopeSet* Set = new CXScopeSet;
+  Set->Count = Methods.size();
+  Set->Scopes = new CXScope[Set->Count];
+  for (auto [Idx, Val] : llvm::enumerate(Methods)) {
+    Set->Scopes[Idx] = makeCXScope(getMeta(S), Val, CXScope_Function);
+  }
+
+  return Set;
+}
+
+CXScopeSet* clang_scope_getFunctionTemplatedDecls(CXScope S) {
+  if (kind(S) == CXScope_Invalid)
+    return nullptr;
+
+  auto US = clang_scope_getUnderlyingScope(S);
+  if (kind(US) == CXScope_Invalid || !clang_scope_isClass(US))
+    return nullptr;
+
+  auto* CXXRD = llvm::dyn_cast<clang::CXXRecordDecl>(getDecl(US));
+
+  auto* I = getInterpreter(S);
+#ifdef USE_CLING
+  cling::Interpreter::PushTransactionRAII RAII(I);
+#endif // USE_CLING
+  I->getSema().ForceDeclarationOfImplicitMembers(CXXRD);
+  llvm::SmallVector<clang::FunctionTemplateDecl*> Methods;
+  for (clang::Decl* DI : CXXRD->decls()) {
+    if (auto* MD = llvm::dyn_cast<clang::FunctionTemplateDecl>(DI)) {
+      Methods.push_back(MD);
+    } else if (auto* USD = llvm::dyn_cast<clang::UsingShadowDecl>(DI)) {
+      auto* MD =
+          llvm::dyn_cast<clang::FunctionTemplateDecl>(USD->getTargetDecl());
+      if (MD)
+        Methods.push_back(MD);
+    }
+  }
+
+  CXScopeSet* Set = new CXScopeSet;
+  Set->Count = Methods.size();
+  Set->Scopes = new CXScope[Set->Count];
+  for (auto [Idx, Val] : llvm::enumerate(Methods)) {
+    Set->Scopes[Idx] = makeCXScope(getMeta(S), Val, CXScope_Function);
+  }
+
+  return Set;
+}
+
+bool clang_scope_hasDefaultConstructor(CXScope S) {
+  auto* D = getDecl(S);
+
+  if (auto* CXXRD = llvm::dyn_cast_or_null<clang::CXXRecordDecl>(D))
+    return CXXRD->hasDefaultConstructor();
+
+  return false;
+}
+
+CXScope clang_scope_getDefaultConstructor(CXScope S) {
+  if (!clang_scope_hasDefaultConstructor(S))
+    return makeCXScope(getMeta(S), nullptr, CXScope_Invalid);
+
+  auto* CXXRD = llvm::dyn_cast_or_null<clang::CXXRecordDecl>(getDecl(S));
+  if (!CXXRD)
+    return makeCXScope(getMeta(S), nullptr, CXScope_Invalid);
+
+  auto* Res = getInterpreter(S)->getSema().LookupDefaultConstructor(CXXRD);
+  return makeCXScope(getMeta(S), Res, CXScope_Function);
+}
+
+CXScope clang_scope_getDestructor(CXScope S) {
+  auto* D = getDecl(S);
+
+  if (auto* CXXRD = llvm::dyn_cast_or_null<clang::CXXRecordDecl>(D)) {
+    getInterpreter(S)->getSema().ForceDeclarationOfImplicitMembers(CXXRD);
+    return makeCXScope(getMeta(S), CXXRD->getDestructor(), CXScope_Function);
+  }
+
+  return makeCXScope(getMeta(S), nullptr, CXScope_Invalid);
+}
+
+CXScopeSet* clang_scope_getFunctionsUsingName(CXScope S, const char* name) {
+  auto* D = getDecl(clang_scope_getUnderlyingScope(S));
+
+  if (!D || !name)
+    return nullptr;
+
+  llvm::StringRef Name(name);
+  auto* I = getInterpreter(S);
+  auto& SM = I->getSema();
+  clang::DeclarationName DName = &SM.getASTContext().Idents.get(name);
+  clang::LookupResult R(SM, DName, clang::SourceLocation(),
+                        clang::Sema::LookupOrdinaryName,
+                        clang::Sema::ForVisibleRedeclaration);
+
+  Cpp::Cpp_utils::Lookup::Named(&SM, R, clang::Decl::castToDeclContext(D));
+
+  if (R.empty())
+    return nullptr;
+
+  R.resolveKind();
+
+  llvm::SmallVector<clang::Decl*> Funcs;
+  for (auto* Found : R)
+    if (llvm::isa<clang::FunctionDecl>(Found))
+      Funcs.push_back(Found);
+
+  CXScopeSet* Set = new CXScopeSet;
+  Set->Count = Funcs.size();
+  Set->Scopes = new CXScope[Set->Count];
+  for (auto [Idx, Val] : llvm::enumerate(Funcs)) {
+    Set->Scopes[Idx] = makeCXScope(getMeta(S), Val, CXScope_Function);
+  }
+
+  return Set;
+}
+
+CXQualType clang_scope_getFunctionReturnType(CXScope func) {
+  auto* D = getDecl(func);
+  if (auto* FD = llvm::dyn_cast_or_null<clang::FunctionDecl>(D))
+    return makeCXQualType(getMeta(func), FD->getReturnType());
+
+  if (auto* FD = llvm::dyn_cast_or_null<clang::FunctionTemplateDecl>(D)) {
+    auto* FTD = FD->getTemplatedDecl();
+    return makeCXQualType(getMeta(func), FTD->getReturnType());
+  }
+
+  return makeCXQualType(getMeta(func), clang::QualType(), CXQualType_Invalid);
+}
+
+size_t clang_scope_getFunctionNumArgs(CXScope func) {
+  auto* D = getDecl(func);
+  if (auto* FD = llvm::dyn_cast_or_null<clang::FunctionDecl>(D))
+    return FD->getNumParams();
+
+  if (auto* FD = llvm::dyn_cast_or_null<clang::FunctionTemplateDecl>(D))
+    return FD->getTemplatedDecl()->getNumParams();
+
+  return 0;
+}
+
+size_t clang_scope_getFunctionRequiredArgs(CXScope func) {
+  auto* D = getDecl(func);
+  if (auto* FD = llvm::dyn_cast_or_null<clang::FunctionDecl>(D))
+    return FD->getMinRequiredArguments();
+
+  if (auto* FD = llvm::dyn_cast_or_null<clang::FunctionTemplateDecl>(D))
+    return FD->getTemplatedDecl()->getMinRequiredArguments();
+
+  return 0;
+}
+
+CXQualType clang_scope_getFunctionArgType(CXScope func, size_t iarg) {
+  auto* D = getDecl(func);
+
+  if (auto* FD = llvm::dyn_cast_or_null<clang::FunctionDecl>(D)) {
+    if (iarg < FD->getNumParams()) {
+      auto* PVD = FD->getParamDecl(iarg);
+      return makeCXQualType(getMeta(func), PVD->getOriginalType());
+    }
+  }
+
+  return makeCXQualType(getMeta(func), clang::QualType(), CXQualType_Invalid);
+}
+
+CXString clang_scope_getFunctionSignature(CXScope func) {
+  if (isNull(func))
+    return makeCXString("");
+
+  auto* D = getDecl(func);
+  if (auto* FD = llvm::dyn_cast<clang::FunctionDecl>(D)) {
+    std::string Signature;
+    llvm::raw_string_ostream SS(Signature);
+    auto& C = getInterpreter(func)->getSema().getASTContext();
+    clang::PrintingPolicy Policy = C.getPrintingPolicy();
+    // Skip printing the body
+    Policy.TerseOutput = true;
+    Policy.FullyQualifiedName = true;
+    Policy.SuppressDefaultTemplateArgs = false;
+    FD->print(SS, Policy);
+    SS.flush();
+    return makeCXString(Signature);
+  }
+
+  return makeCXString("");
+}
+
+bool clang_scope_isFunctionDeleted(CXScope func) {
+  auto* FD = llvm::cast<clang::FunctionDecl>(getDecl(func));
+  return FD->isDeleted();
+}
+
+bool clang_scope_isTemplatedFunction(CXScope func) {
+  auto* D = getDecl(func);
+  if (llvm::isa_and_nonnull<clang::FunctionTemplateDecl>(D))
+    return true;
+
+  if (auto* FD = llvm::dyn_cast_or_null<clang::FunctionDecl>(D)) {
+    auto TK = FD->getTemplatedKind();
+    return TK == clang::FunctionDecl::TemplatedKind::
+                     TK_FunctionTemplateSpecialization ||
+           TK == clang::FunctionDecl::TemplatedKind::
+                     TK_DependentFunctionTemplateSpecialization ||
+           TK == clang::FunctionDecl::TemplatedKind::TK_FunctionTemplate;
+  }
+
+  return false;
+}
+
+bool clang_scope_existsFunctionTemplate(const char* name, CXScope parent) {
+  if (kind(parent) == CXScope_Invalid || !name)
+    return false;
+
+  auto* Within = llvm::dyn_cast<clang::DeclContext>(getDecl(parent));
+
+  auto& S = getInterpreter(parent)->getSema();
+  auto* ND = Cpp::Cpp_utils::Lookup::Named(&S, name, Within);
+
+  if ((intptr_t)ND == (intptr_t)0)
+    return false;
+
+  if ((intptr_t)ND != (intptr_t)-1)
+    return clang_scope_isTemplatedFunction(makeCXScope(getMeta(parent), ND));
+
+  // FIXME: Cycle through the Decls and check if there is a templated function
+  return true;
+}
+
+CXScopeSet* clang_scope_getClassTemplatedMethods(const char* name,
+                                                 CXScope parent) {
+  auto* D = getDecl(clang_scope_getUnderlyingScope(parent));
+
+  if (!D || !name)
+    return nullptr;
+
+  llvm::StringRef Name(name);
+  auto* I = getInterpreter(parent);
+  auto& SM = I->getSema();
+  clang::DeclarationName DName = &SM.getASTContext().Idents.get(name);
+  clang::LookupResult R(SM, DName, clang::SourceLocation(),
+                        clang::Sema::LookupOrdinaryName,
+                        clang::Sema::ForVisibleRedeclaration);
+
+  Cpp::Cpp_utils::Lookup::Named(&SM, R, clang::Decl::castToDeclContext(D));
+
+  if (R.empty())
+    return nullptr;
+
+  R.resolveKind();
+
+  llvm::SmallVector<clang::Decl*> Funcs;
+  for (auto* Found : R)
+    if (llvm::isa<clang::FunctionTemplateDecl>(Found))
+      Funcs.push_back(Found);
+
+  CXScopeSet* Set = new CXScopeSet;
+  Set->Count = Funcs.size();
+  Set->Scopes = new CXScope[Set->Count];
+  for (auto [Idx, Val] : llvm::enumerate(Funcs)) {
+    Set->Scopes[Idx] = makeCXScope(getMeta(parent), Val, CXScope_Function);
+  }
+
+  return Set;
+}
+
+bool clang_scope_isMethod(CXScope method) {
+  auto* D = getDecl(method);
+  return llvm::dyn_cast_or_null<clang::CXXMethodDecl>(D);
+}
+
+bool clang_scope_isPublicMethod(CXScope method) {
+  auto* D = getDecl(method);
+  if (auto* CXXMD = llvm::dyn_cast_or_null<clang::CXXMethodDecl>(D))
+    return CXXMD->getAccess() == clang::AccessSpecifier::AS_public;
+
+  return false;
+}
+
+bool clang_scope_isProtectedMethod(CXScope method) {
+  auto* D = getDecl(method);
+  if (auto* CXXMD = llvm::dyn_cast_or_null<clang::CXXMethodDecl>(D))
+    return CXXMD->getAccess() == clang::AccessSpecifier::AS_protected;
+
+  return false;
+}
+
+bool clang_scope_isPrivateMethod(CXScope method) {
+  auto* D = getDecl(method);
+  if (auto* CXXMD = llvm::dyn_cast_or_null<clang::CXXMethodDecl>(D))
+    return CXXMD->getAccess() == clang::AccessSpecifier::AS_private;
+
+  return false;
+}
+
+bool clang_scope_isConstructor(CXScope method) {
+  auto* D = getDecl(method);
+  return llvm::isa_and_nonnull<clang::CXXConstructorDecl>(D);
+}
+
+bool clang_scope_isDestructor(CXScope method) {
+  auto* D = getDecl(method);
+  return llvm::isa_and_nonnull<clang::CXXDestructorDecl>(D);
+}
+
+bool clang_scope_isStaticMethod(CXScope method) {
+  auto* D = getDecl(method);
+  if (auto* CXXMD = llvm::dyn_cast_or_null<clang::CXXMethodDecl>(D))
+    return CXXMD->isStatic();
+
+  return false;
+}
+
+CXFuncAddr clang_scope_getFunctionAddress(CXScope method) {
+  auto* D = getDecl(method);
+  auto* I = getInterpreter(method);
+
+  const auto get_mangled_name = [I](clang::FunctionDecl* FD) {
+    auto MangleCtx = I->getSema().getASTContext().createMangleContext();
+
+    if (!MangleCtx->shouldMangleDeclName(FD)) {
+      return FD->getNameInfo().getName().getAsString();
+    }
+
+    std::string mangled_name;
+    llvm::raw_string_ostream ostream(mangled_name);
+
+    MangleCtx->mangleName(FD, ostream);
+
+    ostream.flush();
+    delete MangleCtx;
+
+    return mangled_name;
+  };
+
+  if (auto* FD = llvm::dyn_cast_or_null<clang::FunctionDecl>(D)) {
+    auto FDAorErr = compat::getSymbolAddress(*I, get_mangled_name(FD).c_str());
+    if (llvm::Error Err = FDAorErr.takeError())
+      llvm::consumeError(std::move(Err)); // nullptr if missing
+    else
+      return llvm::jitTargetAddressToPointer<void*>(*FDAorErr);
+  }
+
+  return nullptr;
+}
+
+bool clang_scope_isVirtualMethod(CXScope method) {
+  auto* D = getDecl(method);
+  if (auto* CXXMD = llvm::dyn_cast_or_null<clang::CXXMethodDecl>(D))
+    return CXXMD->isVirtual();
+
+  return false;
+}
+
+bool clang_scope_isConstMethod(CXScope method) {
+  auto* D = getDecl(method);
+  if (auto* CXXMD = llvm::dyn_cast_or_null<clang::CXXMethodDecl>(D))
+    return CXXMD->getMethodQualifiers().hasConst();
+
+  return false;
+}
+
+CXString clang_scope_getFunctionArgDefault(CXScope func, size_t param_index) {
+  return makeCXString(Cpp::GetFunctionArgDefault(func.data, param_index));
+}
+
+CXString clang_scope_getFunctionArgName(CXScope func, size_t param_index) {
+  return makeCXString(Cpp::GetFunctionArgName(func.data, param_index));
+}
+
+CXScopeSet* clang_scope_getDatamembers(CXScope S) {
+  auto* CXXRD = llvm::dyn_cast_or_null<clang::CXXRecordDecl>(getDecl(S));
+  if (!CXXRD)
+    return nullptr;
+
+  CXScopeSet* Set = new CXScopeSet;
+  Set->Count = std::distance(CXXRD->field_begin(), CXXRD->field_end());
+  Set->Scopes = new CXScope[Set->Count];
+  for (auto [Idx, Val] : llvm::enumerate(CXXRD->fields())) {
+    Set->Scopes[Idx] = makeCXScope(getMeta(S), Val, CXScope_Function);
+  }
+
+  return Set;
+}
+
+CXScope clang_scope_lookupDatamember(const char* name, CXScope parent) {
+  if (kind(parent) == CXScope_Invalid || !name)
+    return makeCXScope(getMeta(parent), nullptr, CXScope_Invalid);
+
+  clang::DeclContext* Within =
+      llvm::dyn_cast<clang::DeclContext>(getDecl(parent));
+
+  auto& S = getInterpreter(parent)->getSema();
+  auto* ND = Cpp::Cpp_utils::Lookup::Named(&S, name, Within);
+  if (ND && ND != (clang::NamedDecl*)-1) {
+    if (llvm::isa_and_nonnull<clang::FieldDecl>(ND)) {
+      return makeCXScope(getMeta(parent), ND, CXScope_Field);
+    }
+  }
+
+  return makeCXScope(getMeta(parent), nullptr, CXScope_Invalid);
+}
+
+namespace Cpp {
+clang::Decl*
+InstantiateTemplate(clang::TemplateDecl* TemplateD,
+                    llvm::ArrayRef<clang::TemplateArgument> TemplateArgs,
+                    clang::Sema& S);
+} // namespace Cpp
+
+CXScope clang_scope_instantiateTemplate(CXScope tmpl,
+                                        CXTemplateArgInfo* template_args,
+                                        size_t template_args_size) {
+  auto* I = getInterpreter(tmpl);
+  auto& S = I->getSema();
+  auto& C = S.getASTContext();
+
+  llvm::SmallVector<clang::TemplateArgument> TemplateArgs;
+  TemplateArgs.reserve(template_args_size);
+  for (size_t i = 0; i < template_args_size; ++i) {
+    clang::QualType ArgTy =
+        clang::QualType::getFromOpaquePtr(template_args[i].Type);
+    if (template_args[i].IntegralValue) {
+      // We have a non-type template parameter. Create an integral value from
+      // the string representation.
+      auto Res = llvm::APSInt(template_args[i].IntegralValue);
+      Res = Res.extOrTrunc(C.getIntWidth(ArgTy));
+      TemplateArgs.push_back(clang::TemplateArgument(C, Res, ArgTy));
+    } else {
+      TemplateArgs.push_back(ArgTy);
+    }
+  }
+
+  clang::TemplateDecl* TmplD = static_cast<clang::TemplateDecl*>(getDecl(tmpl));
+
+  // We will create a new decl, push a transaction.
+#ifdef USE_CLING
+  cling::Interpreter::PushTransactionRAII RAII(I);
+#endif
+  return makeCXScope(getMeta(tmpl),
+                     Cpp::InstantiateTemplate(TmplD, TemplateArgs, S));
+}
+
+CXQualType clang_scope_getVariableType(CXScope var) {
+  auto D = getDecl(var);
+
+  if (auto DD = llvm::dyn_cast_or_null<clang::DeclaratorDecl>(D))
+    return makeCXQualType(getMeta(var), DD->getType());
+
+  return makeCXQualType(getMeta(var), clang::QualType(), CXQualType_Invalid);
+}
+
+namespace Cpp {
+intptr_t GetVariableOffsetImpl(compat::Interpreter& I, clang::Decl* D);
+} // namespace Cpp
+
+intptr_t clang_scope_getVariableOffset(CXScope var) {
+  return Cpp::GetVariableOffsetImpl(*getInterpreter(var), getDecl(var));
+}
+
+bool clang_scope_isPublicVariable(CXScope var) {
+  auto* D = getDecl(var);
+  if (auto* CXXMD = llvm::dyn_cast_or_null<clang::DeclaratorDecl>(D))
+    return CXXMD->getAccess() == clang::AccessSpecifier::AS_public;
+
+  return false;
+}
+
+bool clang_scope_isProtectedVariable(CXScope var) {
+  auto* D = getDecl(var);
+  if (auto* CXXMD = llvm::dyn_cast_or_null<clang::DeclaratorDecl>(D))
+    return CXXMD->getAccess() == clang::AccessSpecifier::AS_protected;
+
+  return false;
+}
+
+bool clang_scope_isPrivateVariable(CXScope var) {
+  auto* D = getDecl(var);
+  if (auto* CXXMD = llvm::dyn_cast_or_null<clang::DeclaratorDecl>(D))
+    return CXXMD->getAccess() == clang::AccessSpecifier::AS_private;
+
+  return false;
+}
+
+bool clang_scope_isStaticVariable(CXScope var) {
+  auto* D = getDecl(var);
+  if (llvm::isa_and_nonnull<clang::VarDecl>(D))
+    return true;
+
+  return false;
+}
+
+bool clang_scope_isConstVariable(CXScope var) {
+  auto* D = getDecl(var);
+  if (auto* VD = llvm::dyn_cast_or_null<clang::ValueDecl>(D)) {
+    return VD->getType().isConstQualified();
+  }
+
+  return false;
+}
+
+CXObject clang_allocate(CXScope S) {
+  return ::operator new(clang_scope_sizeOf(S));
+}
+
+void clang_deallocate(CXObject address) { ::operator delete(address); }
+
+namespace Cpp {
+JitCall MakeFunctionCallableImpl(TInterp_t I, TCppConstFunction_t func);
+} // namespace Cpp
+
+CXObject clang_construct(CXScope scope, void* arena) {
+  if (!clang_scope_hasDefaultConstructor(scope))
+    return nullptr;
+
+  auto Ctor = clang_scope_getDefaultConstructor(scope);
+  if (kind(Ctor) == CXScope_Invalid)
+    return nullptr;
+
+  auto* I = getInterpreter(scope);
+  if (Cpp::JitCall JC = Cpp::MakeFunctionCallableImpl(I, getDecl(Ctor))) {
+    if (arena) {
+      JC.Invoke(&arena, {}, (void*)~0); // Tell Invoke to use placement new.
+      return arena;
+    }
+
+    void* obj = nullptr;
+    JC.Invoke(&obj);
+    return obj;
+  }
+
+  return nullptr;
+}
+
+namespace Cpp {
+void DestructImpl(compat::Interpreter& interp, TCppObject_t This,
+                  clang::Decl* Class, bool withFree);
+} // namespace Cpp
+
+void clang_destruct(CXObject This, CXScope S, bool withFree) {
+  Cpp::DestructImpl(*getInterpreter(S), This, getDecl(S), withFree);
+}
+
+CXJitCallKind clang_jitcall_getKind(CXJitCall J) {
+  auto* call = reinterpret_cast<Cpp::JitCall*>(J); // NOLINT(*-cast)
+  return static_cast<CXJitCallKind>(call->getKind());
+}
+
+bool clang_jitcall_isValid(CXJitCall J) {
+  return reinterpret_cast<Cpp::JitCall*>(J)->isValid(); // NOLINT(*-cast)
+}
+
+void clang_jitcall_invoke(CXJitCall J, void* result, CXJitCallArgList args,
+                          void* self) {
+  auto* call = reinterpret_cast<Cpp::JitCall*>(J); // NOLINT(*-cast)
+  return call->Invoke(result, {args.data, args.numArgs}, self);
+}
+
+CXJitCall clang_jitcall_makeFunctionCallable(CXScope func) {
+  auto J = Cpp::MakeFunctionCallableImpl(getInterpreter(func), getDecl(func));
+  return reinterpret_cast<CXJitCall>(
+      std::make_unique<Cpp::JitCall>(J).release()); // NOLINT(*-cast)
+}
+
+void clang_jitcall_dispose(CXJitCall J) {
+  delete reinterpret_cast<Cpp::JitCall*>(J); // NOLINT(*-owning-memory, *-cast)
+}

--- a/lib/Interpreter/CXCppInterOp.cpp
+++ b/lib/Interpreter/CXCppInterOp.cpp
@@ -196,9 +196,9 @@ clang_interpreter_getFunctionAddressFromMangledName(CXInterpreter I,
   return nullptr;
 }
 
-static inline CXQualType
-makeCXQualType(const CXInterpreterImpl* I, const clang::QualType Ty,
-               const CXTypeKind K = CXType_Unexposed) {
+static inline CXQualType makeCXQualType(const CXInterpreterImpl* I,
+                                        const clang::QualType Ty,
+                                        const CXTypeKind K = CXType_Unexposed) {
   assert(I && "Invalid interpreter");
   return CXQualType{K, Ty.getAsOpaquePtr(), static_cast<const void*>(I)};
 }

--- a/lib/Interpreter/CXCppInterOp.cpp
+++ b/lib/Interpreter/CXCppInterOp.cpp
@@ -33,8 +33,8 @@ CXStringSet* makeCXStringSet(const std::vector<std::string>& Strs) {
   auto* Set = new CXStringSet; // NOLINT(*-owning-memory)
   Set->Count = Strs.size();
   Set->Strings = new CXString[Set->Count]; // NOLINT(*-owning-memory)
-  for (auto [Idx, Val] : llvm::enumerate(Strs)) {
-    Set->Strings[Idx] = makeCXString(Val);
+  for (auto En : llvm::enumerate(Strs)) {
+    Set->Strings[En.index()] = makeCXString(En.value());
   }
   return Set;
 }
@@ -458,8 +458,9 @@ CXScopeSet* clang_scope_getEnumConstants(CXScope S) {
   auto* Set = new CXScopeSet; // NOLINT(*-owning-memory)
   Set->Count = std::distance(ED->enumerator_begin(), ED->enumerator_end());
   Set->Scopes = new CXScope[Set->Count]; // NOLINT(*-owning-memory)
-  for (auto [Idx, Val] : llvm::enumerate(ED->enumerators())) {
-    Set->Scopes[Idx] = makeCXScope(getMeta(S), Val, CXScope_EnumConstant);
+  for (auto En : llvm::enumerate(ED->enumerators())) {
+    Set->Scopes[En.index()] =
+        makeCXScope(getMeta(S), En.value(), CXScope_EnumConstant);
   }
 
   return Set;
@@ -477,7 +478,8 @@ CXQualType clang_scope_getEnumConstantType(CXScope S) {
 }
 
 size_t clang_scope_getEnumConstantValue(CXScope S) {
-  if (const auto* ECD = llvm::dyn_cast_or_null<clang::EnumConstantDecl>(getDecl(S))) {
+  if (const auto* ECD =
+          llvm::dyn_cast_or_null<clang::EnumConstantDecl>(getDecl(S))) {
     const llvm::APSInt& Val = ECD->getInitVal();
     return Val.getExtValue();
   }
@@ -569,9 +571,9 @@ CXScopeSet* clang_scope_getUsingNamespaces(CXScope S) {
   Set->Count = std::distance(DC->using_directives().begin(),
                              DC->using_directives().end());
   Set->Scopes = new CXScope[Set->Count]; // NOLINT(*-owning-memory)
-  for (auto [Idx, Val] : llvm::enumerate(DC->using_directives())) {
-    Set->Scopes[Idx] = makeCXScope(getMeta(S), Val->getNominatedNamespace(),
-                                   CXScope_Namespace);
+  for (auto En : llvm::enumerate(DC->using_directives())) {
+    Set->Scopes[En.index()] = makeCXScope(
+        getMeta(S), En.value()->getNominatedNamespace(), CXScope_Namespace);
   }
 
   return Set;
@@ -750,8 +752,9 @@ CXScopeSet* clang_scope_getClassMethods(CXScope S) {
   auto* Set = new CXScopeSet; // NOLINT(*-owning-memory)
   Set->Count = Methods.size();
   Set->Scopes = new CXScope[Set->Count]; // NOLINT(*-owning-memory)
-  for (auto [Idx, Val] : llvm::enumerate(Methods)) {
-    Set->Scopes[Idx] = makeCXScope(getMeta(S), Val, CXScope_Function);
+  for (auto En : llvm::enumerate(Methods)) {
+    Set->Scopes[En.index()] =
+        makeCXScope(getMeta(S), En.value(), CXScope_Function);
   }
 
   return Set;
@@ -786,8 +789,9 @@ CXScopeSet* clang_scope_getFunctionTemplatedDecls(CXScope S) {
   auto* Set = new CXScopeSet; // NOLINT(*-owning-memory)
   Set->Count = Methods.size();
   Set->Scopes = new CXScope[Set->Count]; // NOLINT(*-owning-memory)
-  for (auto [Idx, Val] : llvm::enumerate(Methods)) {
-    Set->Scopes[Idx] = makeCXScope(getMeta(S), Val, CXScope_Function);
+  for (auto En : llvm::enumerate(Methods)) {
+    Set->Scopes[En.index()] =
+        makeCXScope(getMeta(S), En.value(), CXScope_Function);
   }
 
   return Set;
@@ -854,8 +858,9 @@ CXScopeSet* clang_scope_getFunctionsUsingName(CXScope S, const char* name) {
   auto* Set = new CXScopeSet; // NOLINT(*-owning-memory)
   Set->Count = Funcs.size();
   Set->Scopes = new CXScope[Set->Count]; // NOLINT(*-owning-memory)
-  for (auto [Idx, Val] : llvm::enumerate(Funcs)) {
-    Set->Scopes[Idx] = makeCXScope(getMeta(S), Val, CXScope_Function);
+  for (auto En : llvm::enumerate(Funcs)) {
+    Set->Scopes[En.index()] =
+        makeCXScope(getMeta(S), En.value(), CXScope_Function);
   }
 
   return Set;
@@ -1002,8 +1007,9 @@ CXScopeSet* clang_scope_getClassTemplatedMethods(const char* name,
   auto* Set = new CXScopeSet; // NOLINT(*-owning-memory)
   Set->Count = Funcs.size();
   Set->Scopes = new CXScope[Set->Count]; // NOLINT(*-owning-memory)
-  for (auto [Idx, Val] : llvm::enumerate(Funcs)) {
-    Set->Scopes[Idx] = makeCXScope(getMeta(parent), Val, CXScope_Function);
+  for (auto En : llvm::enumerate(Funcs)) {
+    Set->Scopes[En.index()] =
+        makeCXScope(getMeta(parent), En.value(), CXScope_Function);
   }
 
   return Set;
@@ -1121,8 +1127,9 @@ CXScopeSet* clang_scope_getDatamembers(CXScope S) {
   auto* Set = new CXScopeSet; // NOLINT(*-owning-memory)
   Set->Count = std::distance(CXXRD->field_begin(), CXXRD->field_end());
   Set->Scopes = new CXScope[Set->Count]; // NOLINT(*-owning-memory)
-  for (auto [Idx, Val] : llvm::enumerate(CXXRD->fields())) {
-    Set->Scopes[Idx] = makeCXScope(getMeta(S), Val, CXScope_Function);
+  for (auto En : llvm::enumerate(CXXRD->fields())) {
+    Set->Scopes[En.index()] =
+        makeCXScope(getMeta(S), En.value(), CXScope_Function);
   }
 
   return Set;

--- a/lib/Interpreter/CXCppInterOp.cpp
+++ b/lib/Interpreter/CXCppInterOp.cpp
@@ -543,11 +543,12 @@ CXString clang_scope_getCompleteName(CXScope S) {
 
 CXString clang_scope_getQualifiedName(CXScope S) {
   auto* D = getDecl(S);
-  if (const auto* ND = llvm::dyn_cast_or_null<clang::NamedDecl>(D))
-    return makeCXString(ND->getQualifiedNameAsString());
 
   if (llvm::isa_and_nonnull<clang::TranslationUnitDecl>(D))
     return makeCXString("");
+
+  if (const auto* ND = llvm::dyn_cast_or_null<clang::NamedDecl>(D))
+    return makeCXString(ND->getQualifiedNameAsString());
 
   return makeCXString("<unnamed>");
 }
@@ -606,12 +607,12 @@ CXScope clang_scope_getGlobalScope(CXInterpreter I) {
 CXScope clang_scope_getUnderlyingScope(CXScope S) {
   const auto* TND = llvm::dyn_cast_or_null<clang::TypedefNameDecl>(getDecl(S));
   if (!TND)
-    return makeCXScope(getMeta(S), nullptr, CXScope_Invalid);
+    return S;
 
   const clang::QualType QT = TND->getUnderlyingType();
   auto* D = Cpp::GetScopeFromType(QT.getAsOpaquePtr());
   if (!D)
-    return makeCXScope(getMeta(S), nullptr, CXScope_Invalid);
+    return S;
 
   return makeCXScope(getMeta(S), static_cast<clang::Decl*>(D));
 }

--- a/lib/Interpreter/CXCppInterOp.cpp
+++ b/lib/Interpreter/CXCppInterOp.cpp
@@ -378,7 +378,8 @@ bool clang_scope_isComplete(CXScope S) {
     const auto* CI = getInterpreter(S)->getCI();
     auto& Sema = CI->getSema();
     const auto& SM = Sema.getSourceManager();
-    const clang::SourceLocation fakeLoc = SM.getLocForStartOfFile(SM.getMainFileID());
+    const clang::SourceLocation fakeLoc =
+        SM.getLocForStartOfFile(SM.getMainFileID());
     return Sema.isCompleteType(fakeLoc, QT);
   }
 
@@ -603,8 +604,8 @@ CXScope clang_scope_getScope(const char* name, CXScope parent) {
   if (kind(S) == CXScope_Invalid)
     return S;
 
-  if (auto* ND = llvm::dyn_cast<clang::NamedDecl>(getDecl(S));
-      llvm::isa<clang::NamespaceDecl>(ND) || llvm::isa<clang::RecordDecl>(ND) ||
+  auto* ND = llvm::dyn_cast<clang::NamedDecl>(getDecl(S));
+  if (llvm::isa<clang::NamespaceDecl>(ND) || llvm::isa<clang::RecordDecl>(ND) ||
       llvm::isa<clang::ClassTemplateDecl>(ND) ||
       llvm::isa<clang::TypedefNameDecl>(ND)) {
     return makeCXScope(getMeta(S), ND->getCanonicalDecl());
@@ -616,15 +617,14 @@ CXScope clang_scope_getScope(const char* name, CXScope parent) {
 CXScope clang_scope_getNamed(const char* name, CXScope parent) {
   const clang::DeclContext* Within = nullptr;
   if (kind(parent) != CXScope_Invalid) {
-    if (const auto US = clang_scope_getUnderlyingScope(parent);
-        kind(US) != CXScope_Invalid)
+    const auto US = clang_scope_getUnderlyingScope(parent);
+    if (kind(US) != CXScope_Invalid)
       Within = llvm::dyn_cast<clang::DeclContext>(getDecl(US));
   }
 
   auto& sema = getInterpreter(parent)->getSema();
-  if (auto* ND =
-          Cpp::Cpp_utils::Lookup::Named(&sema, std::string(name), Within);
-      ND && intptr_t(ND) != (intptr_t)-1) {
+  auto* ND = Cpp::Cpp_utils::Lookup::Named(&sema, std::string(name), Within);
+  if (ND && intptr_t(ND) != (intptr_t)-1) {
     return makeCXScope(getMeta(parent), ND->getCanonicalDecl());
   }
 

--- a/lib/Interpreter/CXCppInterOp.cpp
+++ b/lib/Interpreter/CXCppInterOp.cpp
@@ -1348,12 +1348,12 @@ CXObject clang_construct(CXScope scope, void* arena) {
   auto* I = getInterpreter(scope);
   if (const Cpp::JitCall JC = Cpp::MakeFunctionCallableImpl(I, getDecl(Ctor))) {
     if (arena) {
-      JC.Invoke(arena, {}, (void*)~0); // Tell Invoke to use placement new.
+      JC.Invoke(&arena, {}, (void*)~0); // Tell Invoke to use placement new.
       return arena;
     }
 
     void* obj = nullptr;
-    JC.Invoke(obj);
+    JC.Invoke(&obj);
     return obj;
   }
 

--- a/lib/Interpreter/CXCppInterOp.cpp
+++ b/lib/Interpreter/CXCppInterOp.cpp
@@ -1327,8 +1327,8 @@ bool clang_scope_isConstVariable(CXScope var) {
   return false;
 }
 
-CXObject clang_allocate(CXScope S) {
-  return ::operator new(clang_scope_sizeOf(S));
+CXObject clang_allocate(unsigned int n) {
+  return ::operator new(n);
 }
 
 void clang_deallocate(CXObject address) { ::operator delete(address); }

--- a/lib/Interpreter/CXCppInterOp.cpp
+++ b/lib/Interpreter/CXCppInterOp.cpp
@@ -70,6 +70,10 @@ TInterp_t clang_interpreter_takeInterpreterAsPtr(CXInterpreter I) {
   return static_cast<CXInterpreterImpl*>(I)->Interp.release();
 }
 
+CXErrorCode clang_interpreter_Undo(CXInterpreter I, unsigned int N) {
+  return getInterpreter(I)->Undo(N) ? CXError_Failure : CXError_Success;
+}
+
 void clang_interpreter_dispose(CXInterpreter I) {
   delete I; // NOLINT(*-owning-memory)
 }
@@ -113,7 +117,7 @@ enum CXErrorCode clang_interpreter_process(CXInterpreter I, const char* code) {
   return CXError_Success;
 }
 
-CXValue clang_createValue() {
+CXValue clang_createValue(void) {
 #ifdef USE_CLING
   auto val = std::make_unique<cling::Value>();
 #else

--- a/unittests/CppInterOp/CMakeLists.txt
+++ b/unittests/CppInterOp/CMakeLists.txt
@@ -16,7 +16,6 @@ add_cppinterop_unittest(CppInterOpTests
 target_link_libraries(CppInterOpTests
   PRIVATE
   clangCppInterOp
-  libclang
   )
 
 if(NOT WIN32)

--- a/unittests/CppInterOp/CMakeLists.txt
+++ b/unittests/CppInterOp/CMakeLists.txt
@@ -16,6 +16,7 @@ add_cppinterop_unittest(CppInterOpTests
 target_link_libraries(CppInterOpTests
   PRIVATE
   clangCppInterOp
+  libclang
   )
 
 if(NOT WIN32)

--- a/unittests/CppInterOp/EnumReflectionTest.cpp
+++ b/unittests/CppInterOp/EnumReflectionTest.cpp
@@ -5,7 +5,6 @@
 #include "clang/Interpreter/CppInterOp.h"
 #include "clang/Sema/Sema.h"
 #include "clang-c/CXCppInterOp.h"
-#include "clang-c/CXString.h"
 
 #include "gtest/gtest.h"
 

--- a/unittests/CppInterOp/InterpreterTest.cpp
+++ b/unittests/CppInterOp/InterpreterTest.cpp
@@ -3,6 +3,8 @@
 #include "clang/Interpreter/CppInterOp.h"
 #include "clang/Basic/Version.h"
 
+#include "clang-c/CXCppInterOp.h"
+
 #include "llvm/ADT/SmallString.h"
 #include "llvm/Support/Path.h"
 
@@ -92,6 +94,12 @@ TEST(InterpreterTest, CreateInterpreter) {
                    "#endif");
   EXPECT_TRUE(Cpp::GetNamed("cpp17"));
   EXPECT_FALSE(Cpp::GetNamed("cppUnknown"));
+
+  // C API
+  const char* args[] = {"-std=c++14"};
+  auto CXI = clang_createInterpreter(args, 1);
+  EXPECT_TRUE(CXI);
+  clang_interpreter_dispose(CXI);
 }
 
 #ifdef LLVM_BINARY_DIR

--- a/unittests/CppInterOp/ScopeReflectionTest.cpp
+++ b/unittests/CppInterOp/ScopeReflectionTest.cpp
@@ -783,7 +783,7 @@ TEST(ScopeReflectionTest, GetNamed) {
   auto NS_N1 = clang_scope_getNamed("N1", GS);
   auto NS_N2 = clang_scope_getNamed("N2", NS_N1);
   auto CL_C = clang_scope_getNamed("C", NS_N2);
-  auto EN_E = clang_scope_getScope("E", CL_C);
+  auto EN_E = clang_scope_getNamed("E", CL_C);
 
   EXPECT_EQ(C_API_SHIM(NS_N1), "N1");
   EXPECT_EQ(C_API_SHIM(NS_N2), "N1::N2");

--- a/unittests/CppInterOp/ScopeReflectionTest.cpp
+++ b/unittests/CppInterOp/ScopeReflectionTest.cpp
@@ -1,14 +1,15 @@
 #include "Utils.h"
 
 #include "clang/Interpreter/CppInterOp.h"
+#include "clang-c/CXCppInterOp.h"
 
 #include "clang/AST/ASTContext.h"
-#include "clang/Interpreter/CppInterOp.h"
 #include "clang/Frontend/CompilerInstance.h"
+#include "clang/Interpreter/CppInterOp.h"
 #include "clang/Sema/Sema.h"
 
-#include "clang/AST/DeclBase.h"
 #include "clang/AST/ASTDumper.h"
+#include "clang/AST/DeclBase.h"
 
 #include "gtest/gtest.h"
 
@@ -17,7 +18,7 @@ using namespace llvm;
 using namespace clang;
 
 TEST(ScopeReflectionTest, IsAggregate) {
-  std::vector<Decl *> Decls;
+  std::vector<Decl*> Decls;
   std::string code = R"(
     char cv[4] = {};
     int x[] = {};
@@ -39,6 +40,20 @@ TEST(ScopeReflectionTest, IsAggregate) {
   EXPECT_TRUE(Cpp::IsAggregate(Decls[2]));
   EXPECT_TRUE(Cpp::IsAggregate(Decls[3]));
   EXPECT_FALSE(Cpp::IsAggregate(Decls[4]));
+
+  // C API
+  auto I = clang_createInterpreterFromPtr(Cpp::GetInterpreter());
+  auto C_API_SHIM = [&](auto Decl) {
+    return clang_scope_isAggregate(CXScope{CXScope_Unexposed, Decl, I});
+  };
+  EXPECT_TRUE(C_API_SHIM(Decls[0]));
+  EXPECT_TRUE(C_API_SHIM(Decls[1]));
+  EXPECT_TRUE(C_API_SHIM(Decls[2]));
+  EXPECT_TRUE(C_API_SHIM(Decls[3]));
+  EXPECT_FALSE(C_API_SHIM(Decls[4]));
+  // Clean up resources
+  clang_interpreter_takeInterpreterAsPtr(I);
+  clang_interpreter_dispose(I);
 }
 
 // Check that the CharInfo table has been constructed reasonably.
@@ -48,6 +63,18 @@ TEST(ScopeReflectionTest, IsNamespace) {
   EXPECT_TRUE(Cpp::IsNamespace(Decls[0]));
   EXPECT_FALSE(Cpp::IsNamespace(Decls[1]));
   EXPECT_FALSE(Cpp::IsNamespace(Decls[2]));
+
+  // C API
+  auto I = clang_createInterpreterFromPtr(Cpp::GetInterpreter());
+  auto C_API_SHIM = [&](auto Decl) {
+    return clang_scope_isNamespace(CXScope{CXScope_Unexposed, Decl, I});
+  };
+  EXPECT_TRUE(C_API_SHIM(Decls[0]));
+  EXPECT_FALSE(C_API_SHIM(Decls[1]));
+  EXPECT_FALSE(C_API_SHIM(Decls[2]));
+  // Clean up resources
+  clang_interpreter_takeInterpreterAsPtr(I);
+  clang_interpreter_dispose(I);
 }
 
 TEST(ScopeReflectionTest, IsClass) {
@@ -56,6 +83,18 @@ TEST(ScopeReflectionTest, IsClass) {
   EXPECT_FALSE(Cpp::IsClass(Decls[0]));
   EXPECT_TRUE(Cpp::IsClass(Decls[1]));
   EXPECT_FALSE(Cpp::IsClass(Decls[2]));
+
+  // C API
+  auto I = clang_createInterpreterFromPtr(Cpp::GetInterpreter());
+  auto C_API_SHIM = [&](auto Decl) {
+    return clang_scope_isClass(CXScope{CXScope_Unexposed, Decl, I});
+  };
+  EXPECT_FALSE(C_API_SHIM(Decls[0]));
+  EXPECT_TRUE(C_API_SHIM(Decls[1]));
+  EXPECT_FALSE(C_API_SHIM(Decls[2]));
+  // Clean up resources
+  clang_interpreter_takeInterpreterAsPtr(I);
+  clang_interpreter_dispose(I);
 }
 
 TEST(ScopeReflectionTest, IsComplete) {
@@ -70,8 +109,7 @@ TEST(ScopeReflectionTest, IsComplete) {
     template<typename T> struct TemplatedS{ T x; };
     TemplatedS<int> templateF() { return {}; };
   )";
-  GetAllTopLevelDecls(code,
-                      Decls);
+  GetAllTopLevelDecls(code, Decls);
   EXPECT_TRUE(Cpp::IsComplete(Decls[0]));
   EXPECT_TRUE(Cpp::IsComplete(Decls[1]));
   EXPECT_TRUE(Cpp::IsComplete(Decls[2]));
@@ -81,6 +119,26 @@ TEST(ScopeReflectionTest, IsComplete) {
   Cpp::TCppType_t retTy = Cpp::GetFunctionReturnType(Decls[7]);
   EXPECT_TRUE(Cpp::IsComplete(Cpp::GetScopeFromType(retTy)));
   EXPECT_FALSE(Cpp::IsComplete(nullptr));
+
+  // C API
+  auto I = clang_createInterpreterFromPtr(Cpp::GetInterpreter());
+  auto C_API_SHIM = [&](auto Decl) {
+    return clang_scope_isComplete(CXScope{CXScope_Unexposed, Decl, I});
+  };
+  EXPECT_TRUE(C_API_SHIM(Decls[0]));
+  EXPECT_TRUE(C_API_SHIM(Decls[1]));
+  EXPECT_TRUE(C_API_SHIM(Decls[2]));
+  EXPECT_FALSE(C_API_SHIM(Decls[3]));
+  EXPECT_FALSE(C_API_SHIM(Decls[4]));
+  EXPECT_TRUE(C_API_SHIM(Decls[5]));
+  auto Ty =
+      clang_scope_getFunctionReturnType(CXScope{CXScope_Function, Decls[7], I});
+  auto Scope = clang_scope_getScopeFromType(Ty);
+  EXPECT_TRUE(clang_scope_isComplete(Scope));
+  EXPECT_FALSE(C_API_SHIM(nullptr));
+  // Clean up resources
+  clang_interpreter_takeInterpreterAsPtr(I);
+  clang_interpreter_dispose(I);
 }
 
 TEST(ScopeReflectionTest, SizeOf) {
@@ -98,17 +156,34 @@ TEST(ScopeReflectionTest, SizeOf) {
   EXPECT_EQ(Cpp::SizeOf(Decls[5]), (size_t)1);
   EXPECT_EQ(Cpp::SizeOf(Decls[6]), (size_t)4);
   EXPECT_EQ(Cpp::SizeOf(Decls[7]), (size_t)16);
-}
 
+  // C API
+  auto I = clang_createInterpreterFromPtr(Cpp::GetInterpreter());
+  auto C_API_SHIM = [&](auto Decl) {
+    return clang_scope_sizeOf(CXScope{CXScope_Unexposed, Decl, I});
+  };
+  EXPECT_EQ(C_API_SHIM(Decls[0]), (size_t)0);
+  EXPECT_EQ(C_API_SHIM(Decls[1]), (size_t)1);
+  EXPECT_EQ(C_API_SHIM(Decls[2]), (size_t)0);
+  EXPECT_EQ(C_API_SHIM(Decls[3]), (size_t)0);
+  EXPECT_EQ(C_API_SHIM(Decls[4]), (size_t)0);
+  EXPECT_EQ(C_API_SHIM(Decls[5]), (size_t)1);
+  EXPECT_EQ(C_API_SHIM(Decls[6]), (size_t)4);
+  EXPECT_EQ(C_API_SHIM(Decls[7]), (size_t)16);
+  // Clean up resources
+  clang_interpreter_takeInterpreterAsPtr(I);
+  clang_interpreter_dispose(I);
+}
 
 TEST(ScopeReflectionTest, IsBuiltin) {
   // static std::set<std::string> g_builtins =
-  // {"bool", "char", "signed char", "unsigned char", "wchar_t", "short", "unsigned short",
-  //  "int", "unsigned int", "long", "unsigned long", "long long", "unsigned long long",
-  //  "float", "double", "long double", "void"}
+  // {"bool", "char", "signed char", "unsigned char", "wchar_t", "short",
+  // "unsigned short",
+  //  "int", "unsigned int", "long", "unsigned long", "long long", "unsigned
+  //  long long", "float", "double", "long double", "void"}
 
   Cpp::CreateInterpreter();
-  ASTContext &C = Interp->getCI()->getASTContext();
+  ASTContext& C = Interp->getCI()->getASTContext();
   EXPECT_TRUE(Cpp::IsBuiltin(C.BoolTy.getAsOpaquePtr()));
   EXPECT_TRUE(Cpp::IsBuiltin(C.CharTy.getAsOpaquePtr()));
   EXPECT_TRUE(Cpp::IsBuiltin(C.SignedCharTy.getAsOpaquePtr()));
@@ -118,21 +193,22 @@ TEST(ScopeReflectionTest, IsBuiltin) {
   // complex
   EXPECT_TRUE(Cpp::IsBuiltin(C.getComplexType(C.FloatTy).getAsOpaquePtr()));
   EXPECT_TRUE(Cpp::IsBuiltin(C.getComplexType(C.DoubleTy).getAsOpaquePtr()));
-  EXPECT_TRUE(Cpp::IsBuiltin(C.getComplexType(C.LongDoubleTy).getAsOpaquePtr()));
+  EXPECT_TRUE(
+      Cpp::IsBuiltin(C.getComplexType(C.LongDoubleTy).getAsOpaquePtr()));
   EXPECT_TRUE(Cpp::IsBuiltin(C.getComplexType(C.Float128Ty).getAsOpaquePtr()));
 
   // std::complex
   std::vector<Decl*> Decls;
   Interp->declare("#include <complex>");
-  Sema &S = Interp->getCI()->getSema();
+  Sema& S = Interp->getCI()->getSema();
   auto lookup = S.getStdNamespace()->lookup(&C.Idents.get("complex"));
-  auto *CTD = cast<ClassTemplateDecl>(lookup.front());
-  for (ClassTemplateSpecializationDecl *CTSD : CTD->specializations())
+  auto* CTD = cast<ClassTemplateDecl>(lookup.front());
+  for (ClassTemplateSpecializationDecl* CTSD : CTD->specializations())
     EXPECT_TRUE(Cpp::IsBuiltin(C.getTypeDeclType(CTSD).getAsOpaquePtr()));
 }
 
 TEST(ScopeReflectionTest, IsTemplate) {
-  std::vector<Decl *> Decls;
+  std::vector<Decl*> Decls;
   std::string code = R"(template<typename T>
                         class A{};
 
@@ -155,10 +231,23 @@ TEST(ScopeReflectionTest, IsTemplate) {
   EXPECT_FALSE(Cpp::IsTemplate(Decls[1]));
   EXPECT_TRUE(Cpp::IsTemplate(Decls[2]));
   EXPECT_FALSE(Cpp::IsTemplate(Decls[3]));
+
+  // C API
+  auto I = clang_createInterpreterFromPtr(Cpp::GetInterpreter());
+  auto C_API_SHIM = [&](auto Decl) {
+    return clang_scope_isTemplate(CXScope{CXScope_Unexposed, Decl, I});
+  };
+  EXPECT_TRUE(C_API_SHIM(Decls[0]));
+  EXPECT_FALSE(C_API_SHIM(Decls[1]));
+  EXPECT_TRUE(C_API_SHIM(Decls[2]));
+  EXPECT_FALSE(C_API_SHIM(Decls[3]));
+  // Clean up resources
+  clang_interpreter_takeInterpreterAsPtr(I);
+  clang_interpreter_dispose(I);
 }
 
 TEST(ScopeReflectionTest, IsTemplateSpecialization) {
-  std::vector<Decl *> Decls;
+  std::vector<Decl*> Decls;
   std::string code = R"(
     template<typename T>
     class A{};
@@ -170,11 +259,27 @@ TEST(ScopeReflectionTest, IsTemplateSpecialization) {
   EXPECT_FALSE(Cpp::IsTemplateSpecialization(Decls[0]));
   EXPECT_FALSE(Cpp::IsTemplateSpecialization(Decls[1]));
   EXPECT_TRUE(Cpp::IsTemplateSpecialization(
-          Cpp::GetScopeFromType(Cpp::GetVariableType(Decls[1]))));
+      Cpp::GetScopeFromType(Cpp::GetVariableType(Decls[1]))));
+
+  // C API
+  auto I = clang_createInterpreterFromPtr(Cpp::GetInterpreter());
+  auto C_API_SHIM = [&](auto Decl) {
+    return clang_scope_isTemplateSpecialization(
+        CXScope{CXScope_Unexposed, Decl, I});
+  };
+  EXPECT_FALSE(C_API_SHIM(Decls[0]));
+  EXPECT_FALSE(C_API_SHIM(Decls[1]));
+  auto VarType =
+      clang_scope_getVariableType(CXScope{CXScope_Unexposed, Decls[1], I});
+  auto Scope = clang_scope_getScopeFromType(VarType);
+  EXPECT_TRUE(clang_scope_isTemplateSpecialization(Scope));
+  // Clean up resources
+  clang_interpreter_takeInterpreterAsPtr(I);
+  clang_interpreter_dispose(I);
 }
 
 TEST(ScopeReflectionTest, IsTypedefed) {
-  std::vector<Decl *> Decls;
+  std::vector<Decl*> Decls;
   std::string code = R"(
     typedef int I;
     using D = double;
@@ -185,10 +290,22 @@ TEST(ScopeReflectionTest, IsTypedefed) {
   EXPECT_TRUE(Cpp::IsTypedefed(Decls[0]));
   EXPECT_TRUE(Cpp::IsTypedefed(Decls[1]));
   EXPECT_FALSE(Cpp::IsTypedefed(Decls[2]));
+
+  // C API
+  auto I = clang_createInterpreterFromPtr(Cpp::GetInterpreter());
+  auto C_API_SHIM = [&](auto Decl) {
+    return clang_scope_isTypedefed(CXScope{CXScope_Unexposed, Decl, I});
+  };
+  EXPECT_TRUE(C_API_SHIM(Decls[0]));
+  EXPECT_TRUE(C_API_SHIM(Decls[1]));
+  EXPECT_FALSE(C_API_SHIM(Decls[2]));
+  // Clean up resources
+  clang_interpreter_takeInterpreterAsPtr(I);
+  clang_interpreter_dispose(I);
 }
 
 TEST(ScopeReflectionTest, IsAbstract) {
-  std::vector<Decl *> Decls;
+  std::vector<Decl*> Decls;
   std::string code = R"(
     class A {};
 
@@ -205,10 +322,22 @@ TEST(ScopeReflectionTest, IsAbstract) {
   EXPECT_FALSE(Cpp::IsAbstract(Decls[0]));
   EXPECT_TRUE(Cpp::IsAbstract(Decls[1]));
   EXPECT_FALSE(Cpp::IsAbstract(Decls[2]));
+
+  // C API
+  auto I = clang_createInterpreterFromPtr(Cpp::GetInterpreter());
+  auto C_API_SHIM = [&](auto Decl) {
+    return clang_scope_isAbstract(CXScope{CXScope_Unexposed, Decl, I});
+  };
+  EXPECT_FALSE(C_API_SHIM(Decls[0]));
+  EXPECT_TRUE(C_API_SHIM(Decls[1]));
+  EXPECT_FALSE(C_API_SHIM(Decls[2]));
+  // Clean up resources
+  clang_interpreter_takeInterpreterAsPtr(I);
+  clang_interpreter_dispose(I);
 }
 
 TEST(ScopeReflectionTest, IsVariable) {
-  std::vector<Decl *> Decls;
+  std::vector<Decl*> Decls;
   std::string code = R"(
     int i;
 
@@ -223,12 +352,28 @@ TEST(ScopeReflectionTest, IsVariable) {
   EXPECT_TRUE(Cpp::IsVariable(Decls[0]));
   EXPECT_FALSE(Cpp::IsVariable(Decls[1]));
 
-  std::vector<Decl *> SubDecls;
+  std::vector<Decl*> SubDecls;
   GetAllSubDecls(Decls[1], SubDecls);
   EXPECT_FALSE(Cpp::IsVariable(SubDecls[0]));
   EXPECT_FALSE(Cpp::IsVariable(SubDecls[1]));
   EXPECT_FALSE(Cpp::IsVariable(SubDecls[2]));
   EXPECT_TRUE(Cpp::IsVariable(SubDecls[3]));
+
+  // C API
+  auto I = clang_createInterpreterFromPtr(Cpp::GetInterpreter());
+  auto C_API_SHIM = [&](auto Decl) {
+    return clang_scope_isVariable(CXScope{CXScope_Unexposed, Decl, I});
+  };
+  EXPECT_TRUE(C_API_SHIM(Decls[0]));
+  EXPECT_FALSE(C_API_SHIM(Decls[1]));
+
+  EXPECT_FALSE(C_API_SHIM(SubDecls[0]));
+  EXPECT_FALSE(C_API_SHIM(SubDecls[1]));
+  EXPECT_FALSE(C_API_SHIM(SubDecls[2]));
+  EXPECT_TRUE(C_API_SHIM(SubDecls[3]));
+  // Clean up resources
+  clang_interpreter_takeInterpreterAsPtr(I);
+  clang_interpreter_dispose(I);
 }
 
 TEST(ScopeReflectionTest, GetName) {
@@ -247,10 +392,31 @@ TEST(ScopeReflectionTest, GetName) {
   EXPECT_EQ(Cpp::GetName(Decls[6]), "Size4");
   EXPECT_EQ(Cpp::GetName(Decls[7]), "Size16");
   EXPECT_EQ(Cpp::GetName(nullptr), "<unnamed>");
+
+  // C API
+  auto I = clang_createInterpreterFromPtr(Cpp::GetInterpreter());
+  auto C_API_SHIM = [&](auto Decl) {
+    auto Str = clang_scope_getName(CXScope{CXScope_Unexposed, Decl, I});
+    auto Res = std::string(clang_getCString(Str));
+    clang_disposeString(Str);
+    return Res;
+  };
+  EXPECT_EQ(C_API_SHIM(Decls[0]), "N");
+  EXPECT_EQ(C_API_SHIM(Decls[1]), "C");
+  EXPECT_EQ(C_API_SHIM(Decls[2]), "I");
+  EXPECT_EQ(C_API_SHIM(Decls[3]), "S");
+  EXPECT_EQ(C_API_SHIM(Decls[4]), "E");
+  EXPECT_EQ(C_API_SHIM(Decls[5]), "U");
+  EXPECT_EQ(C_API_SHIM(Decls[6]), "Size4");
+  EXPECT_EQ(C_API_SHIM(Decls[7]), "Size16");
+  EXPECT_EQ(C_API_SHIM(nullptr), "<unnamed>");
+  // Clean up resources
+  clang_interpreter_takeInterpreterAsPtr(I);
+  clang_interpreter_dispose(I);
 }
 
 TEST(ScopeReflectionTest, GetCompleteName) {
-  std::vector<Decl *> Decls;
+  std::vector<Decl*> Decls;
   std::string code = R"(namespace N {}
                         class C{};
                         int I;
@@ -277,11 +443,40 @@ TEST(ScopeReflectionTest, GetCompleteName) {
   EXPECT_EQ(Cpp::GetCompleteName(Decls[6]), "Size4");
   EXPECT_EQ(Cpp::GetCompleteName(Decls[7]), "Size16");
   EXPECT_EQ(Cpp::GetCompleteName(Decls[8]), "A");
-  EXPECT_EQ(Cpp::GetCompleteName(Cpp::GetScopeFromType(
-                                             Cpp::GetVariableType(
-                                                     Decls[9]))), "A<int>");
+  EXPECT_EQ(Cpp::GetCompleteName(
+                Cpp::GetScopeFromType(Cpp::GetVariableType(Decls[9]))),
+            "A<int>");
   EXPECT_EQ(Cpp::GetCompleteName(Decls[10]), "(unnamed)");
   EXPECT_EQ(Cpp::GetCompleteName(nullptr), "<unnamed>");
+
+  // C API
+  auto I = clang_createInterpreterFromPtr(Cpp::GetInterpreter());
+  auto C_API_SHIM = [&](auto Decl) {
+    auto Str = clang_scope_getCompleteName(CXScope{CXScope_Unexposed, Decl, I});
+    auto Res = std::string(clang_getCString(Str));
+    clang_disposeString(Str);
+    return Res;
+  };
+  EXPECT_EQ(C_API_SHIM(Decls[0]), "N");
+  EXPECT_EQ(C_API_SHIM(Decls[1]), "C");
+  EXPECT_EQ(C_API_SHIM(Decls[2]), "I");
+  EXPECT_EQ(C_API_SHIM(Decls[3]), "S");
+  EXPECT_EQ(C_API_SHIM(Decls[4]), "E");
+  EXPECT_EQ(C_API_SHIM(Decls[5]), "U");
+  EXPECT_EQ(C_API_SHIM(Decls[6]), "Size4");
+  EXPECT_EQ(C_API_SHIM(Decls[7]), "Size16");
+  EXPECT_EQ(C_API_SHIM(Decls[8]), "A");
+  auto VarType =
+      clang_scope_getVariableType(CXScope{CXScope_Unexposed, Decls[9], I});
+  auto Scope = clang_scope_getScopeFromType(VarType);
+  auto Str = clang_scope_getCompleteName(Scope);
+  EXPECT_EQ(std::string(clang_getCString(Str)), "A<int>");
+  clang_disposeString(Str);
+  EXPECT_EQ(C_API_SHIM(Decls[10]), "(unnamed)");
+  EXPECT_EQ(C_API_SHIM(nullptr), "<unnamed>");
+  // Clean up resources
+  clang_interpreter_takeInterpreterAsPtr(I);
+  clang_interpreter_dispose(I);
 }
 
 TEST(ScopeReflectionTest, GetQualifiedName) {
@@ -302,6 +497,24 @@ TEST(ScopeReflectionTest, GetQualifiedName) {
   EXPECT_EQ(Cpp::GetQualifiedName(Decls[1]), "N::C");
   EXPECT_EQ(Cpp::GetQualifiedName(Decls[3]), "N::C::i");
   EXPECT_EQ(Cpp::GetQualifiedName(Decls[4]), "N::C::E");
+
+  // C API
+  auto I = clang_createInterpreterFromPtr(Cpp::GetInterpreter());
+  auto C_API_SHIM = [&](auto Decl) {
+    auto Str =
+        clang_scope_getQualifiedName(CXScope{CXScope_Unexposed, Decl, I});
+    auto Res = std::string(clang_getCString(Str));
+    clang_disposeString(Str);
+    return Res;
+  };
+  EXPECT_EQ(C_API_SHIM(nullptr), "<unnamed>");
+  EXPECT_EQ(C_API_SHIM(Decls[0]), "N");
+  EXPECT_EQ(C_API_SHIM(Decls[1]), "N::C");
+  EXPECT_EQ(C_API_SHIM(Decls[3]), "N::C::i");
+  EXPECT_EQ(C_API_SHIM(Decls[4]), "N::C::E");
+  // Clean up resources
+  clang_interpreter_takeInterpreterAsPtr(I);
+  clang_interpreter_dispose(I);
 }
 
 TEST(ScopeReflectionTest, GetQualifiedCompleteName) {
@@ -324,13 +537,40 @@ TEST(ScopeReflectionTest, GetQualifiedCompleteName) {
   EXPECT_EQ(Cpp::GetQualifiedCompleteName(Decls[0]), "N");
   EXPECT_EQ(Cpp::GetQualifiedCompleteName(Decls[1]), "N::C");
   EXPECT_EQ(Cpp::GetQualifiedCompleteName(Decls[2]), "N::A");
-  EXPECT_EQ(Cpp::GetQualifiedCompleteName(Cpp::GetScopeFromType(Cpp::GetVariableType(Decls[3]))), "N::A<int>");
+  EXPECT_EQ(Cpp::GetQualifiedCompleteName(
+                Cpp::GetScopeFromType(Cpp::GetVariableType(Decls[3]))),
+            "N::A<int>");
   EXPECT_EQ(Cpp::GetQualifiedCompleteName(Decls[5]), "N::C::i");
   EXPECT_EQ(Cpp::GetQualifiedCompleteName(Decls[6]), "N::C::E");
+
+  // C API
+  auto I = clang_createInterpreterFromPtr(Cpp::GetInterpreter());
+  auto C_API_SHIM = [&](auto Decl) {
+    auto Str = clang_scope_getQualifiedCompleteName(
+        CXScope{CXScope_Unexposed, Decl, I});
+    auto Res = std::string(clang_getCString(Str));
+    clang_disposeString(Str);
+    return Res;
+  };
+  EXPECT_EQ(C_API_SHIM(nullptr), "<unnamed>");
+  EXPECT_EQ(C_API_SHIM(Decls[0]), "N");
+  EXPECT_EQ(C_API_SHIM(Decls[1]), "N::C");
+  EXPECT_EQ(C_API_SHIM(Decls[2]), "N::A");
+  auto VarType =
+      clang_scope_getVariableType(CXScope{CXScope_Unexposed, Decls[3], I});
+  auto Scope = clang_scope_getScopeFromType(VarType);
+  auto Str = clang_scope_getQualifiedCompleteName(Scope);
+  EXPECT_EQ(std::string(clang_getCString(Str)), "N::A<int>");
+  clang_disposeString(Str);
+  EXPECT_EQ(C_API_SHIM(Decls[5]), "N::C::i");
+  EXPECT_EQ(C_API_SHIM(Decls[6]), "N::C::E");
+  // Clean up resources
+  clang_interpreter_takeInterpreterAsPtr(I);
+  clang_interpreter_dispose(I);
 }
 
 TEST(ScopeReflectionTest, GetUsingNamespaces) {
-  std::vector<Decl *> Decls, Decls1;
+  std::vector<Decl*> Decls, Decls1;
   std::string code = R"(
     namespace abc {
 
@@ -344,14 +584,30 @@ TEST(ScopeReflectionTest, GetUsingNamespaces) {
   )";
 
   GetAllTopLevelDecls(code, Decls);
-  std::vector<void *> usingNamespaces;
+  std::vector<void*> usingNamespaces;
   usingNamespaces = Cpp::GetUsingNamespaces(
-          Decls[0]->getASTContext().getTranslationUnitDecl());
+      Decls[0]->getASTContext().getTranslationUnitDecl());
 
-  //EXPECT_EQ(Cpp::GetName(usingNamespaces[0]), "runtime");
-  EXPECT_EQ(Cpp::GetName(usingNamespaces[usingNamespaces.size()-2]), "std");
-  EXPECT_EQ(Cpp::GetName(usingNamespaces[usingNamespaces.size()-1]), "abc");
+  // EXPECT_EQ(Cpp::GetName(usingNamespaces[0]), "runtime");
+  EXPECT_EQ(Cpp::GetName(usingNamespaces[usingNamespaces.size() - 2]), "std");
+  EXPECT_EQ(Cpp::GetName(usingNamespaces[usingNamespaces.size() - 1]), "abc");
 
+  // C API
+  auto I = clang_createInterpreterFromPtr(Cpp::GetInterpreter());
+  auto C_API_SHIM = [&](const auto& Scope) {
+    auto Str = clang_scope_getName(Scope);
+    auto Res = std::string(clang_getCString(Str));
+    clang_disposeString(Str);
+    return Res;
+  };
+
+  auto* D = Decls[0]->getASTContext().getTranslationUnitDecl();
+  auto* NS = clang_scope_getUsingNamespaces(CXScope{CXScope_Unexposed, D, I});
+  EXPECT_EQ(C_API_SHIM(NS->Scopes[NS->Count - 2]), "std");
+  EXPECT_EQ(C_API_SHIM(NS->Scopes[NS->Count - 1]), "abc");
+  clang_disposeScopeSet(NS);
+
+  // C++ API
   std::string code1 = R"(
     int x;
   )";
@@ -360,6 +616,16 @@ TEST(ScopeReflectionTest, GetUsingNamespaces) {
   std::vector<void*> usingNamespaces1;
   usingNamespaces1 = Cpp::GetUsingNamespaces(Decls1[0]);
   EXPECT_EQ(usingNamespaces1.size(), 0);
+
+  // C API
+  auto NS1 =
+      clang_scope_getUsingNamespaces(CXScope{CXScope_Unexposed, Decls1[0], I});
+  EXPECT_EQ(NS1->Count, 0);
+  clang_disposeScopeSet(NS1);
+
+  // Clean up resources
+  clang_interpreter_takeInterpreterAsPtr(I);
+  clang_interpreter_dispose(I);
 }
 
 TEST(ScopeReflectionTest, GetGlobalScope) {
@@ -368,7 +634,7 @@ TEST(ScopeReflectionTest, GetGlobalScope) {
 }
 
 TEST(ScopeReflectionTest, GetUnderlyingScope) {
-  std::vector<Decl *> Decls;
+  std::vector<Decl*> Decls;
   std::string code = R"(
     namespace N {
       class C {};
@@ -383,7 +649,26 @@ TEST(ScopeReflectionTest, GetUnderlyingScope) {
   EXPECT_EQ(Cpp::GetQualifiedName(Cpp::GetUnderlyingScope(Decls[0])), "N");
   EXPECT_EQ(Cpp::GetQualifiedName(Cpp::GetUnderlyingScope(Decls[1])), "N::C");
   EXPECT_EQ(Cpp::GetQualifiedName(Cpp::GetUnderlyingScope(Decls[2])), "INT");
-  EXPECT_EQ(Cpp::GetQualifiedName(Cpp::GetUnderlyingScope(nullptr)), "<unnamed>");
+  EXPECT_EQ(Cpp::GetQualifiedName(Cpp::GetUnderlyingScope(nullptr)),
+            "<unnamed>");
+
+  // C API
+  auto I = clang_createInterpreterFromPtr(Cpp::GetInterpreter());
+  auto C_API_SHIM = [&](auto Decl) {
+    auto Scope =
+        clang_scope_getUnderlyingScope(CXScope{CXScope_Unexposed, Decl, I});
+    auto Str = clang_scope_getQualifiedName(Scope);
+    auto Res = std::string(clang_getCString(Str));
+    clang_disposeString(Str);
+    return Res;
+  };
+  EXPECT_EQ(C_API_SHIM(Decls[0]), "N");
+  EXPECT_EQ(C_API_SHIM(Decls[1]), "N::C");
+  EXPECT_EQ(C_API_SHIM(Decls[2]), "INT");
+  EXPECT_EQ(C_API_SHIM(nullptr), "<unnamed>");
+  // Clean up resources
+  clang_interpreter_takeInterpreterAsPtr(I);
+  clang_interpreter_dispose(I);
 }
 
 TEST(ScopeReflectionTest, GetScope) {
@@ -410,6 +695,28 @@ TEST(ScopeReflectionTest, GetScope) {
   EXPECT_EQ(Cpp::GetQualifiedName(cl_C), "N::C");
   EXPECT_EQ(Cpp::GetQualifiedName(td_T), "T");
   EXPECT_EQ(Cpp::GetQualifiedName(non_existent), "<unnamed>");
+
+  // C API
+  auto I = clang_createInterpreterFromPtr(Cpp::GetInterpreter());
+  auto C_API_SHIM = [&](const auto& Scope) {
+    auto Str = clang_scope_getQualifiedName(Scope);
+    auto Res = std::string(clang_getCString(Str));
+    clang_disposeString(Str);
+    return Res;
+  };
+  auto GS = clang_scope_getGlobalScope(I);
+  auto NS_N = clang_scope_getScope("N", GS);
+  auto CL_C = clang_scope_getScope("C", NS_N);
+  auto TD_T = clang_scope_getScope("T", GS);
+  auto NON_EXISTENT = clang_scope_getScope("sum", GS);
+  EXPECT_EQ(C_API_SHIM(GS), "");
+  EXPECT_EQ(C_API_SHIM(NS_N), "N");
+  EXPECT_EQ(C_API_SHIM(CL_C), "N::C");
+  EXPECT_EQ(C_API_SHIM(TD_T), "T");
+  EXPECT_EQ(C_API_SHIM(NON_EXISTENT), "<unnamed>");
+  // Clean up resources
+  clang_interpreter_takeInterpreterAsPtr(I);
+  clang_interpreter_dispose(I);
 }
 
 TEST(ScopeReflectionTest, GetScopefromCompleteName) {
@@ -426,9 +733,13 @@ TEST(ScopeReflectionTest, GetScopefromCompleteName) {
 
   Interp->declare(code);
   EXPECT_EQ(Cpp::GetQualifiedName(Cpp::GetScopeFromCompleteName("N1")), "N1");
-  EXPECT_EQ(Cpp::GetQualifiedName(Cpp::GetScopeFromCompleteName("N1::N2")), "N1::N2");
-  EXPECT_EQ(Cpp::GetQualifiedName(Cpp::GetScopeFromCompleteName("N1::N2::C")), "N1::N2::C");
-  EXPECT_EQ(Cpp::GetQualifiedName(Cpp::GetScopeFromCompleteName("N1::N2::C::S")), "N1::N2::C::S");
+  EXPECT_EQ(Cpp::GetQualifiedName(Cpp::GetScopeFromCompleteName("N1::N2")),
+            "N1::N2");
+  EXPECT_EQ(Cpp::GetQualifiedName(Cpp::GetScopeFromCompleteName("N1::N2::C")),
+            "N1::N2::C");
+  EXPECT_EQ(
+      Cpp::GetQualifiedName(Cpp::GetScopeFromCompleteName("N1::N2::C::S")),
+      "N1::N2::C::S");
 }
 
 TEST(ScopeReflectionTest, GetNamed) {
@@ -460,13 +771,52 @@ TEST(ScopeReflectionTest, GetNamed) {
   EXPECT_EQ(Cpp::GetQualifiedName(Cpp::GetNamed("B", cl_C)), "N1::N2::C::B");
   EXPECT_EQ(Cpp::GetQualifiedName(Cpp::GetNamed("S", cl_C)), "N1::N2::C::S");
 
+  // C API
+  auto I = clang_createInterpreterFromPtr(Cpp::GetInterpreter());
+  auto C_API_SHIM = [&](const auto& Scope) {
+    auto Str = clang_scope_getQualifiedName(Scope);
+    auto Res = std::string(clang_getCString(Str));
+    clang_disposeString(Str);
+    return Res;
+  };
+  auto GS = clang_scope_getGlobalScope(I);
+  auto NS_N1 = clang_scope_getNamed("N1", GS);
+  auto NS_N2 = clang_scope_getNamed("N2", NS_N1);
+  auto CL_C = clang_scope_getNamed("C", NS_N2);
+  auto EN_E = clang_scope_getScope("E", CL_C);
+
+  EXPECT_EQ(C_API_SHIM(NS_N1), "N1");
+  EXPECT_EQ(C_API_SHIM(NS_N2), "N1::N2");
+  EXPECT_EQ(C_API_SHIM(CL_C), "N1::N2::C");
+  EXPECT_EQ(C_API_SHIM(clang_scope_getNamed("i", CL_C)), "N1::N2::C::i");
+  EXPECT_EQ(C_API_SHIM(EN_E), "N1::N2::C::E");
+  EXPECT_EQ(C_API_SHIM(clang_scope_getNamed("A", EN_E)), "N1::N2::C::A");
+  EXPECT_EQ(C_API_SHIM(clang_scope_getNamed("B", EN_E)), "N1::N2::C::B");
+  EXPECT_EQ(C_API_SHIM(clang_scope_getNamed("A", CL_C)), "N1::N2::C::A");
+  EXPECT_EQ(C_API_SHIM(clang_scope_getNamed("B", CL_C)), "N1::N2::C::B");
+  EXPECT_EQ(C_API_SHIM(clang_scope_getNamed("S", CL_C)), "N1::N2::C::S");
+
+  // C++ API
   Interp->process("#include <string>");
   Cpp::TCppScope_t std_ns = Cpp::GetNamed("std", nullptr);
   Cpp::TCppScope_t std_string_class = Cpp::GetNamed("string", std_ns);
-  Cpp::TCppScope_t std_string_npos_var = Cpp::GetNamed("npos", std_string_class);
+  Cpp::TCppScope_t std_string_npos_var =
+      Cpp::GetNamed("npos", std_string_class);
   EXPECT_EQ(Cpp::GetQualifiedName(std_ns), "std");
   EXPECT_EQ(Cpp::GetQualifiedName(std_string_class), "std::string");
-  EXPECT_EQ(Cpp::GetQualifiedName(std_string_npos_var), "std::basic_string<char>::npos");
+  EXPECT_EQ(Cpp::GetQualifiedName(std_string_npos_var),
+            "std::basic_string<char>::npos");
+
+  // C API
+  auto STD_NS = clang_scope_getNamed("std", GS);
+  auto STD_STRING_CLASS = clang_scope_getNamed("string", STD_NS);
+  auto STD_STRING_NPOS_VAR = clang_scope_getNamed("npos", STD_STRING_CLASS);
+  EXPECT_EQ(C_API_SHIM(STD_NS), "std");
+  EXPECT_EQ(C_API_SHIM(STD_STRING_CLASS), "std::string");
+  EXPECT_EQ(C_API_SHIM(STD_STRING_NPOS_VAR), "std::basic_string<char>::npos");
+  // Clean up resources
+  clang_interpreter_takeInterpreterAsPtr(I);
+  clang_interpreter_dispose(I);
 }
 
 TEST(ScopeReflectionTest, GetParentScope) {
@@ -499,10 +849,38 @@ TEST(ScopeReflectionTest, GetParentScope) {
   EXPECT_EQ(Cpp::GetQualifiedName(Cpp::GetParentScope(en_E)), "N1::N2::C");
   EXPECT_EQ(Cpp::GetQualifiedName(Cpp::GetParentScope(en_A)), "N1::N2::C::E");
   EXPECT_EQ(Cpp::GetQualifiedName(Cpp::GetParentScope(en_B)), "N1::N2::C::E");
+
+  // C API
+  auto I = clang_createInterpreterFromPtr(Cpp::GetInterpreter());
+  auto C_API_SHIM = [&](const auto& Scope) {
+    auto Str = clang_scope_getQualifiedName(clang_scope_getParentScope(Scope));
+    auto Res = std::string(clang_getCString(Str));
+    clang_disposeString(Str);
+    return Res;
+  };
+  auto GS = clang_scope_getGlobalScope(I);
+  auto NS_N1 = clang_scope_getNamed("N1", GS);
+  auto NS_N2 = clang_scope_getNamed("N2", NS_N1);
+  auto CL_C = clang_scope_getNamed("C", NS_N2);
+  auto INT_I = clang_scope_getNamed("i", CL_C);
+  auto EN_E = clang_scope_getNamed("E", CL_C);
+  auto EN_A = clang_scope_getNamed("A", EN_E);
+  auto EN_B = clang_scope_getNamed("B", EN_E);
+
+  EXPECT_EQ(C_API_SHIM(NS_N1), "");
+  EXPECT_EQ(C_API_SHIM(NS_N2), "N1");
+  EXPECT_EQ(C_API_SHIM(CL_C), "N1::N2");
+  EXPECT_EQ(C_API_SHIM(INT_I), "N1::N2::C");
+  EXPECT_EQ(C_API_SHIM(EN_E), "N1::N2::C");
+  EXPECT_EQ(C_API_SHIM(EN_A), "N1::N2::C::E");
+  EXPECT_EQ(C_API_SHIM(EN_B), "N1::N2::C::E");
+  // Clean up resources
+  clang_interpreter_takeInterpreterAsPtr(I);
+  clang_interpreter_dispose(I);
 }
 
 TEST(ScopeReflectionTest, GetScopeFromType) {
-  std::vector<Decl *> Decls;
+  std::vector<Decl*> Decls;
   std::string code = R"(
     namespace N {
     class C {};
@@ -532,21 +910,40 @@ TEST(ScopeReflectionTest, GetScopeFromType) {
   QualType QT5 = llvm::dyn_cast<VarDecl>(Decls[5])->getType();
   QualType QT6 = llvm::dyn_cast<FunctionDecl>(Decls[6])->getReturnType();
   EXPECT_EQ(Cpp::GetQualifiedName(Cpp::GetScopeFromType(QT1.getAsOpaquePtr())),
-          "N::C");
+            "N::C");
   EXPECT_EQ(Cpp::GetQualifiedName(Cpp::GetScopeFromType(QT2.getAsOpaquePtr())),
-          "N::S");
-  EXPECT_EQ(Cpp::GetScopeFromType(QT3.getAsOpaquePtr()),
-          (Cpp::TCppScope_t) 0);
+            "N::S");
+  EXPECT_EQ(Cpp::GetScopeFromType(QT3.getAsOpaquePtr()), (Cpp::TCppScope_t)0);
   EXPECT_EQ(Cpp::GetQualifiedName(Cpp::GetScopeFromType(QT4.getAsOpaquePtr())),
-          "N::C");
+            "N::C");
   EXPECT_EQ(Cpp::GetQualifiedName(Cpp::GetScopeFromType(QT5.getAsOpaquePtr())),
             "N::E");
   EXPECT_EQ(Cpp::GetQualifiedName(Cpp::GetScopeFromType(QT6.getAsOpaquePtr())),
             "N::C");
+
+  // C API
+  auto I = clang_createInterpreterFromPtr(Cpp::GetInterpreter());
+  auto C_API_SHIM = [&](auto Type) {
+    auto Scope =
+        clang_scope_getScopeFromType(CXQualType{CXType_Unexposed, Type, I});
+    auto Str = clang_scope_getQualifiedName(Scope);
+    auto Res = std::string(clang_getCString(Str));
+    clang_disposeString(Str);
+    return Res;
+  };
+  EXPECT_EQ(C_API_SHIM(QT1.getAsOpaquePtr()), "N::C");
+  EXPECT_EQ(C_API_SHIM(QT2.getAsOpaquePtr()), "N::S");
+  EXPECT_EQ(C_API_SHIM(QT3.getAsOpaquePtr()), "<unnamed>");
+  EXPECT_EQ(C_API_SHIM(QT4.getAsOpaquePtr()), "N::C");
+  EXPECT_EQ(C_API_SHIM(QT5.getAsOpaquePtr()), "N::E");
+  EXPECT_EQ(C_API_SHIM(QT6.getAsOpaquePtr()), "N::C");
+  // Clean up resources
+  clang_interpreter_takeInterpreterAsPtr(I);
+  clang_interpreter_dispose(I);
 }
 
 TEST(ScopeReflectionTest, GetNumBases) {
-  std::vector<Decl *> Decls;
+  std::vector<Decl*> Decls;
   std::string code = R"(
     class A {};
     class B : virtual public A {};
@@ -569,7 +966,7 @@ TEST(ScopeReflectionTest, GetNumBases) {
 }
 
 TEST(ScopeReflectionTest, GetBaseClass) {
-  std::vector<Decl *> Decls;
+  std::vector<Decl*> Decls;
   std::string code = R"(
     class A {};
     class B : virtual public A {};
@@ -593,8 +990,8 @@ TEST(ScopeReflectionTest, GetBaseClass) {
 
   GetAllTopLevelDecls(code, Decls);
 
-  auto get_base_class_name = [](Decl *D, int i) {
-      return Cpp::GetQualifiedName(Cpp::GetBaseClass(D, i));
+  auto get_base_class_name = [](Decl* D, int i) {
+    return Cpp::GetQualifiedName(Cpp::GetBaseClass(D, i));
   };
 
   EXPECT_EQ(get_base_class_name(Decls[1], 0), "A");
@@ -604,10 +1001,10 @@ TEST(ScopeReflectionTest, GetBaseClass) {
   EXPECT_EQ(get_base_class_name(Decls[4], 0), "D");
   EXPECT_EQ(get_base_class_name(Decls[10], 0), "<unnamed>");
 
-  auto *VD = Cpp::GetNamed("var");
-  auto *VT = Cpp::GetVariableType(VD);
-  auto *TC2_A_Decl = Cpp::GetScopeFromType(VT);
-  auto *TC1_A_Decl = Cpp::GetBaseClass(TC2_A_Decl, 0);
+  auto* VD = Cpp::GetNamed("var");
+  auto* VT = Cpp::GetVariableType(VD);
+  auto* TC2_A_Decl = Cpp::GetScopeFromType(VT);
+  auto* TC1_A_Decl = Cpp::GetBaseClass(TC2_A_Decl, 0);
   EXPECT_EQ(Cpp::GetCompleteName(TC1_A_Decl), "TC1<A>");
 
   auto* VD1 = Cpp::GetNamed("var1");
@@ -618,7 +1015,7 @@ TEST(ScopeReflectionTest, GetBaseClass) {
 }
 
 TEST(ScopeReflectionTest, IsSubclass) {
-  std::vector<Decl *> Decls;
+  std::vector<Decl*> Decls;
   std::string code = R"(
     class A {};
     class B : virtual public A {};
@@ -660,44 +1057,66 @@ TEST(ScopeReflectionTest, IsSubclass) {
 }
 
 TEST(ScopeReflectionTest, GetBaseClassOffset) {
-  std::vector<Decl *> Decls;
+  std::vector<Decl*> Decls;
 #define Stringify(s) Stringifyx(s)
 #define Stringifyx(...) #__VA_ARGS__
-#define CODE                                                    \
-  struct A { int m_a; };                                         \
-  struct B { int m_b; };                                         \
-  struct C : virtual A, virtual B { int m_c; };                  \
-  struct D : virtual A, virtual B, public C { int m_d; };        \
-  struct E : public A, public B { int m_e; };                    \
-  struct F : public A { int m_f; };                              \
-  struct G : public F { int m_g; };
+#define CODE                                                                   \
+  struct A {                                                                   \
+    int m_a;                                                                   \
+  };                                                                           \
+  struct B {                                                                   \
+    int m_b;                                                                   \
+  };                                                                           \
+  struct C : virtual A, virtual B {                                            \
+    int m_c;                                                                   \
+  };                                                                           \
+  struct D : virtual A, virtual B, public C {                                  \
+    int m_d;                                                                   \
+  };                                                                           \
+  struct E : public A, public B {                                              \
+    int m_e;                                                                   \
+  };                                                                           \
+  struct F : public A {                                                        \
+    int m_f;                                                                   \
+  };                                                                           \
+  struct G : public F {                                                        \
+    int m_g;                                                                   \
+  };
 
-CODE;
+  CODE;
 
   GetAllTopLevelDecls(Stringify(CODE), Decls);
 #undef Stringifyx
 #undef Stringify
 #undef CODE
 
-  auto *c = new C();
-  EXPECT_EQ(Cpp::GetBaseClassOffset(Decls[2], Decls[0]), (char *)(A*)c - (char *)c);
-  EXPECT_EQ(Cpp::GetBaseClassOffset(Decls[2], Decls[1]), (char *)(B*)c - (char *)c);
+  auto* c = new C();
+  EXPECT_EQ(Cpp::GetBaseClassOffset(Decls[2], Decls[0]),
+            (char*)(A*)c - (char*)c);
+  EXPECT_EQ(Cpp::GetBaseClassOffset(Decls[2], Decls[1]),
+            (char*)(B*)c - (char*)c);
 
-  auto *d = new D();
-  EXPECT_EQ(Cpp::GetBaseClassOffset(Decls[3], Decls[0]), (char *)(A*)d - (char *)d);
-  EXPECT_EQ(Cpp::GetBaseClassOffset(Decls[3], Decls[1]), (char *)(B*)d - (char *)d);
-  EXPECT_EQ(Cpp::GetBaseClassOffset(Decls[3], Decls[2]), (char *)(C*)d - (char *)d);
+  auto* d = new D();
+  EXPECT_EQ(Cpp::GetBaseClassOffset(Decls[3], Decls[0]),
+            (char*)(A*)d - (char*)d);
+  EXPECT_EQ(Cpp::GetBaseClassOffset(Decls[3], Decls[1]),
+            (char*)(B*)d - (char*)d);
+  EXPECT_EQ(Cpp::GetBaseClassOffset(Decls[3], Decls[2]),
+            (char*)(C*)d - (char*)d);
 
-  auto *e = new E();
-  EXPECT_EQ(Cpp::GetBaseClassOffset(Decls[4], Decls[0]), (char *)(A*)e - (char *)e);
-  EXPECT_EQ(Cpp::GetBaseClassOffset(Decls[4], Decls[1]), (char *)(B*)e - (char *)e);
+  auto* e = new E();
+  EXPECT_EQ(Cpp::GetBaseClassOffset(Decls[4], Decls[0]),
+            (char*)(A*)e - (char*)e);
+  EXPECT_EQ(Cpp::GetBaseClassOffset(Decls[4], Decls[1]),
+            (char*)(B*)e - (char*)e);
 
-  auto *g = new G();
-  EXPECT_EQ(Cpp::GetBaseClassOffset(Decls[6], Decls[0]), (char *)(A*)g - (char *)g);
+  auto* g = new G();
+  EXPECT_EQ(Cpp::GetBaseClassOffset(Decls[6], Decls[0]),
+            (char*)(A*)g - (char*)g);
 }
 
 TEST(ScopeReflectionTest, GetAllCppNames) {
-  std::vector<Decl *> Decls;
+  std::vector<Decl*> Decls;
   std::string code = R"(
     class A { int a; };
     class B { int b; };
@@ -716,14 +1135,15 @@ TEST(ScopeReflectionTest, GetAllCppNames) {
 
   GetAllTopLevelDecls(code, Decls);
 
-  auto test_get_all_cpp_names = [](Decl *D, const std::vector<std::string> &truth_names) {
-    auto names = Cpp::GetAllCppNames(D);
-    EXPECT_EQ(names.size(), truth_names.size());
+  auto test_get_all_cpp_names =
+      [](Decl* D, const std::vector<std::string>& truth_names) {
+        auto names = Cpp::GetAllCppNames(D);
+        EXPECT_EQ(names.size(), truth_names.size());
 
-    for (unsigned i = 0; i < truth_names.size() && i < names.size(); i++) {
-      EXPECT_EQ(names[i], truth_names[i]);
-    }
-  };
+        for (unsigned i = 0; i < truth_names.size() && i < names.size(); i++) {
+          EXPECT_EQ(names[i], truth_names[i]);
+        }
+      };
 
   test_get_all_cpp_names(Decls[0], {"a"});
   test_get_all_cpp_names(Decls[1], {"b"});
@@ -734,7 +1154,7 @@ TEST(ScopeReflectionTest, GetAllCppNames) {
 }
 
 TEST(ScopeReflectionTest, InstantiateNNTPClassTemplate) {
-  std::vector<Decl *> Decls;
+  std::vector<Decl*> Decls;
   std::string code = R"(
     template <int N>
     struct Factorial {
@@ -748,7 +1168,7 @@ TEST(ScopeReflectionTest, InstantiateNNTPClassTemplate) {
 
   GetAllTopLevelDecls(code, Decls);
 
-  ASTContext &C = Interp->getCI()->getASTContext();
+  ASTContext& C = Interp->getCI()->getASTContext();
   Cpp::TCppType_t IntTy = C.IntTy.getAsOpaquePtr();
   std::vector<Cpp::TemplateArgInfo> args1 = {{IntTy, "5"}};
   EXPECT_TRUE(Cpp::InstantiateTemplate(Decls[0], args1.data(),
@@ -815,7 +1235,7 @@ TEST(ScopeReflectionTest, InstantiateTemplateFunctionFromString) {
 }
 
 TEST(ScopeReflectionTest, InstantiateTemplate) {
-  std::vector<Decl *> Decls;
+  std::vector<Decl*> Decls;
   std::string code = R"(
     template<typename T>
     class AllDefault {
@@ -855,13 +1275,13 @@ TEST(ScopeReflectionTest, InstantiateTemplate) {
   )";
 
   GetAllTopLevelDecls(code, Decls);
-  ASTContext &C = Interp->getCI()->getASTContext();
+  ASTContext& C = Interp->getCI()->getASTContext();
 
   std::vector<Cpp::TemplateArgInfo> args1 = {C.IntTy.getAsOpaquePtr()};
   auto Instance1 = Cpp::InstantiateTemplate(Decls[0], args1.data(),
                                             /*type_size*/ args1.size());
   EXPECT_TRUE(isa<ClassTemplateSpecializationDecl>((Decl*)Instance1));
-  auto *CTSD1 = static_cast<ClassTemplateSpecializationDecl*>(Instance1);
+  auto* CTSD1 = static_cast<ClassTemplateSpecializationDecl*>(Instance1);
   EXPECT_TRUE(CTSD1->hasDefinition());
   TemplateArgument TA1 = CTSD1->getTemplateArgs().get(0);
   EXPECT_TRUE(TA1.getAsType()->isIntegerType());
@@ -870,7 +1290,7 @@ TEST(ScopeReflectionTest, InstantiateTemplate) {
   auto Instance2 = Cpp::InstantiateTemplate(Decls[1], nullptr,
                                             /*type_size*/ 0);
   EXPECT_TRUE(isa<ClassTemplateSpecializationDecl>((Decl*)Instance2));
-  auto *CTSD2 = static_cast<ClassTemplateSpecializationDecl*>(Instance2);
+  auto* CTSD2 = static_cast<ClassTemplateSpecializationDecl*>(Instance2);
   EXPECT_TRUE(CTSD2->hasDefinition());
   TemplateArgument TA2 = CTSD2->getTemplateArgs().get(0);
   EXPECT_TRUE(TA2.getAsType()->isIntegerType());
@@ -879,7 +1299,7 @@ TEST(ScopeReflectionTest, InstantiateTemplate) {
   auto Instance3 = Cpp::InstantiateTemplate(Decls[2], args3.data(),
                                             /*type_size*/ args3.size());
   EXPECT_TRUE(isa<ClassTemplateSpecializationDecl>((Decl*)Instance3));
-  auto *CTSD3 = static_cast<ClassTemplateSpecializationDecl*>(Instance3);
+  auto* CTSD3 = static_cast<ClassTemplateSpecializationDecl*>(Instance3);
   EXPECT_TRUE(CTSD3->hasDefinition());
   TemplateArgument TA3_0 = CTSD3->getTemplateArgs().get(0);
   TemplateArgument TA3_1 = CTSD3->getTemplateArgs().get(1);
@@ -892,12 +1312,12 @@ TEST(ScopeReflectionTest, InstantiateTemplate) {
             "C1<int>::C1(const C0<int> &val)");
 
   std::vector<Cpp::TemplateArgInfo> args4 = {C.IntTy.getAsOpaquePtr(),
-                                               {C.IntTy.getAsOpaquePtr(), "3"}};
+                                             {C.IntTy.getAsOpaquePtr(), "3"}};
   auto Instance4 = Cpp::InstantiateTemplate(Decls[3], args4.data(),
                                             /*type_size*/ args4.size());
 
   EXPECT_TRUE(isa<ClassTemplateSpecializationDecl>((Decl*)Instance4));
-  auto *CTSD4 = static_cast<ClassTemplateSpecializationDecl*>(Instance4);
+  auto* CTSD4 = static_cast<ClassTemplateSpecializationDecl*>(Instance4);
   EXPECT_TRUE(CTSD4->hasDefinition());
   TemplateArgument TA4_0 = CTSD4->getTemplateArgs().get(0);
   TemplateArgument TA4_1 = CTSD4->getTemplateArgs().get(1);
@@ -906,7 +1326,7 @@ TEST(ScopeReflectionTest, InstantiateTemplate) {
 }
 
 TEST(ScopeReflectionTest, GetClassTemplateInstantiationArgs) {
-  std::vector<Decl *> Decls;
+  std::vector<Decl*> Decls;
   std::string code = R"(
     template<typename ...T> struct __Cppyy_AppendTypesSlow {};
     __Cppyy_AppendTypesSlow<int, float, double> v1;
@@ -916,14 +1336,14 @@ TEST(ScopeReflectionTest, GetClassTemplateInstantiationArgs) {
 
   GetAllTopLevelDecls(code, Decls);
 
-  auto *v1 = Cpp::GetNamed("v1");
-  auto *v2 = Cpp::GetNamed("v2");
-  auto *v3 = Cpp::GetNamed("v3");
+  auto* v1 = Cpp::GetNamed("v1");
+  auto* v2 = Cpp::GetNamed("v2");
+  auto* v3 = Cpp::GetNamed("v3");
   EXPECT_TRUE(v1 && v2 && v3);
 
-  auto *v1_class = Cpp::GetScopeFromType(Cpp::GetVariableType(v1));
-  auto *v2_class = Cpp::GetScopeFromType(Cpp::GetVariableType(v2));
-  auto *v3_class = Cpp::GetScopeFromType(Cpp::GetVariableType(v3));
+  auto* v1_class = Cpp::GetScopeFromType(Cpp::GetVariableType(v1));
+  auto* v2_class = Cpp::GetScopeFromType(Cpp::GetVariableType(v2));
+  auto* v3_class = Cpp::GetScopeFromType(Cpp::GetVariableType(v3));
   EXPECT_TRUE(v1_class && v2_class && v3_class);
 
   std::vector<Cpp::TemplateArgInfo> instance_types;
@@ -942,10 +1362,9 @@ TEST(ScopeReflectionTest, GetClassTemplateInstantiationArgs) {
   EXPECT_TRUE(instance_types.size() == 0);
 }
 
-
 TEST(ScopeReflectionTest, IncludeVector) {
   if (llvm::sys::RunningOnValgrind())
-      GTEST_SKIP() << "XFAIL due to Valgrind report";
+    GTEST_SKIP() << "XFAIL due to Valgrind report";
   std::string code = R"(
     #include <vector>
     #include <iostream>

--- a/unittests/CppInterOp/Utils.cpp
+++ b/unittests/CppInterOp/Utils.cpp
@@ -56,3 +56,12 @@ void TestUtils::GetAllSubDecls(Decl *D, std::vector<Decl*>& SubDecls,
     SubDecls.push_back(Di);
   }
 }
+
+const char* clang_getCString(CXString string) {
+  return static_cast<const char*>(string.data);
+}
+
+void clang_disposeString(CXString string) {
+  if (string.private_flags == 1 && string.data)
+    free(const_cast<void*>(string.data));
+}

--- a/unittests/CppInterOp/Utils.h
+++ b/unittests/CppInterOp/Utils.h
@@ -3,9 +3,10 @@
 
 #include "../../lib/Interpreter/Compatibility.h"
 
+#include "llvm/Support/Valgrind.h"
 #include <memory>
 #include <vector>
-#include "llvm/Support/Valgrind.h"
+#include "clang-c/CXString.h"
 
 using namespace clang;
 using namespace llvm;
@@ -20,5 +21,9 @@ namespace TestUtils {
   void GetAllSubDecls(clang::Decl *D, std::vector<clang::Decl*>& SubDecls,
                       bool filter_implicitGenerated = false);
 } // end namespace TestUtils
+
+// libclang's string manipulation APIs
+const char* clang_getCString(CXString string);
+void clang_disposeString(CXString string);
 
 #endif // CPPINTEROP_UNITTESTS_LIBCPPINTEROP_UTILS_H


### PR DESCRIPTION
TODO:

- [x] `void AddSearchPath(const char *dir, bool isUser, bool prepend);`
- [x] `const char* GetResourceDir();`
- [x] `void AddIncludePath(const char *dir);`
- [x] `int Declare(const char* code, bool silent);`
- [x] `int Process(const char *code);`
- [x] `intptr_t Evaluate(const char *code, bool *HadError/*=nullptr*/);`
- [x] `std::string LookupLibrary(const char* lib_name);`
- [x] `bool LoadLibrary(const char* lib_stem, bool lookup);`
- [x] `void UnloadLibrary(const char* lib_stem);`
- [x] `std::string SearchLibrariesForSymbol(const char* mangled_name, bool search_system /*true*/);`
- [x] `std::string ObjToString(const char *type, void *obj);`
- [x] `void Destruct(TCppObject_t This, TCppScope_t scope, bool withFree /*=true*/);`
- [x] `TCppFuncAddr_t GetFunctionAddress(const char* mangled_name);`
- [x] `CPPINTEROP_API JitCall MakeFunctionCallable(TCppConstFunction_t func);`
- [x] `intptr_t GetVariableOffset(TCppScope_t var); `
- [x] `bool InsertOrReplaceJitSymbol(const char* linker_mangled_name, uint64_t address);`
- [x] Add C APIs for scope, type, object, and jitcall manipulation
- [ ] Add tests and run clang-format and fix clang-tidy

Update:

Keeping the C++ API untouched is impossible if we want libclang-styled types. As a result, I reimplemented most of the C++ APIs on the C API side. 
