### PR TITLE
Add back CUDA target to MacOS cling jobs

### DIFF
--- a/.github/workflows/MacOS.yml
+++ b/.github/workflows/MacOS.yml
@@ -56,7 +56,7 @@ jobs:
             clang-runtime: '13'
             cling: On
             cling-version: '1.0'
-            llvm_enable_projects: "clang"
+            llvm_enable_projects: "clang;NVPTX"
             llvm_targets_to_build: "host"
           - name: osx13-x86-clang-clang-repl-19
             os: macos-13
@@ -92,7 +92,7 @@ jobs:
             clang-runtime: '13'
             cling: On
             cling-version: '1.0'
-            llvm_enable_projects: "clang"
+            llvm_enable_projects: "clang;NVPTX"
             llvm_targets_to_build: "host"
             
     steps:


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

Fixes # (issue)

## Type of change

For some reason the Nvidia target is needed for cling based osx jobs. No idea why.

Please tick all options which are relevant.

- [ ] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [x] I have read the contribution guide recently
