### PR TITLE
Use clangInterpreter clangStaticAnalyzerCore instead of clang-repl target to reduce emscripten llvm cache size

### DIFF
--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -337,7 +337,7 @@ jobs:
                         -DLLVM_ENABLE_THREADS=OFF                       \
                         -G Ninja                                         \
                         ../llvm
-          emmake ninja clang clang-repl lld -j ${{ env.ncpus }}
+          emmake ninja clang clangInterpreter clangStaticAnalyzerCore lld -j ${{ env.ncpus }}
         fi
         cd ../
         rm -rf $(find . -maxdepth 1 ! -name "build" ! -name "llvm" ! -name "clang" ! -name ".")


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

Just like I have done with the non wasm builds I have changed the clang-repl target to be exactly what we need (i.e. clangInterpreter clangStaticAnalyzerCore). This will speed up the emscripten llvm build, and reduce the cache size.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [x] I have read the contribution guide recently
