### PR TITLE
Revert changes to https://github.com/compiler-research/CppInterOp/pull/372

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,12 +5,12 @@ sphinx:
   builder: html
 
 build:
-  os: "ubuntu-24.04"
+  os: "ubuntu-22.04"
   tools:
     python: "3.11"
   apt_packages:
-    - clang-18
+    - clang-13
     - cmake
-    - libclang-18-dev
-    - llvm-18-dev
-    - llvm-18-tools
+    - libclang-13-dev
+    - llvm-13-dev
+    - llvm-13-tools

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,8 +50,8 @@ CPPINTEROP_ROOT = os.path.abspath('..')
 html_extra_path = [CPPINTEROP_ROOT + '/build/docs/']
 
 import subprocess
-command = 'mkdir {0}/build; cd {0}/build; cmake ../ -DClang_DIR=/usr/lib/llvm-18/lib/cmake/clang \
-         -DLLVM_DIR=/usr/lib/llvm-18/lib/cmake/llvm -DCPPINTEROP_ENABLE_DOXYGEN=ON \
+command = 'mkdir {0}/build; cd {0}/build; cmake ../ -DClang_DIR=/usr/lib/llvm-13/build/lib/cmake/clang\
+         -DLLVM_DIR=/usr/lib/llvm-13/build/lib/cmake/llvm -DCPPINTEROP_ENABLE_DOXYGEN=ON\
          -DCPPINTEROP_INCLUDE_DOCS=ON'.format(CPPINTEROP_ROOT)
 subprocess.call(command, shell=True)
 subprocess.call('doxygen {0}/build/docs/doxygen.cfg'.format(CPPINTEROP_ROOT), shell=True)


### PR DESCRIPTION
@vgvassilev This PR reverts the changes to https://github.com/compiler-research/CppInterOp/pull/372 which were controlling the build process in the hopes of fixing the readthedocs.