### PR TITLE
Fix previous commit and move nvptx to targets to builds macos cling builds

### DIFF
--- a/.github/workflows/MacOS.yml
+++ b/.github/workflows/MacOS.yml
@@ -56,8 +56,8 @@ jobs:
             clang-runtime: '13'
             cling: On
             cling-version: '1.0'
-            llvm_enable_projects: "clang;NVPTX"
-            llvm_targets_to_build: "host"
+            llvm_enable_projects: "clang"
+            llvm_targets_to_build: "host;NVPTX"
           - name: osx13-x86-clang-clang-repl-19
             os: macos-13
             compiler: clang
@@ -92,8 +92,8 @@ jobs:
             clang-runtime: '13'
             cling: On
             cling-version: '1.0'
-            llvm_enable_projects: "clang;NVPTX"
-            llvm_targets_to_build: "host"
+            llvm_enable_projects: "clang"
+            llvm_targets_to_build: "host;NVPTX"
             
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
# Description

I rushed this PR https://github.com/compiler-research/CppInterOp/pull/466 and messed it up. This PR moves NVPTX to the correct place

Please include a summary of changes, motivation and context for this PR.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [ ] I have read the contribution guide recently
