### PR TITLE
Improve template instantiate

### DIFF
--- a/include/clang/Interpreter/CppInterOp.h
+++ b/include/clang/Interpreter/CppInterOp.h
@@ -676,6 +676,15 @@ namespace Cpp {
     const char* m_IntegralValue;
     TemplateArgInfo(TCppScope_t type, const char* integral_value = nullptr)
       : m_Type(type), m_IntegralValue(integral_value) {}
+    friend bool operator==(const TemplateArgInfo& lhs,
+                           const TemplateArgInfo& rhs) {
+      return (lhs.m_Type == rhs.m_Type &&
+              lhs.m_IntegralValue == rhs.m_IntegralValue);
+    }
+    friend bool operator!=(const TemplateArgInfo& lhs,
+                           const TemplateArgInfo& rhs) {
+      return !(lhs == rhs);
+    }
   };
   /// Builds a template instantiation for a given templated declaration.
   /// Offers a single interface for instantiation of class, function and


### PR DESCRIPTION
# Description

Match parameter types to argument types in cases of when the parameter type itself is templated.

### Fixes # (issue)

Helps fix up to 4 tests in cppyy.

Also fixes the https://github.com/compiler-research/cppyy-backend/pull/129 's cling failure.

Please tick all options which are relevant.

- [x] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Included tests. I feel codecov will still not be happy. Will add more according to its suggestions.

## Checklist

- [x] I have read the contribution guide recently
