### PR TITLE
Update gtest used to v1.15.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -299,7 +299,11 @@ endif()
 
 # Add appropriate flags for GCC
 if (LLVM_COMPILER_IS_GCC_COMPATIBLE)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-common -Woverloaded-virtual -Wcast-qual -fno-strict-aliasing -pedantic -Wno-long-long -Wall -W -Wno-unused-parameter -Wwrite-strings")
+  if (APPLE)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-common -Woverloaded-virtual -Wcast-qual -fno-strict-aliasing -Wno-long-long -Wall -W -Wno-unused-parameter -Wwrite-strings")
+  else()
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-common -Woverloaded-virtual -Wcast-qual -fno-strict-aliasing -pedantic -Wno-long-long -Wall -W -Wno-unused-parameter -Wwrite-strings")
+  endif ()
 endif ()
 
 # Fixes "C++ exception handler used, but unwind semantics are not enabled" warning Windows

--- a/cmake/modules/GoogleTest.cmake
+++ b/cmake/modules/GoogleTest.cmake
@@ -50,7 +50,6 @@ ExternalProject_Add(
   TIMEOUT 600
   )
 
-
 # Specify include dirs for gtest and gmock
 ExternalProject_Get_Property(googletest source_dir)
 set(GTEST_INCLUDE_DIR ${source_dir}/googletest/include)

--- a/cmake/modules/GoogleTest.cmake
+++ b/cmake/modules/GoogleTest.cmake
@@ -16,7 +16,12 @@ if(WIN32)
     -Dgtest_force_shared_crt=ON
     BUILD_COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR> --config $<CONFIG>)
 elseif(APPLE)
+  #FIXME: Temporarily remove -pedantic from CMAKE_CXX_FLAGS to avoid issues with building
+  #       latest version of gtest on MacOS (use of -Wc++17-attribute-extensions causes 
+  #       issues due to [[maybe_unused]] in gtest)
   set(EXTRA_GTEST_OPTS -DCMAKE_OSX_SYSROOT=${CMAKE_OSX_SYSROOT})
+  set(CMAKE_CXX_FLAGS_TEMP_COPY ${CMAKE_CXX_FLAGS})
+  string(REPLACE "-pedantic" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
 endif()
 
 include(ExternalProject)
@@ -24,7 +29,7 @@ ExternalProject_Add(
   googletest
   GIT_REPOSITORY https://github.com/google/googletest.git
   GIT_SHALLOW 1
-  GIT_TAG release-1.12.1
+  GIT_TAG v1.15.2
   UPDATE_COMMAND ""
   # # Force separate output paths for debug and release builds to allow easy
   # # identification of correct lib in subsequent TARGET_LINK_LIBRARIES commands
@@ -49,6 +54,11 @@ ExternalProject_Add(
   LOG_BUILD ON
   TIMEOUT 600
   )
+
+#FIXME: Related to fixme above which temporarily remodifies CMAKE_CXX_FLAGS
+if(APPLE)
+  set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS_TEMP_COPY})
+endif()
 
 # Specify include dirs for gtest and gmock
 ExternalProject_Get_Property(googletest source_dir)

--- a/cmake/modules/GoogleTest.cmake
+++ b/cmake/modules/GoogleTest.cmake
@@ -16,12 +16,7 @@ if(WIN32)
     -Dgtest_force_shared_crt=ON
     BUILD_COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR> --config $<CONFIG>)
 elseif(APPLE)
-  #FIXME: Temporarily remove -pedantic from CMAKE_CXX_FLAGS to avoid issues with building
-  #       latest version of gtest on MacOS (use of -Wc++17-attribute-extensions causes 
-  #       issues due to [[maybe_unused]] in gtest)
   set(EXTRA_GTEST_OPTS -DCMAKE_OSX_SYSROOT=${CMAKE_OSX_SYSROOT})
-  set(CMAKE_CXX_FLAGS_TEMP_COPY ${CMAKE_CXX_FLAGS})
-  string(REPLACE "-pedantic" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
 endif()
 
 include(ExternalProject)
@@ -55,10 +50,6 @@ ExternalProject_Add(
   TIMEOUT 600
   )
 
-#FIXME: Related to fixme above which temporarily remodifies CMAKE_CXX_FLAGS
-if(APPLE)
-  set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS_TEMP_COPY})
-endif()
 
 # Specify include dirs for gtest and gmock
 ExternalProject_Get_Property(googletest source_dir)


### PR DESCRIPTION
This PR will attempt to update the version of gtest we are using to version 1.15.2 .
Fixes https://github.com/compiler-research/CppInterOp/issues/295