### PR TITLE
Increase operations-per-run in stale-pr-and-issues.yml to 90 so more issues and PRs get processed

### DIFF
--- a/.github/workflows/stale-pr-and-issues.yml
+++ b/.github/workflows/stale-pr-and-issues.yml
@@ -24,4 +24,5 @@ jobs:
           stale-pr-message: "This PR is stale because it has been open for 90 days with no activity."
           close-pr-message: "This PR was closed because it has been inactive for 14 days since being marked as stale."
           exempt-pr-labels: 'awaiting-approval,work-in-progress'
+          operations-per-run: 90
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

Currently the stale pr and issues workflow doesn't process all our issues and PRs due to operations-per-run being 30 by default. I have tripled this so that all our issues and PRs should be processed the next time this workflow runs.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [x] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [x] I have read the contribution guide recently
