### PR TITLE
Add correct options to build xeus-cpp-lite deployment correctly

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -92,7 +92,7 @@ jobs:
       shell: bash -l {0}
       run: |
         ./emsdk/emsdk activate ${{matrix.emsdk_ver}}
-         source ./emsdk/emsdk_env.sh
+        source ./emsdk/emsdk_env.sh
         micromamba create -f environment-wasm.yml --platform=emscripten-wasm32
 
         export PREFIX=$MAMBA_ROOT_PREFIX/envs/CppInterOp-wasm
@@ -142,7 +142,7 @@ jobs:
                 ../
         fi
         
-        emmake make -j ${{ env.ncpus }}
+        emmake make -j ${{ env.ncpus }} install
 
         cd ..
         
@@ -181,12 +181,12 @@ jobs:
       shell: bash -l {0}
       run: |
           cd ./xeus-cpp/
-          micromamba create -n xeus-lite-host jupyterlite-core
+          micromamba create -n xeus-lite-host jupyterlite-core -c conda-forge
           micromamba activate xeus-lite-host
           python -m pip install jupyterlite-xeus
           jupyter lite build --XeusAddon.prefix=${{ env.PREFIX }} --output-dir dist
           cp ${{ env.PREFIX }}/bin/xcpp.data dist/extensions/@jupyterlite/xeus/static
-          cp ${{ env.CPPINTEROP_BUILD_DIR }}/lib/libclangCppInterOp.so dist/extensions/@jupyterlite/xeus/static
+          cp ${{ env.PREFIX }}/lib/libclangCppInterOp.so dist/extensions/@jupyterlite/xeus/static
 
     - name: Upload artifact
       uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -541,7 +541,7 @@ jobs:
       shell: bash -l {0}
       run: |
         ./emsdk/emsdk activate ${{matrix.emsdk_ver}}
-         source ./emsdk/emsdk_env.sh
+        source ./emsdk/emsdk_env.sh
         micromamba create -f environment-wasm.yml --platform=emscripten-wasm32
 
         export PREFIX=$MAMBA_ROOT_PREFIX/envs/CppInterOp-wasm
@@ -590,7 +590,7 @@ jobs:
                 ../
         fi
         
-        emmake make -j ${{ env.ncpus }}
+        emmake make -j ${{ env.ncpus }} install
 
         cd ..
         
@@ -623,4 +623,4 @@ jobs:
           -DCppInterOp_DIR="${{ env.CPPINTEROP_BUILD_DIR }}/lib/cmake/CppInterOp"  \
           -DSYSROOT_PATH=$SYSROOT_PATH                      \
           ..
-        emmake make -j ${{ env.ncpus }}
+        emmake make -j ${{ env.ncpus }} install

--- a/lib/Interpreter/CMakeLists.txt
+++ b/lib/Interpreter/CMakeLists.txt
@@ -17,6 +17,9 @@ if(EMSCRIPTEN)
     LINK_LIBS
     clangInterpreter
   )
+  target_link_options(clangCppInterOp PRIVATE
+    PUBLIC "SHELL: -s WASM_BIGINT"
+  )
 else()
   set(LLVM_LINK_COMPONENTS
     ${LLVM_TARGETS_TO_BUILD}


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

This PR should fix the emscripten build in the ci. The new llvm options may not be necessary. They are just used in emscripten-forge so I decided to add here for consistency. The LDFLAGS definitions are needed otherwise the CppInterOp shared library is not built correctly. I have cleared the cache of one build to check I have not broken the build there. Once it passes this PR should be ready for merging.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [x] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [x] I have read the contribution guide recently
