### PR TITLE
fix `MakeFunctionCallable` for dealing with public typedef to private type

### DIFF
--- a/lib/Interpreter/CppInterOp.cpp
+++ b/lib/Interpreter/CppInterOp.cpp
@@ -1600,7 +1600,10 @@ namespace Cpp {
                             PrintingPolicy Policy) {
       //TODO: Implement cling desugaring from utils::AST
       //      cling::utils::Transform::GetPartiallyDesugaredType()
-      QT = QT.getDesugaredType(C);
+      if (!QT->isTypedefNameType() || QT->isBuiltinType())
+        QT = QT.getDesugaredType(C);
+      Policy.SuppressElaboration = true;
+      Policy.FullyQualifiedName = true;
       QT.getAsStringInternal(type_name, Policy);
     }
 
@@ -1652,13 +1655,13 @@ namespace Cpp {
         return;
       } else if (QT->isPointerType()) {
         isPointer = true;
-        QT = cast<clang::PointerType>(QT)->getPointeeType();
+        QT = cast<clang::PointerType>(QT.getCanonicalType())->getPointeeType();
       } else if (QT->isReferenceType()) {
         if (QT->isRValueReferenceType())
           refType = kRValueReference;
         else
           refType = kLValueReference;
-        QT = cast<ReferenceType>(QT)->getPointeeType();
+        QT = cast<ReferenceType>(QT.getCanonicalType())->getPointeeType();
       }
       // Fall through for the array type to deal with reference/pointer ro array
       // type.
@@ -1911,7 +1914,7 @@ namespace Cpp {
         make_narg_ctor_with_return(FD, N, class_name, buf, indent_level);
         return;
       }
-      QualType QT = FD->getReturnType().getCanonicalType();
+      QualType QT = FD->getReturnType();
       if (QT->isVoidType()) {
         std::ostringstream typedefbuf;
         std::ostringstream callbuf;

--- a/unittests/CppInterOp/FunctionReflectionTest.cpp
+++ b/unittests/CppInterOp/FunctionReflectionTest.cpp
@@ -974,6 +974,35 @@ TEST(FunctionReflectionTest, GetFunctionCallWrapper) {
 
   FCI_Add.Invoke(&result, {args, /*args_size=*/2});
   EXPECT_EQ(result, a + b);
+
+  // typedef resolution testing
+  Interp->process(R"(
+  class TypedefToPrivateClass {
+  private:
+    class PC {
+    public:
+      int m_val = 4;
+    };
+
+  public:
+    typedef PC PP;
+    static PP f() { return PC(); }
+  };
+  )");
+
+  Cpp::TCppScope_t TypedefToPrivateClass =
+      Cpp::GetNamed("TypedefToPrivateClass");
+  EXPECT_TRUE(TypedefToPrivateClass);
+
+  Cpp::TCppScope_t f = Cpp::GetNamed("f", TypedefToPrivateClass);
+  EXPECT_TRUE(f);
+
+  Cpp::JitCall FCI_f = Cpp::MakeFunctionCallable(f);
+  EXPECT_TRUE(FCI_f.getKind() == Cpp::JitCall::kGenericCall);
+
+  void* res = nullptr;
+  FCI_f.Invoke(&res, {nullptr, 0});
+  EXPECT_TRUE(res);
 }
 
 TEST(FunctionReflectionTest, IsConstMethod) {


### PR DESCRIPTION
# Description

Fixes `MakeFunctionCallable`'s `make_wrapper`'s code generation for the situation where a public typedef is used to point to a private type.

## Fixes # (issue)

`test24_typedef_to_private_class` at cppyy.

## Type of change

Please tick all options which are relevant.

- [x] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Added in a test case replicating the cppyy's test.

## Checklist

- [x] I have read the contribution guide recently
