### PR TITLE
Remove unneeded built tools and compile_commands.json build.ninja Ubuntu ci

### DIFF
--- a/.github/workflows/Ubuntu.yml
+++ b/.github/workflows/Ubuntu.yml
@@ -309,6 +309,10 @@ jobs:
                 -DLLVM_INCLUDE_TESTS=OFF                        \
                 ../llvm
           ninja clang clangInterpreter clangStaticAnalyzerCore -j ${{ env.ncpus }}
+          cd ./tools/
+          rm -rf $(find . -maxdepth 1 ! -name "clang" ! -name ".")
+          cd ..
+          rm compile_commands.json build.ninja
         fi
         cd ../
         rm -rf $(find . -maxdepth 1 ! -name "build" ! -name "llvm" ! -name "clang" ! -name ".")


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

Fixes # (issue)

My local build suggests we do not need these files after the llvm build is complete. They add up to a significant size, so if the ci passes, then it should lead to a significant reduction in the llvm cache taken up by Ubuntu jobs. Next i'll move onto doing this for MacOS jobs if it works.

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [x] I have read the contribution guide recently
