### PR TITLE
Revert back to Cpp11 clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,7 +1,7 @@
 BasedOnStyle: LLVM
 
 Language: Cpp
-Standard: Cpp14
+Standard: Cpp11
 PointerAlignment: Left
 
 IncludeCategories:


### PR DESCRIPTION
The recent PR which change clang format from Cpp11 to Cpp14 failed. Despite what I read online Cpp14 is not being recognised as an option, so I am reverting to the previous standard.