### PR TITLE
Remove soname and zdefs flags emscripten build

### DIFF
--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -575,6 +575,7 @@ jobs:
                 -DCODE_COVERAGE=${{ env.CODE_COVERAGE }}        \
                 -DCMAKE_INSTALL_PREFIX=$PREFIX         \
                 -DCMAKE_FIND_ROOT_PATH_MODE_PACKAGE=ON            \
+                -DLLVM_ENABLE_WERROR=On                      \
                 ../
         else
           emcmake cmake -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }}    \
@@ -586,6 +587,7 @@ jobs:
                 -DCODE_COVERAGE=${{ env.CODE_COVERAGE }}    \
                 -DCMAKE_INSTALL_PREFIX=$PREFIX      \
                 -DCMAKE_FIND_ROOT_PATH_MODE_PACKAGE=ON            \
+                -DLLVM_ENABLE_WERROR=On                      \
                 ../
         fi
         

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,5 @@
 cmake_minimum_required(VERSION 3.13)
 
-enable_language(CXX)
-set(CMAKE_CXX_EXTENSIONS NO)
-
-include(GNUInstallDirs)
-
 set(CMAKE_MODULE_PATH
   ${CMAKE_MODULE_PATH}
   "${CMAKE_CURRENT_SOURCE_DIR}/cmake"
@@ -59,6 +54,9 @@ if( CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR )
     endif()
   endif()
 
+enable_language(CXX)
+set(CMAKE_CXX_EXTENSIONS NO)
+include(GNUInstallDirs)
   option(USE_CLING "Use Cling as backend" OFF)
   option(USE_REPL "Use clang-repl as backend" ON)
 

--- a/lib/Interpreter/CMakeLists.txt
+++ b/lib/Interpreter/CMakeLists.txt
@@ -17,6 +17,13 @@ if(EMSCRIPTEN)
     LINK_LIBS
     clangInterpreter
   )
+  #FIXME: This is needed until https://github.com/emscripten-core/emscripten/blob/ac676d5e437525d15df5fd46bc2c208ec6d376a3/cmake/Modules/Platform/Emscripten.cmake#L36
+  # is patched out of emsdk, as --soname is not recognised by emscripten.
+  #FIXME: A patch is needed to llvm to remove -Wl,-z,defs since it is now recognised on emscripten. What needs to be removed is here
+  # https://github.com/llvm/llvm-project/blob/128e2e446e90c3b1827cfc7d4d19e3c0976beff3/llvm/cmake/modules/HandleLLVMOptions.cmake#L318
+  set_target_properties(clangCppInterOp
+  PROPERTIES NO_SONAME 1
+)
   target_link_options(clangCppInterOp PRIVATE
     PUBLIC "SHELL: -s WASM_BIGINT"
   )

--- a/patches/llvm/emscripten-clang19-3-remove-zdefs.patch
+++ b/patches/llvm/emscripten-clang19-3-remove-zdefs.patch
@@ -1,0 +1,22 @@
+diff --git a/llvm/cmake/modules/HandleLLVMOptions.cmake b/llvm/cmake/modules/HandleLLVMOptions.cmake
+index 5ca580fbb..d39b2eb7e 100644
+--- a/llvm/cmake/modules/HandleLLVMOptions.cmake
++++ b/llvm/cmake/modules/HandleLLVMOptions.cmake
+@@ -299,7 +299,7 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "AIX")
+     message(WARNING "Build and install environment path info may be exposed; binaries will also be unrelocatable.")
+   endif()
+ endif()
+-
++#ifndef EMSCRIPTEN
+ # Pass -Wl,-z,defs. This makes sure all symbols are defined. Otherwise a DSO
+ # build might work on ELF but fail on MachO/COFF.
+ if(NOT (CMAKE_SYSTEM_NAME MATCHES "Darwin|FreeBSD|OpenBSD|DragonFly|AIX|OS390" OR
+@@ -307,7 +307,7 @@ if(NOT (CMAKE_SYSTEM_NAME MATCHES "Darwin|FreeBSD|OpenBSD|DragonFly|AIX|OS390" O
+    NOT LLVM_USE_SANITIZER)
+   set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-z,defs")
+ endif()
+-
++#endif
+ # Pass -Wl,-z,nodelete. This makes sure our shared libraries are not unloaded
+ # by dlclose(). We need that since the CLI API relies on cross-references
+ # between global objects which became horribly broken when one of the libraries

--- a/patches/llvm/emscripten-clang19-3-remove-zdefs.patch
+++ b/patches/llvm/emscripten-clang19-3-remove-zdefs.patch
@@ -1,22 +1,13 @@
 diff --git a/llvm/cmake/modules/HandleLLVMOptions.cmake b/llvm/cmake/modules/HandleLLVMOptions.cmake
-index 5ca580fbb..d39b2eb7e 100644
+index 5ca580fbb..cff186b7b 100644
 --- a/llvm/cmake/modules/HandleLLVMOptions.cmake
 +++ b/llvm/cmake/modules/HandleLLVMOptions.cmake
-@@ -299,7 +299,7 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "AIX")
-     message(WARNING "Build and install environment path info may be exposed; binaries will also be unrelocatable.")
-   endif()
- endif()
--
-+#ifndef EMSCRIPTEN
+@@ -302,7 +302,7 @@ endif()
+ 
  # Pass -Wl,-z,defs. This makes sure all symbols are defined. Otherwise a DSO
  # build might work on ELF but fail on MachO/COFF.
- if(NOT (CMAKE_SYSTEM_NAME MATCHES "Darwin|FreeBSD|OpenBSD|DragonFly|AIX|OS390" OR
-@@ -307,7 +307,7 @@ if(NOT (CMAKE_SYSTEM_NAME MATCHES "Darwin|FreeBSD|OpenBSD|DragonFly|AIX|OS390" O
+-if(NOT (CMAKE_SYSTEM_NAME MATCHES "Darwin|FreeBSD|OpenBSD|DragonFly|AIX|OS390" OR
++if(NOT (CMAKE_SYSTEM_NAME MATCHES "Darwin|FreeBSD|OpenBSD|DragonFly|AIX|OS390|Emscripten" OR
+         WIN32 OR CYGWIN) AND
     NOT LLVM_USE_SANITIZER)
    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-z,defs")
- endif()
--
-+#endif
- # Pass -Wl,-z,nodelete. This makes sure our shared libraries are not unloaded
- # by dlclose(). We need that since the CLI API relies on cross-references
- # between global objects which became horribly broken when one of the libraries


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

When building the emscripten version of CppInterOp we get undefined linker flag soname and undefined z value warning here https://github.com/compiler-research/CppInterOp/actions/runs/12736895837/job/35497425197#step:9:213 . This PR should fix this.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [x] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [x] I have read the contribution guide recently
