### PR TITLE
Fix clang-format workflow

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -33,11 +33,6 @@ jobs:
           sudo apt update
           sudo apt install -y clang-format-18
 
-      - name: Download git-clang-format
-        run: |
-          wget https://raw.githubusercontent.com/llvm/llvm-project/main/clang/tools/clang-format/git-clang-format
-          chmod +x git-clang-format
-
       - name: Run git-clang-format
         run: |
           PR_BASE=$(git rev-list ${{ github.event.pull_request.head.sha }} ^${{ github.event.pull_request.base.sha }} | tail --lines 1 | xargs -I {} git rev-parse {}~1)

--- a/lib/Interpreter/Compatibility.h
+++ b/lib/Interpreter/Compatibility.h
@@ -2,7 +2,6 @@
 // CppInterOp Compatibility
 // author:  Alexander Penev <alexander_penev@yahoo.com>
 //------------------------------------------------------------------------------
-
 #ifndef CPPINTEROP_COMPATIBILITY_H
 #define CPPINTEROP_COMPATIBILITY_H
 


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

The clang format workflow is broken because it tries to get a git-clang-format by wgetting it. Git-clang-format is not used as far as I can tell from the workflow, so should be safe to just remove the 'Download git-clang-format' section of the workflow.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [x] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [x] I have read the contribution guide recently
