### PR TITLE
Remove Fortran files from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,10 +16,6 @@
 *.dylib
 *.dll
 
-# Fortran module files
-*.mod
-*.smod
-
 # Compiled Static libraries
 *.lai
 *.la


### PR DESCRIPTION
We do not create any Fortran files during the build process, so seems unneeded to have them in the .gitignore