### PR TITLE
Install libarchive-c to remove warning when building jupyter lite deployment

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -183,7 +183,7 @@ jobs:
           cd ./xeus-cpp/
           micromamba create -n xeus-lite-host jupyterlite-core -c conda-forge
           micromamba activate xeus-lite-host
-          python -m pip install jupyterlite-xeus jupyter_server notebook
+          python -m pip install jupyterlite-xeus jupyter_server notebook libarchive-c
           jupyter lite build --XeusAddon.prefix=${{ env.PREFIX }} --contents notebooks/xeus-cpp-lite-demo.ipynb --output-dir dist
           cp ${{ env.PREFIX }}/bin/xcpp.data dist/extensions/@jupyterlite/xeus/static
           cp ${{ env.PREFIX }}/lib/libclangCppInterOp.so dist/extensions/@jupyterlite/xeus/static


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

This PR should fix the warning we are currently getting when we build pur deployment about not having linarchive c

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [x] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [x] I have read the contribution guide recently
