### PR TITLE
Reduce MacOS llvm cache

### DIFF
--- a/.github/workflows/MacOS.yml
+++ b/.github/workflows/MacOS.yml
@@ -256,7 +256,7 @@ jobs:
                 -DLLVM_ENABLE_LIBXML2=OFF                           \
                 -G Ninja                                            \
                 ../llvm
-          ninja clang clang-repl -j ${{ env.ncpus }}
+          ninja clang clangInterpreter clangStaticAnalyzerCore -j ${{ env.ncpus }}
         fi
         cd ../
         rm -rf $(find . -maxdepth 1 ! -name "build" ! -name "llvm" ! -name "clang" ! -name ".")


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

Not entirely sure whether this will work. I think in the ci we can replace the clang-repl target with clangInterpreter clangStaticAnalyzerCore and still pass. This might have a small effect on the cache size it produces. Need to wait for the ci to run to see if this is the case.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [x] I have read the contribution guide recently
