### PR TITLE
Export __clang_Interpreter_SetValueNoAlloc to allow automatic printf in xeus-cpp-lite

### DIFF
--- a/lib/Interpreter/CMakeLists.txt
+++ b/lib/Interpreter/CMakeLists.txt
@@ -19,6 +19,7 @@ if(EMSCRIPTEN)
   )
   target_link_options(clangCppInterOp PRIVATE
     PUBLIC "SHELL: -s WASM_BIGINT"
+    PUBLIC "SHELL: -Wl,--export=__clang_Interpreter_SetValueNoAlloc"
   )
 else()
   set(LLVM_LINK_COMPONENTS


### PR DESCRIPTION
# Description

Check 
1) https://github.com/emscripten-forge/recipes/pull/1515
2) https://github.com/compiler-research/xeus-cpp/issues/202
3) https://github.com/compiler-research/xeus-cpp/pull/203

## Type of change

Please tick all options which are relevant.

- [x] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [x] I have read the contribution guide recently
