### PR TITLE
Add instructions so users can add notebooks to Jupyter lite deployments

### DIFF
--- a/Emscripten-build-instructions.md
+++ b/Emscripten-build-instructions.md
@@ -149,8 +149,8 @@ To build Jupyter Lite website with this kernel locally that you can use for test
 cd ../..
 micromamba create -n xeus-lite-host jupyterlite-core -c conda-forge
 micromamba activate xeus-lite-host
-python -m pip install jupyterlite-xeus
-jupyter lite build --XeusAddon.prefix=$PREFIX
+python -m pip install jupyterlite-xeus jupyter_server
+jupyter lite build --XeusAddon.prefix=$PREFIX --contents xeus-cpp/notebooks/xeus-cpp-lite-demo.ipynb
 ```
 
 We now need to shift necessary files like `xcpp.data` which contains the binary representation of the file(s)  


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

Thie PR updates Emscripten-build-instructions.md to include instructions so user can add own notebooks to own deployments

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [ ] New feature
- [x] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [x] I have read the contribution guide recently
