### PR TITLE
Remove unxip ci osx

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -315,6 +315,7 @@ jobs:
       run: |
         brew update
         brew remove ruby@3.0
+        brew remove unxip
         # workaround for https://github.com/actions/setup-python/issues/577
         for pkg in $(brew list | grep '^python@'); do
           brew unlink "$pkg"
@@ -769,6 +770,7 @@ jobs:
       run: |
         brew update
         brew remove ruby@3.0
+        brew remove unxip
         export ARCHITECHURE=$(uname -m)
         if [[ "$ARCHITECHURE" == "x86_64" ]]; then
           brew remove swiftlint


### PR DESCRIPTION
Currently the osx jobs in the ci are failing due to full Xcode requirement for unxip (see https://github.com/compiler-research/CppInterOp/actions/runs/11645652818/job/32429107514#step:12:175). This package description to me suggests this package is not needed https://formulae.brew.sh/formula/unxip . This PR remove unxip hopefully fixing the issue.