### PR TITLE
Switch deploy runner to MacOS

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -19,9 +19,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: ubu22-x86-gcc12-clang-repl-19-emscripten_wasm
-            os: ubuntu-22.04
-            compiler: gcc-12
+          - name: osx15-arm-clang-clang-repl-19-emscripten_wasm
+            os: macos-15
+            compiler: clang
             clang-runtime: '19'
             cling: Off
             micromamba_shell_init: bash


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

The MacOS 15 runner is around 5 minutes faster than the Ubuntu one at emscripten builds, so switching the runner we use to MacOS so we get faster new deployments.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [x] I have read the contribution guide recently
