### PR TITLE
Reduce Ubuntu cache size by not including benchmarks, examples and tests

### DIFF
--- a/.github/workflows/Ubuntu.yml
+++ b/.github/workflows/Ubuntu.yml
@@ -232,6 +232,9 @@ jobs:
                 -DLLVM_ENABLE_TERMINFO=OFF                          \
                 -DLLVM_ENABLE_LIBXML2=OFF                           \
                 -G Ninja                                            \
+                -DLLVM_INCLUDE_BENCHMARKS=OFF                   \
+                -DLLVM_INCLUDE_EXAMPLES=OFF                     \
+                -DLLVM_INCLUDE_TESTS=OFF                        \
                 ../llvm
           ninja clang clangInterpreter clangStaticAnalyzerCore -j ${{ env.ncpus }}
         fi


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

By turning benchmarks, examples and tests off we don't carry these folders over to our build folder. This will have the effect of decreasing the size of the cache for Ubuntu. Just doing it for the clang-repl jobs for this PR to limit the effect of any PRs which may go in while the CI finishes on this PR.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [x] I have read the contribution guide recently
