### PR TITLE
fix `MakeFunctionCallable`'s codegen when return type is a function pointer

### DIFF
--- a/lib/Interpreter/CppInterOp.cpp
+++ b/lib/Interpreter/CppInterOp.cpp
@@ -1670,6 +1670,9 @@ namespace Cpp {
       //
       ASTContext& C = FD->getASTContext();
       PrintingPolicy Policy(C.getPrintingPolicy());
+#if CLANG_VERSION_MAJOR > 16
+      Policy.SuppressElaboration = true;
+#endif
       refType = kNotReference;
       if (QT->isRecordType() && forArgument) {
         get_type_as_string(QT, type_name, C, Policy);
@@ -1984,18 +1987,22 @@ namespace Cpp {
         EReferenceType refType = kNotReference;
         bool isPointer = false;
 
+        std::ostringstream typedefbuf;
+        std::ostringstream callbuf;
+
+        collect_type_info(FD, QT, typedefbuf, callbuf, type_name, refType,
+                          isPointer, indent_level, false);
+
+        buf << typedefbuf.str();
+
         buf << "if (ret) {\n";
         ++indent_level;
         {
-          std::ostringstream typedefbuf;
-          std::ostringstream callbuf;
           //
           //  Write the placement part of the placement new.
           //
           indent(callbuf, indent_level);
           callbuf << "new (ret) ";
-          collect_type_info(FD, QT, typedefbuf, callbuf, type_name, refType,
-                            isPointer, indent_level, false);
           //
           //  Write the type part of the placement new.
           //

--- a/unittests/CppInterOp/FunctionReflectionTest.cpp
+++ b/unittests/CppInterOp/FunctionReflectionTest.cpp
@@ -885,6 +885,9 @@ TEST(FunctionReflectionTest, GetFunctionCallWrapper) {
       int f3() { return 3; }
 
       extern "C" int f4() { return 4; }
+
+      typedef int(*int_func)(void);
+      int_func f5() { return f3; }
     }
   )");
 
@@ -919,6 +922,18 @@ TEST(FunctionReflectionTest, GetFunctionCallWrapper) {
 
   FCI4.Invoke(&ret4);
   EXPECT_EQ(ret4, 4);
+
+#if CLANG_VERSION_MAJOR > 16
+  Cpp::JitCall FCI5 =
+      Cpp::MakeFunctionCallable(Cpp::GetNamed("f5", Cpp::GetNamed("NS")));
+  EXPECT_TRUE(FCI5.getKind() == Cpp::JitCall::kGenericCall);
+
+  typedef int (*int_func)();
+  int_func callback = nullptr;
+  FCI5.Invoke((void*)&callback);
+  EXPECT_TRUE(callback);
+  EXPECT_EQ(callback(), 3);
+#endif
 
   // FIXME: Do we need to support private ctors?
   Interp->process(R"(


### PR DESCRIPTION
# Description

Fixes code generation of `MakeFunctionCallable` for the cases where the return type of the function is a function pointer.

## Fixes # (issue)

Potentially fix 4 tests at cppyy.

## Type of change

Please tick all options which are relevant.

- [x] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Implemented a test case where it used to fail, but passed with these changes.

## Checklist

- [x] I have read the contribution guide recently
