### PR TITLE
Remove random coverage flags ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,28 +27,24 @@ jobs:
             clang-runtime: '19'
             cling: Off
             cppyy: On
-            coverage: true
           - name: ubu22-x86-gcc12-clang-repl-18
             os: ubuntu-22.04
             compiler: gcc-12
             clang-runtime: '18'
             cling: Off
             cppyy: On
-            coverage: true
           - name: ubu22-x86-gcc12-clang-repl-17
             os: ubuntu-22.04
             compiler: gcc-12
             clang-runtime: '17'
             cling: Off
             cppyy: On
-            coverage: true
           - name: ubu22-x86-gcc12-clang-repl-16
             os: ubuntu-22.04
             compiler: gcc-12
             clang-runtime: '16'
             cling: Off
             cppyy: On
-            coverage: true
           - name: ubu22-x86-gcc9-clang13-cling
             os: ubuntu-22.04
             compiler: gcc-9
@@ -56,7 +52,6 @@ jobs:
             cling: On
             cling-version: '1.0'
             cppyy: On
-            coverage: true
           - name: win2022-msvc-clang-repl-19
             os: windows-2022
             compiler: msvc
@@ -494,7 +489,6 @@ jobs:
             clang-runtime: '18'
             cling: Off
             cppyy: On
-            coverage: true
           - name: ubu22-x86-gcc12-clang-repl-17-cppyy
             os: ubuntu-22.04
             compiler: gcc-12


### PR DESCRIPTION
Coverage was set to try for all llvm cache builds. Didn't do anything to effect results but needs removing. Coverage was set to true for both llvm 18 and llvm 19 builds of CppInterOp. I've removed the true flag from the llvm 18 build so we have consistent coverage report results going forward.