### PR TITLE
Remove osx x86 job and Ubuntu 22 emscripten jobs from ci

### DIFF
--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -21,22 +21,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: ubu22-x86-gcc12-clang-repl-19-emscripten
-            os: ubuntu-22.04
-            compiler: gcc-12
-            clang-runtime: '19'
-            cling: Off
-            llvm_enable_projects: "clang;lld"
-            llvm_targets_to_build: "WebAssembly"
-            emsdk_ver: "3.1.45"
-          - name: ubu22-arm-gcc12-clang-repl-19-emscripten
-            os: ubuntu-22.04-arm
-            compiler: gcc-12
-            clang-runtime: '19'
-            cling: Off
-            llvm_enable_projects: "clang;lld"
-            llvm_targets_to_build: "WebAssembly"
-            emsdk_ver: "3.1.45"
           - name: ubu24-arm-gcc12-clang-repl-19-emscripten
             os: ubuntu-24.04-arm
             compiler: gcc-12
@@ -55,14 +39,6 @@ jobs:
             emsdk_ver: "3.1.45"
           - name: osx15-arm-clang-clang-repl-19-emscripten
             os: macos-15
-            compiler: clang
-            clang-runtime: '19'
-            cling: Off
-            llvm_enable_projects: "clang;lld"
-            llvm_targets_to_build: "WebAssembly"
-            emsdk_ver: "3.1.45"
-          - name: osx13-x86-clang-clang-repl-19-emscripten
-            os: macos-13
             compiler: clang
             clang-runtime: '19'
             cling: Off
@@ -483,15 +459,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: ubu22-x86-gcc12-clang-repl-19-emscripten_wasm
-            os: ubuntu-22.04
+          - name: ubu24-x86-gcc12-clang-repl-19-emscripten_wasm
+            os: ubuntu-24.04
             compiler: gcc-12
             clang-runtime: '19'
             cling: Off
             micromamba_shell_init: bash
             emsdk_ver: "3.1.45"
-          - name: ubu22-arm-gcc12-clang-repl-19-emscripten_wasm
-            os: ubuntu-22.04-arm
+          - name: ubu24-arm-gcc12-clang-repl-19-emscripten_wasm
+            os: ubuntu-24.04-arm
             compiler: gcc-12
             clang-runtime: '19'
             cling: Off
@@ -499,13 +475,6 @@ jobs:
             emsdk_ver: "3.1.45"
           - name: osx15-arm-clang-clang-repl-19-emscripten_wasm
             os: macos-15
-            compiler: clang
-            clang-runtime: '19'
-            cling: Off
-            micromamba_shell_init: bash
-            emsdk_ver: "3.1.45"
-          - name: osx13-x86-clang-clang-repl-19-emscripten_wasm
-            os: macos-13
             compiler: clang
             clang-runtime: '19'
             cling: Off


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

This PR removes the x86 osx emscripten job from the ci, and the Ubuntu 22.04 x86 and arm ones. This keeps us covered for emscripten job for Linux and osx platforms, but only keeps the fast Github runners.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [x] I have read the contribution guide recently
