### PR TITLE
Remove flag as no undefined symbols found while building for wasm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1344,7 +1344,7 @@ jobs:
                 ../
         fi
         
-        EMCC_CFLAGS='-sERROR_ON_UNDEFINED_SYMBOLS=0' emmake make -j ${{ env.ncpus }}
+        emmake make -j ${{ env.ncpus }}
 
         cd ..
         


### PR DESCRIPTION
As done in https://github.com/emscripten-forge/recipes/pull/1385 there are no undefined symbols coming out of a wasm build for cppinterop and hence this flag (`EMCC_CFLAGS='-sERROR_ON_UNDEFINED_SYMBOLS=0'`) is redundant.