### PR TITLE
Use Ninja to build llvm in the ci (osx and Ubuntu)

### DIFF
--- a/.github/workflows/MacOS.yml
+++ b/.github/workflows/MacOS.yml
@@ -206,6 +206,7 @@ jobs:
         done
         brew upgrade openssl >/dev/null 2>&1 
         brew upgrade
+        brew install ninja
 
     - name: Build LLVM/Cling if the cache is invalid
       if: ${{ steps.cache.outputs.cache-hit != 'true' }}
@@ -238,11 +239,12 @@ jobs:
                 -DLLVM_ENABLE_ZSTD=OFF                             \
                 -DLLVM_ENABLE_TERMINFO=OFF                         \
                 -DLLVM_ENABLE_LIBXML2=OFF                          \
+                -G Ninja                                           \
                 ../llvm
-          cmake --build . --target clang --parallel ${{ env.ncpus }}
-          cmake --build . --target cling --parallel ${{ env.ncpus }}
+          ninja clang -j ${{ env.ncpus }}
+          ninja cling -j ${{ env.ncpus }}
           # Now build gtest.a and gtest_main for CppInterOp to run its tests.
-          cmake --build . --target gtest_main --parallel ${{ env.ncpus }}
+          ninja gtest_main -j ${{ env.ncpus }}
         else
           # Apply patches
           llvm_vers=$(echo "${{ matrix.clang-runtime }}" | tr '[:lower:]' '[:upper:]')
@@ -262,9 +264,9 @@ jobs:
                 -DLLVM_ENABLE_ZSTD=OFF                              \
                 -DLLVM_ENABLE_TERMINFO=OFF                          \
                 -DLLVM_ENABLE_LIBXML2=OFF                           \
+                -G Ninja                                            \
                 ../llvm
-          cmake --build . --target clang clang-repl --parallel ${{ env.ncpus }}
-          
+          ninja clang clang-repl -j ${{ env.ncpus }}
         fi
         cd ../
         rm -rf $(find . -maxdepth 1 ! -name "build" ! -name "llvm" ! -name "clang" ! -name ".")

--- a/.github/workflows/Ubuntu.yml
+++ b/.github/workflows/Ubuntu.yml
@@ -140,7 +140,7 @@ jobs:
       run: |
         # Install deps
         sudo apt-get update
-        sudo apt-get install valgrind
+        sudo apt-get install valgrind ninja-build
         sudo apt-get autoremove
         sudo apt-get clean
 
@@ -175,11 +175,12 @@ jobs:
                 -DLLVM_ENABLE_ZSTD=OFF                             \
                 -DLLVM_ENABLE_TERMINFO=OFF                         \
                 -DLLVM_ENABLE_LIBXML2=OFF                          \
+                -G Ninja                                           \
                 ../llvm
-          cmake --build . --target clang --parallel ${{ env.ncpus }}
-          cmake --build . --target cling --parallel ${{ env.ncpus }}
+          ninja clang -j ${{ env.ncpus }}
+          ninja cling -j ${{ env.ncpus }}
           # Now build gtest.a and gtest_main for CppInterOp to run its tests.
-          cmake --build . --target gtest_main --parallel ${{ env.ncpus }}
+          ninja gtest_main -j ${{ env.ncpus }}
         else
           # Apply patches
           llvm_vers=$(echo "${{ matrix.clang-runtime }}" | tr '[:lower:]' '[:upper:]')
@@ -199,9 +200,9 @@ jobs:
                 -DLLVM_ENABLE_ZSTD=OFF                              \
                 -DLLVM_ENABLE_TERMINFO=OFF                          \
                 -DLLVM_ENABLE_LIBXML2=OFF                           \
+                -G Ninja                                            \
                 ../llvm
-          cmake --build . --target clang clang-repl --parallel ${{ env.ncpus }}
-          
+          ninja clang clang-repl -j ${{ env.ncpus }}
         fi
         cd ../
         rm -rf $(find . -maxdepth 1 ! -name "build" ! -name "llvm" ! -name "clang" ! -name ".")


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

My local testing on an osx arm Macbook found an 35% reduction in the size of the build folder when using Ninja to build llvm. This should help reduce the pressure on the cache. Supposedly Ninja is faster so we should see a speed in the llvm build when we have to rebuild the cache. If the ci passes then all Ubuntu and MacOS builds should be cleared from the cache before merging.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [x] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [x] I have read the contribution guide recently
