### PR TITLE
Reduce Windows cache size by only building necessary targets

### DIFF
--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -200,7 +200,7 @@ jobs:
                 -DLLVM_ENABLE_TERMINFO=OFF                          `
                 -DLLVM_ENABLE_LIBXML2=OFF                           `
                 ..\llvm
-          cmake --build . --config Release --target clang clang-repl --parallel ${{ env.ncpus }}
+          cmake --build . --config Release --target clang clangInterpreter clangStaticAnalyzerCore --parallel ${{ env.ncpus }}
         }
         cd ..\
         rm -r -force $(find.exe . -maxdepth 1 ! -name "build" ! -name "llvm" ! -name "clang" ! -name ".")


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

Just like what was done in https://github.com/compiler-research/CppInterOp/pull/465 , by only building clangInterpreter clangStaticAnalyzerCore instead of clang-repl then we should see a small decrease in the build size while still passing all tests. Given we have a large number of ci jobs, all these small reductions will build up.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [x] I have read the contribution guide recently
