### PR TITLE
Remove valgrind install emscripten.yml

### DIFF
--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -260,7 +260,6 @@ jobs:
       run: |
         # Install deps
         sudo apt-get update
-        sudo apt-get install valgrind
         sudo apt-get autoremove
         sudo apt-get clean
 


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

When doing the emscripten llvm build in the ci we have a random valgrind install as a dependency. This can be removed.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [x] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [x] I have read the contribution guide recently
