### PR TITLE
[ci] No longer run cppyy with clang-repl16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -496,12 +496,12 @@ jobs:
             clang-runtime: '17'
             cling: Off
             cppyy: On
-          - name: ubu22-x86-gcc12-clang-repl-16-cppyy
+          - name: ubu22-x86-gcc12-clang-repl-16
             os: ubuntu-22.04
             compiler: gcc-12
             clang-runtime: '16'
             cling: Off
-            cppyy: On
+            cppyy: Off
           - name: ubu22-x86-gcc9-clang13-cling-cppyy
             os: ubuntu-22.04
             compiler: gcc-9


### PR DESCRIPTION
This is due to the recently enabled test on cppyy that crashes on clang 16 and passes with clang >=17