### PR TITLE
Restrict the use of `_s` (Annex K) functions to MSVC

### DIFF
--- a/lib/Interpreter/Compatibility.h
+++ b/lib/Interpreter/Compatibility.h
@@ -10,7 +10,7 @@
 #include "clang/Basic/Version.h"
 #include "clang/Config/config.h"
 
-#ifdef _WIN32
+#ifdef _MSC_VER
 #define dup _dup
 #define dup2 _dup2
 #define close _close
@@ -18,7 +18,7 @@
 #endif
 
 static inline char* GetEnv(const char* Var_Name) {
-#ifdef _WIN32
+#ifdef _MSC_VER
   char* Env = nullptr;
   size_t sz = 0;
   getenv_s(&sz, Env, sz, Var_Name);

--- a/lib/Interpreter/CppInterOp.cpp
+++ b/lib/Interpreter/CppInterOp.cpp
@@ -3414,7 +3414,7 @@ namespace Cpp {
     int m_DupFD = -1;
 
   public:
-#ifdef _WIN32
+#ifdef _MSC_VER
     StreamCaptureInfo(int FD)
         : m_TempFile(
               []() {


### PR DESCRIPTION
These `_s` secure functions are introduced in C11 as optional bounds-checking interfaces, there is no guarantee that they are implemented/enabled by other compilers.