### PR TITLE
Reduce Ubuntu cache size by only building necessary targets

### DIFF
--- a/.github/workflows/Ubuntu.yml
+++ b/.github/workflows/Ubuntu.yml
@@ -233,7 +233,7 @@ jobs:
                 -DLLVM_ENABLE_LIBXML2=OFF                           \
                 -G Ninja                                            \
                 ../llvm
-          ninja clang clang-repl -j ${{ env.ncpus }}
+          ninja clang clangInterpreter clangStaticAnalyzerCore -j ${{ env.ncpus }}
         fi
         cd ../
         rm -rf $(find . -maxdepth 1 ! -name "build" ! -name "llvm" ! -name "clang" ! -name ".")


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

This PR reduces the llvm cache size on Ubuntu by only bulding clangInterpreter clangStaticAnalyzerCore instead of clang-repl.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [x] I have read the contribution guide recently
