### PR TITLE
Fix git clang workflow os to Ubuntu 22.04

### DIFF
--- a/.github/workflows/clang-tidy-review-post.yml
+++ b/.github/workflows/clang-tidy-review-post.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Post review comments

--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   review:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout PR branch
         uses: actions/checkout@v4


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

The git clang workflow currently has a warning to see that soon the ubuntu-latest runners will default to Ubuntu 24.04 .  To stop this I have fixed the version to Ubuntu 22.04 . This workflow will soon be replaced due to the workflow known to be fragile.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [x] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [x] I have read the contribution guide recently
