### PR TITLE
Upgrade Windows ci runners to Windows 2025

### DIFF
--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -21,24 +21,24 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: win2022-msvc-clang-repl-19
-            os: windows-2022
+          - name: win2025-msvc-clang-repl-19
+            os: windows-2025
             compiler: msvc
             clang-runtime: '19'
             cling: Off
             cppyy: Off
             llvm_enable_projects: "clang"
             llvm_targets_to_build: "host;NVPTX"
-          - name: win2022-msvc-clang-repl-18
-            os: windows-2022
+          - name: win2025-msvc-clang-repl-18
+            os: windows-2025
             compiler: msvc
             clang-runtime: '18'
             cling: Off
             cppyy: Off
             llvm_enable_projects: "clang"
             llvm_targets_to_build: "host;NVPTX"
-          - name: win2022-msvc-clang-repl-17
-            os: windows-2022
+          - name: win2025-msvc-clang-repl-17
+            os: windows-2025
             compiler: msvc
             clang-runtime: '17'
             cling: Off


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

Recently Github made Windows 2025 runners available. This updates the ci to use them.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [x] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [x] I have read the contribution guide recently
