### PR TITLE
Split Ubuntu workflow into one for x86 and one for arm

### DIFF
--- a/.github/workflows/Ubuntu-arm.yml
+++ b/.github/workflows/Ubuntu-arm.yml
@@ -1,4 +1,4 @@
-name: Ubuntu-x86
+name: Ubuntu-arm
 
 on:
   pull_request:
@@ -22,72 +22,72 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: ubu22-x86-gcc12-clang-repl-19
-            os: ubuntu-22.04
+          - name: ubu22-arm-gcc12-clang-repl-19
+            os: ubuntu-22.04-arm
             compiler: gcc-12
             clang-runtime: '19'
             cling: Off
             llvm_enable_projects: "clang"
             llvm_targets_to_build: "host;NVPTX"
-          - name: ubu22-x86-gcc12-clang-repl-18
-            os: ubuntu-22.04
+          - name: ubu22-arm-gcc12-clang-repl-18
+            os: ubuntu-22.04-arm
             compiler: gcc-12
             clang-runtime: '18'
             cling: Off
             llvm_enable_projects: "clang"
             llvm_targets_to_build: "host;NVPTX"
-          - name: ubu22-x86-gcc12-clang-repl-17
-            os: ubuntu-22.04
+          - name: ubu22-arm-gcc12-clang-repl-17
+            os: ubuntu-22.04-arm
             compiler: gcc-12
             clang-runtime: '17'
             cling: Off
             llvm_enable_projects: "clang"
             llvm_targets_to_build: "host;NVPTX"
-          - name: ubu22-x86-gcc12-clang-repl-16
-            os: ubuntu-22.04
+          - name: ubu22-arm-gcc12-clang-repl-16
+            os: ubuntu-22.04-arm
             compiler: gcc-12
             clang-runtime: '16'
             cling: Off
             llvm_enable_projects: "clang"
             llvm_targets_to_build: "host;NVPTX"
-          - name: ubu22-x86-gcc9-clang13-cling
-            os: ubuntu-22.04
+          - name: ubu22-arm-gcc9-clang13-cling
+            os: ubuntu-22.04-arm
             compiler: gcc-9
             clang-runtime: '13'
             cling: On
             cling-version: '1.0'
             llvm_enable_projects: "clang"
             llvm_targets_to_build: "host;NVPTX"
-          - name: ubu24-x86-gcc12-clang-repl-19
-            os: ubuntu-24.04
+          - name: ubu24-arm-gcc12-clang-repl-19
+            os: ubuntu-24.04-arm
             compiler: gcc-12
             clang-runtime: '19'
             cling: Off
             llvm_enable_projects: "clang"
             llvm_targets_to_build: "host;NVPTX"
-          - name: ubu24-x86-gcc12-clang-repl-18
-            os: ubuntu-24.04
+          - name: ubu24-arm-gcc12-clang-repl-18
+            os: ubuntu-24.04-arm
             compiler: gcc-12
             clang-runtime: '18'
             cling: Off
             llvm_enable_projects: "clang"
             llvm_targets_to_build: "host;NVPTX"
-          - name: ubu24-x86-gcc12-clang-repl-17
-            os: ubuntu-24.04
+          - name: ubu24-arm-gcc12-clang-repl-17
+            os: ubuntu-24.04-arm
             compiler: gcc-12
             clang-runtime: '17'
             cling: Off
             llvm_enable_projects: "clang"
             llvm_targets_to_build: "host;NVPTX"
-          - name: ubu24-x86-gcc12-clang-repl-16
-            os: ubuntu-24.04
+          - name: ubu24-arm-gcc12-clang-repl-16
+            os: ubuntu-24.04-arm
             compiler: gcc-12
             clang-runtime: '16'
             cling: Off
             llvm_enable_projects: "clang"
             llvm_targets_to_build: "host;NVPTX"
-          - name: ubu24-x86-gcc9-clang13-cling
-            os: ubuntu-24.04
+          - name: ubu24-arm-gcc9-clang13-cling
+            os: ubuntu-24.04-arm
             compiler: gcc-9
             clang-runtime: '13'
             cling: On
@@ -275,68 +275,56 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: ubu22-x86-gcc12-clang-repl-19-docs
-            os: ubuntu-22.04
+          - name: ubu22-arm-gcc12-clang-repl-19
+            os: ubuntu-22.04-arm
             compiler: gcc-12
             clang-runtime: '19'
             cling: Off
