### PR TITLE
Swap cling target for clingInterpreter llvm build Ubuntu ci

### DIFF
--- a/.github/workflows/Ubuntu-arm.yml
+++ b/.github/workflows/Ubuntu-arm.yml
@@ -209,7 +209,7 @@ jobs:
                 -G Ninja                                           \
                 ../llvm
           ninja clang -j ${{ env.ncpus }}
-          ninja cling -j ${{ env.ncpus }}
+          ninja clingInterpreter -j ${{ env.ncpus }}
           # Now build gtest.a and gtest_main for CppInterOp to run its tests.
           ninja gtest_main -j ${{ env.ncpus }}
         else

--- a/.github/workflows/Ubuntu.yml
+++ b/.github/workflows/Ubuntu.yml
@@ -209,7 +209,7 @@ jobs:
                 -G Ninja                                           \
                 ../llvm
           ninja clang -j ${{ env.ncpus }}
-          ninja cling -j ${{ env.ncpus }}
+          ninja clingInterpreter -j ${{ env.ncpus }}
           # Now build gtest.a and gtest_main for CppInterOp to run its tests.
           ninja gtest_main -j ${{ env.ncpus }}
         else


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

By swapping the cling target when building llvm for clingInterpreter we should save cache space while still passing the ci.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [x] I have read the contribution guide recently
