### PR TITLE
Minor patches to unittests, improve offset initialization in getExecutionEngine

### DIFF
--- a/lib/Interpreter/Compatibility.h
+++ b/lib/Interpreter/Compatibility.h
@@ -117,11 +117,13 @@ inline llvm::orc::LLJIT* getExecutionEngine(cling::Interpreter& I) {
   return I.getExecutionEngine();
 #endif
 
+  unsigned m_ExecutorOffset = 0;
+
 #if CLANG_VERSION_MAJOR == 13
 #ifdef __APPLE__
-  const unsigned m_ExecutorOffset = 62;
+  m_ExecutorOffset = 62;
 #else
-  const unsigned m_ExecutorOffset = 72;
+  m_ExecutorOffset = 72;
 #endif // __APPLE__
 #endif
 
@@ -129,9 +131,9 @@ inline llvm::orc::LLJIT* getExecutionEngine(cling::Interpreter& I) {
 // a thread safe context - llvm::orc::ThreadSafeContext
 #if CLANG_VERSION_MAJOR == 16
 #ifdef __APPLE__
-  const unsigned m_ExecutorOffset = 68;
+  m_ExecutorOffset = 68;
 #else
-  const unsigned m_ExecutorOffset = 78;
+  m_ExecutorOffset = 78;
 #endif // __APPLE__
 #endif
 

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -33,6 +33,7 @@ endif()
   add_test(NAME cppinterop-${name} COMMAND ${name})
   set_tests_properties(cppinterop-${name} PROPERTIES
                        TIMEOUT "${TIMEOUT_VALUE}"
+                       ENVIRONMENT "CPLUS_INCLUDE_PATH=${CMAKE_BINARY_DIR}/etc"
                        LABELS
                        DEPENDS)
   # FIXME: Just call gtest_add_tests this function is available.

--- a/unittests/CppInterOp/ScopeReflectionTest.cpp
+++ b/unittests/CppInterOp/ScopeReflectionTest.cpp
@@ -1022,7 +1022,7 @@ TEST(ScopeReflectionTest, IncludeVector) {
     #include <vector>
     #include <iostream>
   )";
-  Interp->process(code);
+  Interp->declare(code);
 }
 
 TEST(ScopeReflectionTest, GetOperator) {


### PR DESCRIPTION
# Description

Set of patches required on top of InterOp master for enabling ROOT, which can added upstream.