### PR TITLE
Add support for an external interpreter

### DIFF
--- a/include/clang/Interpreter/CppInterOp.h
+++ b/include/clang/Interpreter/CppInterOp.h
@@ -530,6 +530,13 @@ namespace Cpp {
   ///\returns the current interpreter instance, if any.
   CPPINTEROP_API TInterp_t GetInterpreter();
 
+  /// Sets the Interpreter instance with an external interpreter, meant to
+  /// be called by an external library that manages it's own interpreter.
+  /// Sets a flag signifying CppInterOp does not have ownership of the
+  /// sInterpreter.
+  ///\param[in] Args - the pointer to an external interpreter
+  CPPINTEROP_API void UseExternalInterpreter(TInterp_t I);
+
   /// Adds a Search Path for the Interpreter to get the libraries.
   CPPINTEROP_API void AddSearchPath(const char* dir, bool isUser = true,
                                     bool prepend = false);

--- a/unittests/CppInterOp/InterpreterTest.cpp
+++ b/unittests/CppInterOp/InterpreterTest.cpp
@@ -1,6 +1,16 @@
+
 #include "Utils.h"
 
 #include "clang/Interpreter/CppInterOp.h"
+
+#ifdef USE_CLING
+#include "cling/Interpreter/Interpreter.h"
+#endif // USE_CLING
+
+#ifdef USE_REPL
+#include "clang/Interpreter/Interpreter.h"
+#endif // USE_REPL
+
 #include "clang/Basic/Version.h"
 
 #include "llvm/ADT/SmallString.h"
@@ -160,5 +170,43 @@ TEST(InterpreterTest, CodeCompletion) {
   EXPECT_EQ(2U, cnt); // float and foo
 #else
   GTEST_SKIP();
+#endif
+}
+
+TEST(InterpreterTest, ExternalInterpreterTest) {
+
+#ifdef USE_REPL
+  llvm::ExitOnError ExitOnErr;
+  clang::IncrementalCompilerBuilder CB;
+  CB.SetCompilerArgs({"-std=c++20"});
+
+  // Create the incremental compiler instance.
+  std::unique_ptr<clang::CompilerInstance> CI;
+  CI = ExitOnErr(CB.CreateCpp());
+
+  // Create the interpreter instance.
+  std::unique_ptr<clang::Interpreter> I =
+      ExitOnErr(clang::Interpreter::create(std::move(CI)));
+  auto ExtInterp = I.get();
+#endif
+
+#ifdef USE_CLING
+    std::string MainExecutableName = sys::fs::getMainExecutable(nullptr, nullptr);
+    std::string ResourceDir = compat::MakeResourceDir(LLVM_BINARY_DIR);
+    std::vector<const char *> ClingArgv = {"-resource-dir", ResourceDir.c_str(),
+                                           "-std=c++14"};
+    ClingArgv.insert(ClingArgv.begin(), MainExecutableName.c_str());
+    auto *ExtInterp = new compat::Interpreter(ClingArgv.size(), &ClingArgv[0]);
+#endif
+
+  EXPECT_NE(ExtInterp, nullptr);
+  Cpp::UseExternalInterpreter(ExtInterp);
+  EXPECT_TRUE(Cpp::GetInterpreter()) << "External Interpreter not set";
+
+#ifdef USE_REPL
+  I.release();
+#endif
+#ifdef USE_CLING
+  delete ExtInterp;
 #endif
 }


### PR DESCRIPTION
The new interface can be called by an external library like ROOT, that manages it's own `TInterpreter` instance. In this case the `cling::Interpreter*` initialized by TCling is passed to InterOp and a flag indicates that InterOp does not have ownership