### PR TITLE
fix `MakeFunctionCallable`'s codegen for templated operators

### DIFF
--- a/lib/Interpreter/CppInterOp.cpp
+++ b/lib/Interpreter/CppInterOp.cpp
@@ -1862,10 +1862,22 @@ namespace Cpp {
       {
         std::string name;
         {
-          llvm::raw_string_ostream stream(name);
+          std::string complete_name;
+          llvm::raw_string_ostream stream(complete_name);
           FD->getNameForDiagnostic(stream,
                                    FD->getASTContext().getPrintingPolicy(),
                                    /*Qualified=*/false);
+
+          // insert space between template argument list and the function name
+          // this is require if the function is `operator<`
+          // `operator<<type1, type2, ...>` is invalid syntax
+          // whereas `operator< <type1, type2, ...>` is valid
+          std::string simple_name = FD->getNameAsString();
+          size_t idx = complete_name.find(simple_name, 0) + simple_name.size();
+          std::string name_without_template_args = complete_name.substr(0, idx);
+          std::string template_args = complete_name.substr(idx);
+          name = name_without_template_args +
+                 (template_args.empty() ? "" : " " + template_args);
         }
         callbuf << name;
       }


### PR DESCRIPTION
# Description

Fixes code generation of `MakeFunctionCallable` for templated operators.
Look at the inline comment.

## Fixes # (issue)

Fixes one test case in cppyy.

Please tick all options which are relevant.

- [x] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Tests included.

## Checklist

- [x] I have read the contribution guide recently
