### PR TITLE
Add example notebooks to deployment

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -183,8 +183,8 @@ jobs:
           cd ./xeus-cpp/
           micromamba create -n xeus-lite-host jupyterlite-core -c conda-forge
           micromamba activate xeus-lite-host
-          python -m pip install jupyterlite-xeus
-          jupyter lite build --XeusAddon.prefix=${{ env.PREFIX }} --output-dir dist
+          python -m pip install jupyterlite-xeus jupyter_server
+          jupyter lite build --XeusAddon.prefix=${{ env.PREFIX }} --contents notebooks --output-dir dist
           cp ${{ env.PREFIX }}/bin/xcpp.data dist/extensions/@jupyterlite/xeus/static
           cp ${{ env.PREFIX }}/lib/libclangCppInterOp.so dist/extensions/@jupyterlite/xeus/static
 


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

There is a known bug in Jupyter Lite where is jupyter_server is not installed then the contents flag doesn't work to upload files (see https://github.com/jupyterlite/jupyterlite/issues/1453). This PR adds this dependency to fix that so we can upload the example notebook (not everything in the notebook works).

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [x] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [x] I have read the contribution guide recently
