### PR TITLE
Stale issue and PR workflow

### DIFF
--- a/.github/workflows/stale-pr-and-issues.yml
+++ b/.github/workflows/stale-pr-and-issues.yml
@@ -1,0 +1,25 @@
+name: Close inactive issues
+on:
+  schedule:
+    - cron: "30 1 * * *"
+
+jobs:
+  close-issues:
+    runs-on: ubuntu-22.04
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-issue-stale: 90
+          days-before-issue-close: 14
+          stale-issue-label: "stale"
+          stale-issue-message: "This issue is stale because it has been open for 90 days with no activity."
+          close-issue-message: "This issue was closed because it has been inactive for 14 days since being marked as stale."
+          days-before-pr-stale: 90
+          days-before-pr-close: 14
+          stale-issue-label: "stale"
+          stale-issue-message: "This PR is stale because it has been open for 90 days with no activity."
+          close-issue-message: "This PR was closed because it has been inactive for 14 days since being marked as stale."
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR makes it so issues and PRs which have had no activity for 90 days will be marked as stale, and will be closed 14 days after that if no further activity.