### PR TITLE
Move enable language in cmakelist.txt to avoid configure warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,5 @@
 cmake_minimum_required(VERSION 3.13)
 
-include(GNUInstallDirs)
-
 set(CMAKE_MODULE_PATH
   ${CMAKE_MODULE_PATH}
   "${CMAKE_CURRENT_SOURCE_DIR}/cmake"
@@ -58,7 +56,7 @@ if( CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR )
 
 enable_language(CXX)
 set(CMAKE_CXX_EXTENSIONS NO)
-
+include(GNUInstallDirs)
   option(USE_CLING "Use Cling as backend" OFF)
   option(USE_REPL "Use clang-repl as backend" ON)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,16 +1,3 @@
-cmake_minimum_required(VERSION 3.13)
-
-enable_language(CXX)
-set(CMAKE_CXX_EXTENSIONS NO)
-
-include(GNUInstallDirs)
-
-set(CMAKE_MODULE_PATH
-  ${CMAKE_MODULE_PATH}
-  "${CMAKE_CURRENT_SOURCE_DIR}/cmake"
-  "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules"
-  )
-
 # If we are not building as a part of LLVM, build CppInterOp as a standalone
 # project, using LLVM as an external library:
 if( CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR )
@@ -58,6 +45,19 @@ if( CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR )
       set(Clang_DIR ${Cling_DIR})
     endif()
   endif()
+
+cmake_minimum_required(VERSION 3.13)
+
+enable_language(CXX)
+set(CMAKE_CXX_EXTENSIONS NO)
+
+include(GNUInstallDirs)
+
+set(CMAKE_MODULE_PATH
+  ${CMAKE_MODULE_PATH}
+  "${CMAKE_CURRENT_SOURCE_DIR}/cmake"
+  "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules"
+  )
 
   option(USE_CLING "Use Cling as backend" OFF)
   option(USE_REPL "Use clang-repl as backend" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,13 @@
+cmake_minimum_required(VERSION 3.13)
+
+include(GNUInstallDirs)
+
+set(CMAKE_MODULE_PATH
+  ${CMAKE_MODULE_PATH}
+  "${CMAKE_CURRENT_SOURCE_DIR}/cmake"
+  "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules"
+  )
+
 # If we are not building as a part of LLVM, build CppInterOp as a standalone
 # project, using LLVM as an external library:
 if( CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR )
@@ -46,18 +56,8 @@ if( CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR )
     endif()
   endif()
 
-cmake_minimum_required(VERSION 3.13)
-
 enable_language(CXX)
 set(CMAKE_CXX_EXTENSIONS NO)
-
-include(GNUInstallDirs)
-
-set(CMAKE_MODULE_PATH
-  ${CMAKE_MODULE_PATH}
-  "${CMAKE_CURRENT_SOURCE_DIR}/cmake"
-  "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules"
-  )
 
   option(USE_CLING "Use Cling as backend" OFF)
   option(USE_REPL "Use clang-repl as backend" ON)


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

Currently we get a warning when configuring CppInterOp that we should define the project before using enable language. This PR should fix this issue. See here for the warning this PR should remove https://github.com/compiler-research/CppInterOp/actions/runs/12732612570/job/35488024303#step:10:76

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [x] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [x] I have read the contribution guide recently
