### PR TITLE
Implement `GetIncludePaths`

### DIFF
--- a/include/clang/Interpreter/CppInterOp.h
+++ b/include/clang/Interpreter/CppInterOp.h
@@ -507,7 +507,9 @@ namespace Cpp {
   /// GetResourceDir() function.
   CPPINTEROP_API void AddIncludePath(const char* dir);
 
-  ///\returns include paths as string with ':' as delimiter
+  // Gets the currently used include paths
+  ///\param[out] IncludePaths - the list of include paths
+  ///
   CPPINTEROP_API void GetIncludePaths(std::vector<std::string>& IncludePaths);
 
   /// Only Declares a code snippet in \c code and does not execute it.

--- a/include/clang/Interpreter/CppInterOp.h
+++ b/include/clang/Interpreter/CppInterOp.h
@@ -510,7 +510,9 @@ namespace Cpp {
   // Gets the currently used include paths
   ///\param[out] IncludePaths - the list of include paths
   ///
-  CPPINTEROP_API void GetIncludePaths(std::vector<std::string>& IncludePaths);
+  CPPINTEROP_API void GetIncludePaths(std::vector<std::string>& IncludePaths,
+                                      bool withSystem = false,
+                                      bool withFlags = false);
 
   /// Only Declares a code snippet in \c code and does not execute it.
   ///\returns 0 on success

--- a/include/clang/Interpreter/CppInterOp.h
+++ b/include/clang/Interpreter/CppInterOp.h
@@ -507,6 +507,9 @@ namespace Cpp {
   /// GetResourceDir() function.
   CPPINTEROP_API void AddIncludePath(const char* dir);
 
+  ///\returns include paths as string with ':' as delimiter
+  CPPINTEROP_API std::string GetIncludePaths();
+
   /// Only Declares a code snippet in \c code and does not execute it.
   ///\returns 0 on success
   CPPINTEROP_API int Declare(const char* code, bool silent = false);

--- a/include/clang/Interpreter/CppInterOp.h
+++ b/include/clang/Interpreter/CppInterOp.h
@@ -508,7 +508,7 @@ namespace Cpp {
   CPPINTEROP_API void AddIncludePath(const char* dir);
 
   ///\returns include paths as string with ':' as delimiter
-  CPPINTEROP_API std::string GetIncludePaths();
+  CPPINTEROP_API void GetIncludePaths(std::vector<std::string>& IncludePaths);
 
   /// Only Declares a code snippet in \c code and does not execute it.
   ///\returns 0 on success

--- a/lib/Interpreter/CppInterOp.cpp
+++ b/lib/Interpreter/CppInterOp.cpp
@@ -2702,8 +2702,12 @@ namespace Cpp {
     getInterp().AddIncludePath(dir);
   }
 
-  std::string GetIncludePaths() {
-    return getInterp().GetIncludePaths();
+  void GetIncludePaths(std::vector<std::string>& IncludePaths) {
+    llvm::SmallVector<std::string> paths(10);
+    getInterp().GetIncludePaths(paths, false, false);
+    for (auto &i: paths) {
+      IncludePaths.push_back(i);
+    }
   }
 
   namespace {

--- a/lib/Interpreter/CppInterOp.cpp
+++ b/lib/Interpreter/CppInterOp.cpp
@@ -2702,10 +2702,10 @@ namespace Cpp {
     getInterp().AddIncludePath(dir);
   }
 
-  void GetIncludePaths(std::vector<std::string>& IncludePaths) {
+  void GetIncludePaths(std::vector<std::string>& IncludePaths, bool withSystem,
+                       bool withFlags) {
     llvm::SmallVector<std::string> paths(1);
-    getInterp().GetIncludePaths(paths, /*withSystem=*/false,
-                                /*withFlags=*/false);
+    getInterp().GetIncludePaths(paths, withSystem, withFlags);
     for (auto& i : paths)
       IncludePaths.push_back(i);
   }

--- a/lib/Interpreter/CppInterOp.cpp
+++ b/lib/Interpreter/CppInterOp.cpp
@@ -2704,8 +2704,9 @@ namespace Cpp {
 
   void GetIncludePaths(std::vector<std::string>& IncludePaths) {
     llvm::SmallVector<std::string> paths(1);
-    getInterp().GetIncludePaths(paths, /*withSystem=*/false, /*withFlags=*/false);
-    for (auto &i: paths)
+    getInterp().GetIncludePaths(paths, /*withSystem=*/false,
+                                /*withFlags=*/false);
+    for (auto& i : paths)
       IncludePaths.push_back(i);
   }
 

--- a/lib/Interpreter/CppInterOp.cpp
+++ b/lib/Interpreter/CppInterOp.cpp
@@ -2704,10 +2704,9 @@ namespace Cpp {
 
   void GetIncludePaths(std::vector<std::string>& IncludePaths) {
     llvm::SmallVector<std::string> paths(1);
-    getInterp().GetIncludePaths(paths, false, false);
-    for (auto &i: paths) {
+    getInterp().GetIncludePaths(paths, /*withSystem=*/false, /*withFlags=*/false);
+    for (auto &i: paths)
       IncludePaths.push_back(i);
-    }
   }
 
   namespace {

--- a/lib/Interpreter/CppInterOp.cpp
+++ b/lib/Interpreter/CppInterOp.cpp
@@ -2702,6 +2702,10 @@ namespace Cpp {
     getInterp().AddIncludePath(dir);
   }
 
+  std::string GetIncludePaths() {
+    return getInterp().GetIncludePaths();
+  }
+
   namespace {
 
   class clangSilent {

--- a/lib/Interpreter/CppInterOp.cpp
+++ b/lib/Interpreter/CppInterOp.cpp
@@ -2703,7 +2703,7 @@ namespace Cpp {
   }
 
   void GetIncludePaths(std::vector<std::string>& IncludePaths) {
-    llvm::SmallVector<std::string> paths(10);
+    llvm::SmallVector<std::string> paths(1);
     getInterp().GetIncludePaths(paths, false, false);
     for (auto &i: paths) {
       IncludePaths.push_back(i);

--- a/lib/Interpreter/CppInterOpInterpreter.h
+++ b/lib/Interpreter/CppInterOpInterpreter.h
@@ -381,17 +381,12 @@ public:
     return AddIncludePaths(PathsStr, nullptr);
   }
 
-  /// \returns include paths as string with ':' as delimiter
-  std::string GetIncludePaths() {
-    const clang::CompilerInstance* CI = getCompilerInstance();
-    clang::HeaderSearchOptions& HOpts =
-        const_cast<clang::HeaderSearchOptions&>(CI->getHeaderSearchOpts());
-    
-    std::string Paths;
-    for (const clang::HeaderSearchOptions::Entry& E : HOpts.UserEntries) {
-      Paths += E.Path + ":";
-    }
-    return Paths;
+  ///\brief pushes include path to incpaths and compiler flags 
+  ///
+  void GetIncludePaths(llvm::SmallVectorImpl<std::string>& incpaths,
+                       bool withSystem, bool withFlags) const {
+    utils::CopyIncludePaths(getCI()->getHeaderSearchOpts(),
+                              incpaths, withSystem, withFlags);
   }
 
   CompilationResult loadLibrary(const std::string& filename, bool lookup) {

--- a/lib/Interpreter/CppInterOpInterpreter.h
+++ b/lib/Interpreter/CppInterOpInterpreter.h
@@ -381,7 +381,17 @@ public:
     return AddIncludePaths(PathsStr, nullptr);
   }
 
-  ///\brief pushes include path to incpaths and compiler flags 
+  ///\brief Get the current include paths that are used.
+  ///
+  ///\param[out] incpaths - Pass in a llvm::SmallVector<std::string, N> with
+  ///       sufficiently sized N, to hold the result of the call.
+  ///\param[in] withSystem - if true, incpaths will also contain system
+  ///       include paths (framework, STL etc).
+  ///\param[in] withFlags - if true, each element in incpaths will be prefixed
+  ///       with a "-I" or similar, and some entries of incpaths will signal
+  ///       a new include path region (e.g. "-cxx-isystem"). Also, flags
+  ///       defining header search behavior will be included in incpaths, e.g.
+  ///       "-nostdinc".
   ///
   void GetIncludePaths(llvm::SmallVectorImpl<std::string>& incpaths,
                        bool withSystem, bool withFlags) const {

--- a/lib/Interpreter/CppInterOpInterpreter.h
+++ b/lib/Interpreter/CppInterOpInterpreter.h
@@ -381,6 +381,19 @@ public:
     return AddIncludePaths(PathsStr, nullptr);
   }
 
+  /// \returns include paths as string with ':' as delimiter
+  std::string GetIncludePaths() {
+    const clang::CompilerInstance* CI = getCompilerInstance();
+    clang::HeaderSearchOptions& HOpts =
+        const_cast<clang::HeaderSearchOptions&>(CI->getHeaderSearchOpts());
+    
+    std::string Paths;
+    for (const clang::HeaderSearchOptions::Entry& E : HOpts.UserEntries) {
+      Paths += E.Path + ":";
+    }
+    return Paths;
+  }
+
   CompilationResult loadLibrary(const std::string& filename, bool lookup) {
     DynamicLibraryManager* DLM = getDynamicLibraryManager();
     std::string canonicalLib;

--- a/lib/Interpreter/CppInterOpInterpreter.h
+++ b/lib/Interpreter/CppInterOpInterpreter.h
@@ -395,8 +395,8 @@ public:
   ///
   void GetIncludePaths(llvm::SmallVectorImpl<std::string>& incpaths,
                        bool withSystem, bool withFlags) const {
-    utils::CopyIncludePaths(getCI()->getHeaderSearchOpts(),
-                              incpaths, withSystem, withFlags);
+    utils::CopyIncludePaths(getCI()->getHeaderSearchOpts(), incpaths,
+                            withSystem, withFlags);
   }
 
   CompilationResult loadLibrary(const std::string& filename, bool lookup) {

--- a/unittests/CppInterOp/InterpreterTest.cpp
+++ b/unittests/CppInterOp/InterpreterTest.cpp
@@ -119,6 +119,27 @@ TEST(InterpreterTest, GetIncludePaths) {
   EXPECT_FALSE(includes.empty());
 }
 
+TEST(InterpreterTest, GetIncludePaths2) {
+  Cpp::Interpreter* I =
+      static_cast<Cpp::Interpreter*>(Cpp::CreateInterpreter());
+
+  llvm::SmallVector<std::string> includes(1);
+
+  I->GetIncludePaths(includes, /*withSystem=*/false, /*withFlags=*/false);
+  EXPECT_FALSE(includes.empty());
+  size_t len = includes.size();
+  includes.clear();
+
+  I->GetIncludePaths(includes, /*withSystem=*/true, /*withFlags=*/false);
+  EXPECT_FALSE(includes.empty());
+  EXPECT_TRUE(includes.size() >= len);
+  len = includes.size();
+
+  I->GetIncludePaths(includes, /*withSystem=*/true, /*withFlags=*/true);
+  EXPECT_FALSE(includes.empty());
+  EXPECT_TRUE(includes.size() >= len);
+}
+
 TEST(InterpreterTest, CodeCompletion) {
 #if CLANG_VERSION_MAJOR >= 18 || defined(USE_CLING)
   Cpp::CreateInterpreter();

--- a/unittests/CppInterOp/InterpreterTest.cpp
+++ b/unittests/CppInterOp/InterpreterTest.cpp
@@ -117,25 +117,16 @@ TEST(InterpreterTest, GetIncludePaths) {
   std::vector<std::string> includes;
   Cpp::GetIncludePaths(includes);
   EXPECT_FALSE(includes.empty());
-}
 
-TEST(InterpreterTest, GetIncludePaths2) {
-  Cpp::Interpreter* I =
-      static_cast<Cpp::Interpreter*>(Cpp::CreateInterpreter());
-
-  llvm::SmallVector<std::string> includes(1);
-
-  I->GetIncludePaths(includes, /*withSystem=*/false, /*withFlags=*/false);
-  EXPECT_FALSE(includes.empty());
   size_t len = includes.size();
   includes.clear();
-
-  I->GetIncludePaths(includes, /*withSystem=*/true, /*withFlags=*/false);
+  Cpp::GetIncludePaths(includes, true, false);
   EXPECT_FALSE(includes.empty());
   EXPECT_TRUE(includes.size() >= len);
-  len = includes.size();
 
-  I->GetIncludePaths(includes, /*withSystem=*/true, /*withFlags=*/true);
+  len = includes.size();
+  includes.clear();
+  Cpp::GetIncludePaths(includes, true, true);
   EXPECT_FALSE(includes.empty());
   EXPECT_TRUE(includes.size() >= len);
 }

--- a/unittests/CppInterOp/InterpreterTest.cpp
+++ b/unittests/CppInterOp/InterpreterTest.cpp
@@ -113,6 +113,12 @@ TEST(InterpreterTest, DetectSystemCompilerIncludePaths) {
   EXPECT_FALSE(includes.empty());
 }
 
+TEST(InterpreterTest, GetIncludePaths) {
+  std::vector<std::string> includes;
+  Cpp::GetIncludePaths(includes);
+  EXPECT_FALSE(includes.empty());
+}
+
 TEST(InterpreterTest, CodeCompletion) {
 #if CLANG_VERSION_MAJOR >= 18 || defined(USE_CLING)
   Cpp::CreateInterpreter();


### PR DESCRIPTION
Fixes #69 

I was unsure if to return `std::vector<std::string>` or a single `std::string` with delimiter. I have gone with a single `std::string` with `:` as the delimiter, but it can be changed.

---

With the following changes in the [cppyy](https://github.com/compiler-research/cppyy) library.
```diff
diff --git a/python/cppyy/__init__.py b/python/cppyy/__init__.py
index 53b7e92..441c34c 100644
--- a/python/cppyy/__init__.py
+++ b/python/cppyy/__init__.py
@@ -260,6 +260,11 @@ def add_include_path(path):
         raise OSError('No such directory: %s' % path)
     gbl.Cpp.AddIncludePath(path)
 
+def get_include_path():
+    """Get include paths available to Cling."""
+    path = gbl.Cpp.GetIncludePaths()
+    return path.split(":")
+
 def add_library_path(path):
     """Add a path to the library search paths available to Cling."""
     if not os.path.isdir(path):
```

We can get the include paths in Python
```python
>>> import cppyy
>>> print(*cppyy.get_include_path(), sep="\n")
.
/home/vipul/Workspace/c/llvm-project/llvm/include
/home/vipul/Workspace/c/llvm-project/clang/include
/home/vipul/Workspace/c/llvm-project/build/include
/home/vipul/Workspace/c/llvm-project/build/tools/clang/include
/usr/lib/gcc/x86_64-redhat-linux/14/../../../../include/c++/14
/usr/lib/gcc/x86_64-redhat-linux/14/../../../../include/c++/14/x86_64-redhat-linux
/usr/lib/gcc/x86_64-redhat-linux/14/../../../../include/c++/14/backward
/home/vipul/Workspace/c/llvm-project/build/lib/clang/17/include
/usr/local/include
/usr/lib/gcc/x86_64-redhat-linux/14/../../../../x86_64-redhat-linux/include
/include
/usr/include
/home/vipul/Workspace/c/llvm-project/build/lib/clang/17/../../../../cling-src/tools/cling/include
/home/vipul/Workspace/c/llvm-project/build/lib/clang/17/../../../../cling-src/include
/home/vipul/Workspace/c/llvm-project/build/lib/clang/17/../../..//include
/home/vipul/Workspace/c/cppyy-backend-compiler-research/python/cppyy_backend/include
/home/vipul/micromamba/envs/compiler-research/include/python3.12
/home/vipul/micromamba/envs/compiler-research/lib/python3.12/site-packages/../../../include/python3.12
/home/vipul/micromamba/envs/compiler-research/include
```