### PR TITLE
Add `GetEnumConstantDatamembers` function

### DIFF
--- a/include/clang/Interpreter/CppInterOp.h
+++ b/include/clang/Interpreter/CppInterOp.h
@@ -459,6 +459,15 @@ namespace Cpp {
   GetStaticDatamembers(TCppScope_t scope,
                        std::vector<TCppScope_t>& datamembers);
 
+  /// Gets all the Enum Constants declared in a Class
+  ///\param[in] scope - class
+  ///\param[out] funcs - vector of static data members
+  ///\param[in] include_enum_class - include enum constants from enum class
+  CPPINTEROP_API
+  void GetEnumConstantDatamembers(TCppScope_t scope,
+                                  std::vector<TCppScope_t>& datamembers,
+                                  bool include_enum_class = true);
+
   /// This is a Lookup function to be used specifically for data members.
   CPPINTEROP_API TCppScope_t LookupDatamember(const std::string& name,
                                               TCppScope_t parent);

--- a/unittests/CppInterOp/VariableReflectionTest.cpp
+++ b/unittests/CppInterOp/VariableReflectionTest.cpp
@@ -576,3 +576,27 @@ TEST(VariableReflectionTest, StaticConstExprDatamember) {
   offset = Cpp::GetVariableOffset(datamembers[0]);
   EXPECT_EQ(2, *(int*)offset);
 }
+
+TEST(VariableReflectionTest, GetEnumConstantDatamembers) {
+  Cpp::CreateInterpreter();
+
+  Cpp::Declare(R"(
+  class MyEnumClass {
+    enum { FOUR, FIVE, SIX };
+    enum A { ONE, TWO, THREE };
+    enum class B { SEVEN, EIGHT, NINE };
+  };
+  )");
+
+  Cpp::TCppScope_t MyEnumClass = Cpp::GetNamed("MyEnumClass");
+  EXPECT_TRUE(MyEnumClass);
+
+  std::vector<Cpp::TCppScope_t> datamembers;
+  Cpp::GetEnumConstantDatamembers(MyEnumClass, datamembers);
+  EXPECT_EQ(datamembers.size(), 9);
+  EXPECT_TRUE(Cpp::IsEnumType(Cpp::GetVariableType(datamembers[0])));
+
+  std::vector<Cpp::TCppScope_t> datamembers2;
+  Cpp::GetEnumConstantDatamembers(MyEnumClass, datamembers2, false);
+  EXPECT_EQ(datamembers2.size(), 6);
+}


### PR DESCRIPTION
Resolve all `EnumConstantDecl`s declared in a class.

## Fixes # (issue)

1 test at cppyy.

Please tick all options which are relevant.

- [ ] Bug fix
- [x] New feature
- [ ] Requires documentation updates

## Testing

Implemented tests.

## Checklist

- [x] I have read the contribution guide recently