-            cppyy: Off
-            documentation: On
-          - name: ubu22-x86-gcc12-clang-repl-19-cppyy
-            os: ubuntu-22.04
-            compiler: gcc-12
-            clang-runtime: '19'
-            cling: Off
-            cppyy: On
-            coverage: true
-          - name: ubu22-x86-gcc12-clang-repl-18-cppyy
-            os: ubuntu-22.04
+          - name: ubu22-arm-gcc12-clang-repl-18
+            os: ubuntu-22.04-arm
             compiler: gcc-12
             clang-runtime: '18'
             cling: Off
-            cppyy: On
-          - name: ubu22-x86-gcc12-clang-repl-17-cppyy
-            os: ubuntu-22.04
+          - name: ubu22-arm-gcc12-clang-repl-17
+            os: ubuntu-22.04-arm
             compiler: gcc-12
             clang-runtime: '17'
             cling: Off
-            cppyy: On
-          - name: ubu22-x86-gcc12-clang-repl-16
-            os: ubuntu-22.04
+          - name: ubu22-arm-gcc12-clang-repl-16
+            os: ubuntu-22.04-arm
             compiler: gcc-12
             clang-runtime: '16'
             cling: Off
             cppyy: Off
-          - name: ubu22-x86-gcc9-clang13-cling-cppyy
-            os: ubuntu-22.04
+          - name: ubu22-arm-gcc9-clang13-cling
+            os: ubuntu-22.04-arm
             compiler: gcc-9
             clang-runtime: '13'
             cling: On
             cling-version: '1.0'
-            cppyy: On
-          - name: ubu24-x86-gcc12-clang-repl-19
-            os: ubuntu-24.04
+          - name: ubu24-arm-gcc12-clang-repl-19
+            os: ubuntu-24.04-arm
             compiler: gcc-12
             clang-runtime: '19'
             cling: Off
-          - name: ubu24-x86-gcc12-clang-repl-18
-            os: ubuntu-24.04
+          - name: ubu24-arm-gcc12-clang-repl-18
+            os: ubuntu-24.04-arm
             compiler: gcc-12
             clang-runtime: '18'
             cling: Off
-          - name: ubu24-x86-gcc12-clang-repl-17
-            os: ubuntu-24.04
+          - name: ubu24-arm-gcc12-clang-repl-17
+            os: ubuntu-24.04-arm
             compiler: gcc-12
             clang-runtime: '17'
             cling: Off
-          - name: ubu24-x86-gcc12-clang-repl-16
-            os: ubuntu-24.04
+          - name: ubu24-arm-gcc12-clang-repl-16
+            os: ubuntu-24.04-arm
             compiler: gcc-12
             clang-runtime: '16'
             cling: Off
             cppyy: Off
-          - name: ubu24-x86-gcc9-clang13-cling
-            os: ubuntu-24.04
+          - name: ubu24-arm-gcc9-clang13-cling
+            os: ubuntu-24.04-arm
             compiler: gcc-9
             clang-runtime: '13'
             cling: On
@@ -407,7 +395,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install git g++ debhelper devscripts gnupg python3 doxygen graphviz python3-sphinx
         sudo apt-get install -y libc6-dbg
-        sudo snap install valgrind --classic
+        sudo apt-get install valgrind
         sudo apt autoremove
         sudo apt clean
         # Install libraries used by the cppyy test suite

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![Build Status](https://github.com/compiler-research/CppInterOp/actions/workflows/Ubuntu.yml/badge.svg)](https://github.com/compiler-research/CppInterOp/actions/workflows/Ubuntu.yml)
 
+[![Build Status](https://github.com/compiler-research/CppInterOp/actions/workflows/Ubuntu.yml/badge.svg)](https://github.com/compiler-research/CppInterOp/actions/workflows/Ubuntu-arm.yml)
+
 [![Build Status](https://github.com/compiler-research/CppInterOp/actions/workflows/MacOS.yml/badge.svg)](https://github.com/compiler-research/CppInterOp/actions/workflows/MacOS.yml)
 
 [![Build Status](https://github.com/compiler-research/CppInterOp/actions/workflows/Windows.yml/badge.svg)](https://github.com/compiler-research/CppInterOp/actions/workflows/Windows.yml)


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

This splits the Ubuntu workflow into one for x86 and one for arm. This makes it easier to maintain, and allows us to have a build badge for both build targets.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [x] I have read the contribution guide recently
