### PR TITLE
Fix Windows 2025 ci

### DIFF
--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -241,20 +241,20 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: win2022-msvc-clang-repl-19
-            os: windows-2022
+          - name: win2025-msvc-clang-repl-19
+            os: windows-2025
             compiler: msvc
             clang-runtime: '19'
             cling: Off
             cppyy: Off
-          - name: win2022-msvc-clang-repl-18
-            os: windows-2022
+          - name: win2025-msvc-clang-repl-18
+            os: windows-2025
             compiler: msvc
             clang-runtime: '18'
             cling: Off
             cppyy: Off
-          - name: win2022-msvc-clang-repl-17
-            os: windows-2022
+          - name: win2025-msvc-clang-repl-17
+            os: windows-2025
             compiler: msvc
             clang-runtime: '17'
             cling: Off


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

I made a mistake in https://github.com/compiler-research/CppInterOp/pull/429 and forget to update all the Windows jobs to 2025. This didn't show up until it was merged into main.  This PR will fix that. Once the PR passes in this PR I will merge to fix the broken main branch Windows ci.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [x] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [x] I have read the contribution guide recently
