### PR TITLE
Fix issues with DLM tests

### DIFF
--- a/unittests/CppInterOp/CMakeLists.txt
+++ b/unittests/CppInterOp/CMakeLists.txt
@@ -37,7 +37,7 @@ target_link_libraries(DynamicLibraryManagerTests
   clangCppInterOp
   )
 
-set_output_directory(DynamicLibraryManagerTests BINARY_DIR ${CMAKE_BINARY_DIR}/unittests/bin/$<CONFIG>/)
+set_output_directory(DynamicLibraryManagerTests BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/TestSharedLib/unittests/bin/$<CONFIG>/)
 
 add_dependencies(DynamicLibraryManagerTests TestSharedLib)
 #export_executable_symbols_for_plugins(TestSharedLib)

--- a/unittests/CppInterOp/TestSharedLib/CMakeLists.txt
+++ b/unittests/CppInterOp/TestSharedLib/CMakeLists.txt
@@ -5,7 +5,7 @@ add_llvm_library(TestSharedLib
   TestSharedLib.cpp)
 # Put TestSharedLib next to the unit test executable.
 set_output_directory(TestSharedLib
-  BINARY_DIR ${CMAKE_BINARY_DIR}/unittests/bin/$<CONFIG>/
-  LIBRARY_DIR ${CMAKE_BINARY_DIR}/unittests/bin/$<CONFIG>/
+  BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/unittests/bin/$<CONFIG>/
+  LIBRARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/unittests/bin/$<CONFIG>/
   )
 set_target_properties(TestSharedLib PROPERTIES FOLDER "Tests")

--- a/unittests/CppInterOp/TestSharedLib/TestSharedLib.h
+++ b/unittests/CppInterOp/TestSharedLib/TestSharedLib.h
@@ -5,7 +5,7 @@
 #ifdef _WIN32
 extern "C" __declspec(dllexport) int ret_zero();
 #else
-extern "C" int ret_zero();
+extern "C" int __attribute__((visibility("default"))) ret_zero();
 #endif
 
 #endif // UNITTESTS_CPPINTEROP_TESTSHAREDLIB_TESTSHAREDLIB_H


### PR DESCRIPTION
Fixes issues with how the DLM tests are built in ROOT, and forces the symbol to be exported in Release mode

