### PR TITLE
fix `GetVariableOffset` in cases of multi-level and multiple inheritance

### DIFF
--- a/include/clang/Interpreter/CppInterOp.h
+++ b/include/clang/Interpreter/CppInterOp.h
@@ -446,7 +446,8 @@ namespace Cpp {
 
   /// Gets the address of the variable, you can use it to get the
   /// value stored in the variable.
-  CPPINTEROP_API intptr_t GetVariableOffset(TCppScope_t var);
+  CPPINTEROP_API intptr_t GetVariableOffset(TCppScope_t var,
+                                            TCppScope_t parent = nullptr);
 
   /// Checks if the provided variable is a 'Public' variable.
   CPPINTEROP_API bool IsPublicVariable(TCppScope_t var);


### PR DESCRIPTION
# Description

Fixes the calculation of data member offsets of a class C. Where C inherits from multiple classes and these classes themselves inherit from other classes.

## Fixes # (issue)

I found this issue when tinkering with cross-inheritance in cppyy.
It looks like upstream cppyy also faces a similar problem. Opened a PR stating the issue at https://github.com/wlav/cppyy/issues/280.

> Does not contribute to test cases that pass in cppyy.

## Type of change

Please tick all options which are relevant.

- [x] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Added in tests with multi-level and multiple inheritance.

## Checklist

- [x] I have read the contribution guide recently
