### PR TITLE
Build target sphinx-cppinterop in ci docs job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -898,6 +898,7 @@ jobs:
         docs_on=$(echo "${{ matrix.documentation }}" | tr '[:lower:]' '[:upper:]')
         if [[ "${docs_on}" == "ON" ]]; then
           cmake --build . --target doxygen-cppinterop --parallel ${{ env.ncpus }}
+          cmake --build . --target sphinx-cppinterop --parallel ${{ env.ncpus }}
         else
           cmake --build . --target check-cppinterop --parallel ${{ env.ncpus }}
           if [[ ("${os}" == "ubuntu"*) ]]; then


### PR DESCRIPTION
When adding the docs jobs in the ci the other day it was forgotten that we need to build the target sphinx-cppinterop too. This PR fixes that.