### PR TITLE
disable unnecessery clang-tidy checks in unittests

### DIFF
--- a/unittests/.clang-tidy
+++ b/unittests/.clang-tidy
@@ -1,0 +1,8 @@
+Checks: >
+  -misc-use-internal-linkage,
+  -modernize-pass-by-value,
+  -cppcoreguidelines-macro-usage,
+  -cppcoreguidelines-pro-type-cstyle-cast,
+  -cppcoreguidelines-avoid-non-const-global-variables,
+  -performance-unnecessary-value-param,
+  -performance-no-int-to-ptr,


### PR DESCRIPTION
# Description

disable unnecessery clang-tidy checks in unittests

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [ ] I have read the contribution guide recently
