### PR TITLE
Turn on Ubuntu 22.04 arm cppyy jobs

### DIFF
--- a/.github/workflows/Ubuntu-arm.yml
+++ b/.github/workflows/Ubuntu-arm.yml
@@ -596,7 +596,7 @@ jobs:
         echo "Running valgrind on passing tests"
         CLANG_VERSION="${{ matrix.clang-runtime }}"
         SUPPRESSION_FILE="../etc/clang${CLANG_VERSION}-valgrind_arm.supp"
-        valgrind --show-error-list=yes --error-exitcode=1 --track-origins=yes --suppressions="${SUPPRESSION_FILE}" --suppressions=../etc/valgrind-cppyy-cling.supp python -m pytest -m "not xfail" -sv -ra
+        valgrind --show-error-list=yes --error-exitcode=1 --track-origins=yes --gen-suppressions=all --suppressions="${SUPPRESSION_FILE}" --suppressions=../etc/valgrind-cppyy-cling.supp python -m pytest -m "not xfail" -sv -ra
         export RETCODE=+$?
         echo ::endgroup::
 

--- a/.github/workflows/Ubuntu-arm.yml
+++ b/.github/workflows/Ubuntu-arm.yml
@@ -595,7 +595,7 @@ jobs:
     
         echo "Running valgrind on passing tests"
         CLANG_VERSION="${{ matrix.clang-runtime }}"
-        SUPPRESSION_FILE="../etc/clang${CLANG_VERSION}-valgrind.supp"
+        SUPPRESSION_FILE="../etc/clang${CLANG_VERSION}-valgrind_arm.supp"
         valgrind --show-error-list=yes --error-exitcode=1 --track-origins=yes --suppressions="${SUPPRESSION_FILE}" --suppressions=../etc/valgrind-cppyy-cling.supp python -m pytest -m "not xfail" -sv -ra
         export RETCODE=+$?
         echo ::endgroup::

--- a/.github/workflows/Ubuntu-arm.yml
+++ b/.github/workflows/Ubuntu-arm.yml
@@ -399,7 +399,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install git g++ debhelper devscripts gnupg python3 doxygen graphviz python3-sphinx
         sudo apt-get install -y libc6-dbg
-        sudo apt-get install valgrind
+        sudo apt-get install valgrind --classic
         sudo apt autoremove
         sudo apt clean
         # Install libraries used by the cppyy test suite

--- a/.github/workflows/Ubuntu-arm.yml
+++ b/.github/workflows/Ubuntu-arm.yml
@@ -399,7 +399,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install git g++ debhelper devscripts gnupg python3 doxygen graphviz python3-sphinx
         sudo apt-get install -y libc6-dbg
-        sudo apt-get install valgrind --classic
+        sudo snap install valgrind --classic
         sudo apt autoremove
         sudo apt clean
         # Install libraries used by the cppyy test suite

--- a/.github/workflows/Ubuntu-arm.yml
+++ b/.github/workflows/Ubuntu-arm.yml
@@ -275,38 +275,42 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: ubu22-arm-gcc12-clang-repl-19
+          - name: ubu22-arm-gcc12-clang-repl-19-cppyy
             os: ubuntu-22.04-arm
             compiler: gcc-12
             clang-runtime: '19'
             cling: Off
-          - name: ubu22-arm-gcc12-clang-repl-18
+            cppyy: On
+          - name: ubu22-arm-gcc12-clang-repl-18-cppyy
             os: ubuntu-22.04-arm
             compiler: gcc-12
             clang-runtime: '18'
-            cling: Off
-          - name: ubu22-arm-gcc12-clang-repl-17
+            cling: On
+            cppyy: On
+          - name: ubu22-arm-gcc12-clang-repl-17-cppyy
             os: ubuntu-22.04-arm
             compiler: gcc-12
             clang-runtime: '17'
-            cling: Off
+            cling: On
+            cppyy: On
           - name: ubu22-arm-gcc12-clang-repl-16
             os: ubuntu-22.04-arm
             compiler: gcc-12
             clang-runtime: '16'
             cling: Off
             cppyy: Off
-          - name: ubu22-arm-gcc9-clang13-cling
+          - name: ubu22-arm-gcc9-clang13-cling-cppyy
             os: ubuntu-22.04-arm
             compiler: gcc-9
             clang-runtime: '13'
             cling: On
             cling-version: '1.0'
+            cppyy: On
           - name: ubu24-arm-gcc12-clang-repl-19
             os: ubuntu-24.04-arm
             compiler: gcc-12
             clang-runtime: '19'
-            cling: Off
+            cling: On
           - name: ubu24-arm-gcc12-clang-repl-18
             os: ubuntu-24.04-arm
             compiler: gcc-12

--- a/.github/workflows/Ubuntu-arm.yml
+++ b/.github/workflows/Ubuntu-arm.yml
@@ -310,7 +310,7 @@ jobs:
             os: ubuntu-24.04-arm
             compiler: gcc-12
             clang-runtime: '19'
-            cling: On
+            cling: Off
           - name: ubu24-arm-gcc12-clang-repl-18
             os: ubuntu-24.04-arm
             compiler: gcc-12

--- a/.github/workflows/Ubuntu-arm.yml
+++ b/.github/workflows/Ubuntu-arm.yml
@@ -285,13 +285,13 @@ jobs:
             os: ubuntu-22.04-arm
             compiler: gcc-12
             clang-runtime: '18'
-            cling: On
+            cling: Off
             cppyy: On
           - name: ubu22-arm-gcc12-clang-repl-17-cppyy
             os: ubuntu-22.04-arm
             compiler: gcc-12
             clang-runtime: '17'
-            cling: On
+            cling: Off
             cppyy: On
           - name: ubu22-arm-gcc12-clang-repl-16
             os: ubuntu-22.04-arm


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

Now that support for Ubuntu 22.04 arm has been added to cppyy we can turn it on in the CppInterop Ubuntu-arm.yml workflow.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [x] I have read the contribution guide recently
