### PR TITLE
Remove warning to CppInterOp config file about shared builds on emscripten

### DIFF
--- a/cmake/CppInterOp/CppInterOpConfig.cmake.in
+++ b/cmake/CppInterOp/CppInterOpConfig.cmake.in
@@ -1,5 +1,11 @@
 # This file allows users to call find_package(CppInterOp) and pick up our targets.
 
+# If you call this file while doing an emscripten build you will get a warning that 
+# emscripten does not support shared library builds
+if(EMSCRIPTEN)
+  set_property(GLOBAL PROPERTY TARGET_SUPPORTS_SHARED_LIBS TRUE)
+endif()
+
 # Compute the installation prefix from this CppInterOpConfig.cmake file location.
 get_filename_component(CPPINTEROP_INSTALL_PREFIX "${CMAKE_CURRENT_LIST_FILE}" PATH)
 get_filename_component(CPPINTEROP_INSTALL_PREFIX "${CPPINTEROP_INSTALL_PREFIX}" PATH)


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

When you call CppInterOps config file with emscripten builds you get a warning that emscripten doesn't support shared library builds (e.g. see https://github.com/compiler-research/CppInterOp/actions/runs/12843770588/job/35816075582#step:10:79 ). This PR should stop that warning from happening.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [x] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [x] I have read the contribution guide recently
