### PR TITLE
Fix wasm jobs in ci due to changes in xeus-cpp requirements

### DIFF
--- a/environment-wasm.yml
+++ b/environment-wasm.yml
@@ -4,8 +4,7 @@ channels:
 dependencies:
   - zlib
   - nlohmann_json
-  - xeus-lite <2.0
-  - xeus >=3.0.5,<4.0
-  - xtl >=0.7,<0.8
+  - xeus-lite
+  - xeus
   - cpp-argparse
   - pugixml


### PR DESCRIPTION
This PR should allow the wasm jobs in the ci to pass again after the changes to the requirements in xeus-cpp