### PR TITLE
Remove Windows llvm 17 and 18 jobs from ci

### DIFF
--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -28,20 +28,6 @@ jobs:
             cling: Off
             llvm_enable_projects: "clang"
             llvm_targets_to_build: "host;NVPTX"
-          - name: win2025-msvc-clang-repl-18
-            os: windows-2025
-            compiler: msvc
-            clang-runtime: '18'
-            cling: Off
-            llvm_enable_projects: "clang"
-            llvm_targets_to_build: "host;NVPTX"
-          - name: win2025-msvc-clang-repl-17
-            os: windows-2025
-            compiler: msvc
-            clang-runtime: '17'
-            cling: Off
-            llvm_enable_projects: "clang"
-            llvm_targets_to_build: "host;NVPTX"
             
     steps:
     - uses: actions/checkout@v4
@@ -242,18 +228,6 @@ jobs:
             os: windows-2025
             compiler: msvc
             clang-runtime: '19'
-            cling: Off
-            cppyy: Off
-          - name: win2025-msvc-clang-repl-18
-            os: windows-2025
-            compiler: msvc
-            clang-runtime: '18'
-            cling: Off
-            cppyy: Off
-          - name: win2025-msvc-clang-repl-17
-            os: windows-2025
-            compiler: msvc
-            clang-runtime: '17'
             cling: Off
             cppyy: Off
 


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

We are unlikely to ever have Windows builds passing all tests building against llvm 17 and 18. After https://github.com/compiler-research/CppInterOp/pull/463 is merged this PR should be merged, so we can remove the cache used up by these jobs. Keeping the llvm 19 build makes sure our Windows build doesn't break. With the freed up cache space I plan to replace these 2 Windows jobs with Ubuntu 24.04 x86 coverage, which is a good trade.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [x] I have read the contribution guide recently
