### PR TITLE
Change standard clang format to Cpp14

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,7 +1,7 @@
 BasedOnStyle: LLVM
 
 Language: Cpp
-Standard: Cpp11
+Standard: Cpp14
 PointerAlignment: Left
 
 IncludeCategories:


### PR DESCRIPTION
C++14 is stated as the minimum standard acceptable by roots llvm 13 that we use, so I've updated the clang-format file to reflect this standard.