### PR TITLE
Reduce emscripten cache size by removing everything but llvm, clang and build folders

### DIFF
--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -339,7 +339,9 @@ jobs:
                         ../llvm
           emmake ninja clang clang-repl lld -j ${{ env.ncpus }}
         fi
-        cd ../..
+        cd ../
+        rm -rf $(find . -maxdepth 1 ! -name "build" ! -name "llvm" ! -name "clang" ! -name ".")
+        cd ../
 
     - name: Build LLVM/Cling on Windows systems if the cache is invalid
       if: ${{ runner.os == 'windows' && steps.cache.outputs.cache-hit != 'true' }}


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

Our cache for our emscripten llvm builds is quite large. This is the first in a series of 2 PRs to reduce its impact on our total cache. This should provide a small speed up in our emscripten builds, since the emscripten llvm uploads and downloads should be quicker.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [x] I have read the contribution guide recently
