### PR TITLE
Change cling to clingInterpreter target macos ci

### DIFF
--- a/.github/workflows/MacOS-arm.yml
+++ b/.github/workflows/MacOS-arm.yml
@@ -185,7 +185,7 @@ jobs:
                 -G Ninja                                           \
                 ../llvm
           ninja clang -j ${{ env.ncpus }}
-          ninja cling -j ${{ env.ncpus }}
+          ninja clingInterpreter -j ${{ env.ncpus }}
           # Now build gtest.a and gtest_main for CppInterOp to run its tests.
           ninja gtest_main -j ${{ env.ncpus }}
         else

--- a/.github/workflows/MacOS.yml
+++ b/.github/workflows/MacOS.yml
@@ -170,7 +170,7 @@ jobs:
                 -G Ninja                                           \
                 ../llvm
           ninja clang -j ${{ env.ncpus }}
-          ninja cling -j ${{ env.ncpus }}
+          ninja clingInterpreter -j ${{ env.ncpus }}
           # Now build gtest.a and gtest_main for CppInterOp to run its tests.
           ninja gtest_main -j ${{ env.ncpus }}
         else


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

Fixes # (issue)

This build changes from using the cling target to clinginterpreter in the ci to save space in the cache.

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [x] I have read the contribution guide recently
