### PR TITLE
Fixes read the docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,7 +50,7 @@ CPPINTEROP_ROOT = os.path.abspath('..')
 html_extra_path = [CPPINTEROP_ROOT + '/build/docs/']
 
 import subprocess
-command = 'mkdir {0}/build; cd {0}/build; cmake ../ -DClang_DIR=/usr/lib/llvm-13/build/lib/cmake/clang\
+command = 'mkdir {0}/build; cd {0}/build; cmake ../  -DUSE_CLING=Off -DUSE_REPL=ON -DClang_DIR=/usr/lib/llvm-13/build/lib/cmake/clang\
          -DLLVM_DIR=/usr/lib/llvm-13/build/lib/cmake/llvm -DCPPINTEROP_ENABLE_DOXYGEN=ON\
          -DCPPINTEROP_INCLUDE_DOCS=ON'.format(CPPINTEROP_ROOT)
 subprocess.call(command, shell=True)


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

@vgvassilev This PR will fix the read the docs giving us the developer documentation again. The other day I was fixing the deployment blind as I didn't know about the build logs. Here it is for the most recent build https://readthedocs.org/projects/cppinterop/builds/26507232/  . By expanding the `python -m sphinx -T -b html -d _build/doctrees -D language=en . $READTHEDOCS_OUTPUT/html` command you see we fail due to the following error 
```
CMake Error at CMakeLists.txt:238 (message):
  We need either USE_CLING or USE_REPL
```
This PR will fix that by defining that we want to use the repl when building the docs. The build logs explain why we still get some of the documentation, see
```
writing output... [ 14%] DevelopersDocumentation
writing output... [ 29%] FAQ
writing output... [ 43%] InstallationAndUsage
writing output... [ 57%] UsingCppInterOp
writing output... [ 71%] index
writing output... [ 86%] reference
writing output... [100%] tutorials
```

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [x] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [x] I have read the contribution guide recently
