### PR TITLE
Minimal example of a bug from cppyy

### DIFF
--- a/unittests/CppInterOp/VariableReflectionTest.cpp
+++ b/unittests/CppInterOp/VariableReflectionTest.cpp
@@ -139,6 +139,39 @@ TEST(VariableReflectionTest, DatamembersWithAnonymousStructOrUnion) {
 #endif
 }
 
+TEST(VariableReflectionTest, GetTypeAsString) {
+  if (llvm::sys::RunningOnValgrind())
+    GTEST_SKIP() << "XFAIL due to Valgrind report";
+
+  std::string code = R"(
+  namespace my_namespace {
+  
+  struct Container {
+    int value;
+  };
+  
+  struct Wrapper {
+    Container item;
+  };
+
+  }
+  )";
+
+  Cpp::CreateInterpreter();
+  EXPECT_EQ(Cpp::Declare(code.c_str()), 0);
+
+  Cpp::TCppScope_t wrapper =
+      Cpp::GetScopeFromCompleteName("my_namespace::Wrapper");
+  EXPECT_TRUE(wrapper);
+
+  std::vector<Cpp::TCppScope_t> datamembers;
+  Cpp::GetDatamembers(wrapper, datamembers);
+  EXPECT_EQ(datamembers.size(), 1);
+
+  EXPECT_EQ(Cpp::GetTypeAsString(Cpp::GetVariableType(datamembers[0])),
+            "my_namespace::Container");
+}
+
 TEST(VariableReflectionTest, LookupDatamember) {
   std::vector<Decl*> Decls;
   std::string code = R"(


### PR DESCRIPTION
That needs to be fixed at CppInterOp
reference: look at comments at compiler-research/cppyy-backend#116

---

I have written a test case that is a minimal example of a failing test at cppyy (suspected).
I am not sure how to fix this. More experienced people here could take a look at it.