### PR TITLE
Fix warning about ehs and ehc being switch to ehs- and ehc-

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -370,7 +370,7 @@ endif ()
 
 # Fixes "C++ exception handler used, but unwind semantics are not enabled" warning Windows
 if (MSVC)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /EHsc")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /EHsc-")
 endif ()
 
 if (APPLE)


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

I won't know for sure until the ci has run, but the objective of this PR is to fix the warning here https://github.com/compiler-research/CppInterOp/actions/runs/12736900694/job/35497330109#step:8:144 about ehs and ehc being overridden with ehs- and ehc-

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [x] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [x] I have read the contribution guide recently
