### PR TITLE
Use Ninja for emscripten build of llvm

### DIFF
--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -253,6 +253,7 @@ jobs:
           brew link --overwrite "$pkg"
         done
         brew upgrade openssl >/dev/null 2>&1 
+        brew install ninja
         brew upgrade
 
     - name: Install deps on Linux
@@ -260,7 +261,7 @@ jobs:
       run: |
         # Install deps
         sudo apt-get update
-        sudo apt-get install valgrind
+        sudo apt-get install valgrind ninja-build
         sudo apt-get autoremove
         sudo apt-get clean
 
@@ -302,11 +303,9 @@ jobs:
                         -DLLVM_INCLUDE_EXAMPLES=OFF                     \
                         -DLLVM_INCLUDE_TESTS=OFF                        \
                         -DLLVM_ENABLE_THREADS=OFF                       \
+                        -G Ninja                                         \
                          ../llvm
-          emmake make clang -j ${{ env.ncpus }}
-          emmake make  cling -j ${{ env.ncpus }}
-          # Now build gtest.a and gtest_main for CppInterOp to run its tests.
-          emmake make gtest_main -j ${{ env.ncpus }}
+          emmake ninja clang cling lld gtest_main -j ${{ env.ncpus }}
         else
           # Apply patches
           llvm_vers=$(echo "${{ matrix.clang-runtime }}" | tr '[:lower:]' '[:upper:]')
@@ -331,10 +330,9 @@ jobs:
                         -DLLVM_INCLUDE_EXAMPLES=OFF                     \
                         -DLLVM_INCLUDE_TESTS=OFF                        \
                         -DLLVM_ENABLE_THREADS=OFF                       \
+                        -G Ninja                                         \
                         ../llvm
-          emmake make clang -j ${{ env.ncpus }}
-          emmake make clang-repl -j ${{ env.ncpus }}
-          emmake make lld -j ${{ env.ncpus }}
+          emmake ninja clang clang-repl lld -j ${{ env.ncpus }}
         fi
         cd ../..
 


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

emsdk supports Ninja builds, so this PR switches the ci over the Ninja for hopefully smaller and faster emscripten llvm builds. I have cleared the cache of emscripten llvm builds to check I haven't broken anything. Once the ci passes this PR should be ok to merge.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [x] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [x] I have read the contribution guide recently
