### PR TITLE
Add exemptions to stale-pr-and-issues.yml

### DIFF
--- a/.github/workflows/stale-pr-and-issues.yml
+++ b/.github/workflows/stale-pr-and-issues.yml
@@ -1,4 +1,4 @@
-name: Close inactive issues
+name: Close inactive issues and PRs
 on:
   schedule:
     - cron: "30 1 * * *"
@@ -17,9 +17,11 @@ jobs:
           stale-issue-label: "stale"
           stale-issue-message: "This issue is stale because it has been open for 90 days with no activity."
           close-issue-message: "This issue was closed because it has been inactive for 14 days since being marked as stale."
+          exempt-issue-labels: 'to-fix'
           days-before-pr-stale: 90
           days-before-pr-close: 14
           stale-pr-label: "stale"
           stale-pr-message: "This PR is stale because it has been open for 90 days with no activity."
           close-pr-message: "This PR was closed because it has been inactive for 14 days since being marked as stale."
+          exempt-pr-labels: 'awaiting-approval,work-in-progress'
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
@vgvassilev @aaronj0  You may have noticed that a large number of issues got labelled as stale yesterday (PRs will eventually be labelled this too). This PR will add exemptions to the state issue and PR workflow. If you do not want an issue to be labelled as stale, and eventually closed if inactive, then add the 'to-fix' label to the issue. If you want a PR to be made exempt then you should add the 'awaiting-approval' or 'work-in-progress' label to the PR. After merging this PR it may be worth going through out list of issues and PRs and relabelling accordingly.