### PR TITLE
Added undo command for CppInterOp

### DIFF
--- a/include/clang/Interpreter/CppInterOp.h
+++ b/include/clang/Interpreter/CppInterOp.h
@@ -785,6 +785,11 @@ namespace Cpp {
                                    unsigned complete_line = 1U,
                                    unsigned complete_column = 1U);
 
+  /// Reverts the last N operations performed by the interpreter.
+  ///\param[in] N The number of operations to undo. Defaults to 1.
+  ///\returns 0 on success, non-zero on failure.
+  CPPINTEROP_API int Undo(unsigned N = 1);
+
 } // end namespace Cpp
 
 #endif // CPPINTEROP_CPPINTEROP_H

--- a/lib/Interpreter/CXCppInterOp.cpp
+++ b/lib/Interpreter/CXCppInterOp.cpp
@@ -306,7 +306,10 @@ TInterp_t clang_Interpreter_takeInterpreterAsPtr(CXInterpreter I) {
 
 enum CXErrorCode clang_Interpreter_undo(CXInterpreter I, unsigned int N) {
 #ifdef CPPINTEROP_USE_CLING
-  return CXError_Failure;
+  auto* interp = getInterpreter(I);
+  cling::Interpreter::PushTransactionRAII RAII(interp);
+  interp->unload(N);
+  return CXError_Success;
 #else
   return getInterpreter(I)->Undo(N) ? CXError_Failure : CXError_Success;
 #endif // CPPINTEROP_USE_CLING

--- a/lib/Interpreter/CppInterOp.cpp
+++ b/lib/Interpreter/CppInterOp.cpp
@@ -3686,7 +3686,7 @@ namespace Cpp {
 
   int Undo(unsigned N) {
 #ifdef CPPINTEROP_USE_CLING
-    auto &I = getInterp();
+    auto& I = getInterp();
     cling::Interpreter::PushTransactionRAII RAII(&I);
     I.unload(N);
     return compat::Interpreter::kSuccess;

--- a/lib/Interpreter/CppInterOp.cpp
+++ b/lib/Interpreter/CppInterOp.cpp
@@ -3686,8 +3686,6 @@ namespace Cpp {
 
   int Undo(unsigned N) {
 #ifdef CPPINTEROP_USE_CLING
-    llvm::logAllUnhandledErrors(Undo(N), llvm::errs(),
-                                "Undo not implemented in Cling");
     return compat::Interpreter::kFailure;
 #else
     return getInterp().undo(N);

--- a/lib/Interpreter/CppInterOp.cpp
+++ b/lib/Interpreter/CppInterOp.cpp
@@ -3684,6 +3684,14 @@ namespace Cpp {
                          complete_column);
   }
 
-  int Undo(unsigned N) { return getInterp().undo(N); }
+  int Undo(unsigned N) {
+#ifdef CPPINTEROP_USE_CLING
+    llvm::logAllUnhandledErrors(Undo(N), llvm::errs(),
+                                "Undo not implemented in Cling");
+    return compat::Interpreter::kFailure;
+#else
+    return getInterp().undo(N);
+#endif
+  }
 
   } // end namespace Cpp

--- a/lib/Interpreter/CppInterOp.cpp
+++ b/lib/Interpreter/CppInterOp.cpp
@@ -3684,4 +3684,6 @@ namespace Cpp {
                          complete_column);
   }
 
+  int Undo(unsigned N) { return getInterp().undo(N); }
+
   } // end namespace Cpp

--- a/lib/Interpreter/CppInterOp.cpp
+++ b/lib/Interpreter/CppInterOp.cpp
@@ -3686,7 +3686,10 @@ namespace Cpp {
 
   int Undo(unsigned N) {
 #ifdef CPPINTEROP_USE_CLING
-    return compat::Interpreter::kFailure;
+    auto &I = getInterp();
+    cling::Interpreter::PushTransactionRAII RAII(&I);
+    I.unload(N);
+    return compat::Interpreter::kSuccess;
 #else
     return getInterp().undo(N);
 #endif

--- a/lib/Interpreter/CppInterOpInterpreter.h
+++ b/lib/Interpreter/CppInterOpInterpreter.h
@@ -429,6 +429,21 @@ public:
     return ret; // TODO: Implement
   }
 
+  CompilationResult undo(unsigned N = 1) {
+#ifdef CPPINTEROP_USE_CLING
+    llvm::logAllUnhandledErrors(Undo(N), llvm::errs(),
+                                "Undo not implemented in Cling");
+    return kFailure;
+#else
+    if (llvm::Error Err = Undo(N)) {
+      llvm::logAllUnhandledErrors(std::move(Err), llvm::errs(),
+                                  "Failed to undo via ::undo: or something");
+      return kFailure;
+    }
+    return kSuccess;
+#endif
+  }
+
 }; // Interpreter
 } // namespace Cpp
 

--- a/lib/Interpreter/CppInterOpInterpreter.h
+++ b/lib/Interpreter/CppInterOpInterpreter.h
@@ -430,18 +430,12 @@ public:
   }
 
   CompilationResult undo(unsigned N = 1) {
-#ifdef CPPINTEROP_USE_CLING
-    llvm::logAllUnhandledErrors(Undo(N), llvm::errs(),
-                                "Undo not implemented in Cling");
-    return kFailure;
-#else
     if (llvm::Error Err = Undo(N)) {
       llvm::logAllUnhandledErrors(std::move(Err), llvm::errs(),
                                   "Failed to undo via ::undo");
       return kFailure;
     }
     return kSuccess;
-#endif
   }
 
 }; // Interpreter

--- a/lib/Interpreter/CppInterOpInterpreter.h
+++ b/lib/Interpreter/CppInterOpInterpreter.h
@@ -437,7 +437,7 @@ public:
 #else
     if (llvm::Error Err = Undo(N)) {
       llvm::logAllUnhandledErrors(std::move(Err), llvm::errs(),
-                                  "Failed to undo via ::undo: or something");
+                                  "Failed to undo via ::undo");
       return kFailure;
     }
     return kSuccess;

--- a/unittests/CppInterOp/FunctionReflectionTest.cpp
+++ b/unittests/CppInterOp/FunctionReflectionTest.cpp
@@ -1622,6 +1622,8 @@ TEST(FunctionReflectionTest, UndoTest) {
         << "Test fails for Emscipten builds";
   #else
     Cpp::CreateInterpreter();
+    EXPECT_EQ(Cpp::Process("int a = 5;"), 0);
+    EXPECT_EQ(Cpp::Process("int b = 10;"), 0);
     EXPECT_EQ(Cpp::Process("int x = 5;"), 0);
     Cpp::Undo();
     EXPECT_NE(Cpp::Process("int y = x;"), 0);

--- a/unittests/CppInterOp/FunctionReflectionTest.cpp
+++ b/unittests/CppInterOp/FunctionReflectionTest.cpp
@@ -1627,7 +1627,7 @@ TEST(FunctionReflectionTest, UndoTest) {
   testing::internal::CaptureStderr();
   Cpp::Process("int y = x;");
   cerrs = testing::internal::GetCapturedStderr();
-  EXPECT_TRUE(strstr(cerrs.c_str(), "error: use of undeclared identifier 'x'") != nullptr);
+  EXPECT_TRUE(strstr(cerrs.c_str(), "use of undeclared identifier 'x'") != nullptr);
   testing::internal::CaptureStderr();
   Cpp::Process("int x = 10;");
   cerrs = testing::internal::GetCapturedStderr();
@@ -1645,4 +1645,11 @@ TEST(FunctionReflectionTest, UndoTest) {
   Cpp::Process("int y = 20;");
   cerrs = testing::internal::GetCapturedStderr();
   EXPECT_STREQ(cerrs.c_str(), "");
+
+  int ret = Cpp::Undo(100);
+  #if defined(CPPINTEROP_USE_CLING)
+  EXPECT_EQ(ret, 0);
+  #else
+  EXPECT_EQ(ret, 1);
+  #endif
 }

--- a/unittests/CppInterOp/FunctionReflectionTest.cpp
+++ b/unittests/CppInterOp/FunctionReflectionTest.cpp
@@ -1617,6 +1617,10 @@ TEST(FunctionReflectionTest, Destruct) {
 }
 
 TEST(FunctionReflectionTest, UndoTest) {
+#ifdef EMSCRIPTEN
+  GTEST_SKIP()
+      << "Currently not implemented while running clang-repl in the broswer";
+#else
   Cpp::CreateInterpreter();
   std::string cerrs;
   testing::internal::CaptureStderr();
@@ -1650,5 +1654,6 @@ TEST(FunctionReflectionTest, UndoTest) {
   EXPECT_EQ(ret, 0);
 #else
   EXPECT_EQ(ret, 1);
+#endif
 #endif
 }

--- a/unittests/CppInterOp/FunctionReflectionTest.cpp
+++ b/unittests/CppInterOp/FunctionReflectionTest.cpp
@@ -1619,7 +1619,7 @@ TEST(FunctionReflectionTest, Destruct) {
 TEST(FunctionReflectionTest, UndoTest) {
 #ifdef EMSCRIPTEN
   GTEST_SKIP()
-      << "Currently not implemented while running clang-repl in the broswer";
+      << "Test fails for Emscipten builds";
 #else
   Cpp::CreateInterpreter();
   std::string cerrs;

--- a/unittests/CppInterOp/FunctionReflectionTest.cpp
+++ b/unittests/CppInterOp/FunctionReflectionTest.cpp
@@ -1627,11 +1627,7 @@ TEST(FunctionReflectionTest, UndoTest) {
   testing::internal::CaptureStderr();
   Cpp::Process("int y = x;");
   cerrs = testing::internal::GetCapturedStderr();
-  EXPECT_STREQ(
-      cerrs.c_str(),
-      "In file included from <<< inputs >>>:1:\ninput_line_2:1:9: error: use "
-      "of undeclared identifier 'x'\n    1 | int y = x;\n      |         "
-      "^\nFailed to parse via ::process:Parsing failed.\n");
+  EXPECT_TRUE(strstr(cerrs.c_str(), "error: use of undeclared identifier 'x'") != nullptr);
   testing::internal::CaptureStderr();
   Cpp::Process("int x = 10;");
   cerrs = testing::internal::GetCapturedStderr();

--- a/unittests/CppInterOp/FunctionReflectionTest.cpp
+++ b/unittests/CppInterOp/FunctionReflectionTest.cpp
@@ -1617,43 +1617,24 @@ TEST(FunctionReflectionTest, Destruct) {
 }
 
 TEST(FunctionReflectionTest, UndoTest) {
-#ifdef EMSCRIPTEN
-  GTEST_SKIP()
-      << "Test fails for Emscipten builds";
-#else
-  Cpp::CreateInterpreter();
-  std::string cerrs;
-  testing::internal::CaptureStderr();
-  Cpp::Process("int x = 5;");
-  cerrs = testing::internal::GetCapturedStderr();
-  EXPECT_STREQ(cerrs.c_str(), "");
-  Cpp::Undo();
-  testing::internal::CaptureStderr();
-  Cpp::Process("int y = x;");
-  cerrs = testing::internal::GetCapturedStderr();
-  EXPECT_TRUE(strstr(cerrs.c_str(), "use of undeclared identifier 'x'") != nullptr);
-  testing::internal::CaptureStderr();
-  Cpp::Process("int x = 10;");
-  cerrs = testing::internal::GetCapturedStderr();
-  EXPECT_STREQ(cerrs.c_str(), "");
-  testing::internal::CaptureStderr();
-  Cpp::Process("int y = 10;");
-  cerrs = testing::internal::GetCapturedStderr();
-  EXPECT_STREQ(cerrs.c_str(), "");
-  Cpp::Undo(2);
-  testing::internal::CaptureStderr();
-  Cpp::Process("int x = 20;");
-  cerrs = testing::internal::GetCapturedStderr();
-  EXPECT_STREQ(cerrs.c_str(), "");
-  testing::internal::CaptureStderr();
-  Cpp::Process("int y = 20;");
-  cerrs = testing::internal::GetCapturedStderr();
-  EXPECT_STREQ(cerrs.c_str(), "");
-  int ret = Cpp::Undo(100);
-#ifdef CPPINTEROP_USE_CLING
-  EXPECT_EQ(ret, 0);
-#else
-  EXPECT_EQ(ret, 1);
-#endif
-#endif
-}
+  #ifdef EMSCRIPTEN
+    GTEST_SKIP()
+        << "Test fails for Emscipten builds";
+  #else
+    Cpp::CreateInterpreter();
+    EXPECT_EQ(Cpp::Process("int x = 5;"), 0);
+    Cpp::Undo();
+    EXPECT_NE(Cpp::Process("int y = x;"), 0);
+    EXPECT_EQ(Cpp::Process("int x = 10;"), 0);
+    EXPECT_EQ(Cpp::Process("int y = 10;"), 0);
+    Cpp::Undo(2);
+    EXPECT_EQ(Cpp::Process("int x = 20;"), 0);
+    EXPECT_EQ(Cpp::Process("int y = 20;"), 0);
+    int ret = Cpp::Undo(100);
+  #ifdef CPPINTEROP_USE_CLING
+    EXPECT_EQ(ret, 0);
+  #else
+    EXPECT_EQ(ret, 1);
+  #endif
+  #endif
+  }

--- a/unittests/CppInterOp/FunctionReflectionTest.cpp
+++ b/unittests/CppInterOp/FunctionReflectionTest.cpp
@@ -1646,9 +1646,9 @@ TEST(FunctionReflectionTest, UndoTest) {
   cerrs = testing::internal::GetCapturedStderr();
   EXPECT_STREQ(cerrs.c_str(), "");
   int ret = Cpp::Undo(100);
-  #if defined(CPPINTEROP_USE_CLING)
+#ifdef CPPINTEROP_USE_CLING
   EXPECT_EQ(ret, 0);
-  #else
+#else
   EXPECT_EQ(ret, 1);
-  #endif
+#endif
 }

--- a/unittests/CppInterOp/FunctionReflectionTest.cpp
+++ b/unittests/CppInterOp/FunctionReflectionTest.cpp
@@ -1615,3 +1615,17 @@ TEST(FunctionReflectionTest, Destruct) {
   clang_Interpreter_takeInterpreterAsPtr(I);
   clang_Interpreter_dispose(I);
 }
+
+TEST(FunctionReflectionTest, UndoTest) {
+  Cpp::CreateInterpreter();
+  std::string cerrs;
+  testing::internal::CaptureStderr();
+  Cpp::Process("int x = 5;");
+  cerrs = testing::internal::GetCapturedStderr();
+  EXPECT_STREQ(cerrs.c_str(), "");
+  Cpp::Undo();
+  testing::internal::CaptureStderr();
+  Cpp::Process("int x = 10;");
+  cerrs = testing::internal::GetCapturedStderr();
+  EXPECT_STREQ(cerrs.c_str(), "");
+}

--- a/unittests/CppInterOp/FunctionReflectionTest.cpp
+++ b/unittests/CppInterOp/FunctionReflectionTest.cpp
@@ -1617,26 +1617,28 @@ TEST(FunctionReflectionTest, Destruct) {
 }
 
 TEST(FunctionReflectionTest, UndoTest) {
-  #ifdef EMSCRIPTEN
-    GTEST_SKIP()
-        << "Test fails for Emscipten builds";
-  #else
-    Cpp::CreateInterpreter();
-    EXPECT_EQ(Cpp::Process("int a = 5;"), 0);
-    EXPECT_EQ(Cpp::Process("int b = 10;"), 0);
-    EXPECT_EQ(Cpp::Process("int x = 5;"), 0);
-    Cpp::Undo();
-    EXPECT_NE(Cpp::Process("int y = x;"), 0);
-    EXPECT_EQ(Cpp::Process("int x = 10;"), 0);
-    EXPECT_EQ(Cpp::Process("int y = 10;"), 0);
-    Cpp::Undo(2);
-    EXPECT_EQ(Cpp::Process("int x = 20;"), 0);
-    EXPECT_EQ(Cpp::Process("int y = 20;"), 0);
-    int ret = Cpp::Undo(100);
-  #ifdef CPPINTEROP_USE_CLING
-    EXPECT_EQ(ret, 0);
-  #else
-    EXPECT_EQ(ret, 1);
-  #endif
-  #endif
+#ifdef _WIN32
+  GTEST_SKIP() << "Disabled on Windows. Needs fixing.";
+#endif
+#ifdef EMSCRIPTEN
+  GTEST_SKIP() << "Test fails for Emscipten builds";
+#else
+  Cpp::CreateInterpreter();
+  EXPECT_EQ(Cpp::Process("int a = 5;"), 0);
+  EXPECT_EQ(Cpp::Process("int b = 10;"), 0);
+  EXPECT_EQ(Cpp::Process("int x = 5;"), 0);
+  Cpp::Undo();
+  EXPECT_NE(Cpp::Process("int y = x;"), 0);
+  EXPECT_EQ(Cpp::Process("int x = 10;"), 0);
+  EXPECT_EQ(Cpp::Process("int y = 10;"), 0);
+  Cpp::Undo(2);
+  EXPECT_EQ(Cpp::Process("int x = 20;"), 0);
+  EXPECT_EQ(Cpp::Process("int y = 20;"), 0);
+  int ret = Cpp::Undo(100);
+#ifdef CPPINTEROP_USE_CLING
+  EXPECT_EQ(ret, 0);
+#else
+  EXPECT_EQ(ret, 1);
+#endif
+#endif
   }

--- a/unittests/CppInterOp/FunctionReflectionTest.cpp
+++ b/unittests/CppInterOp/FunctionReflectionTest.cpp
@@ -1645,7 +1645,6 @@ TEST(FunctionReflectionTest, UndoTest) {
   Cpp::Process("int y = 20;");
   cerrs = testing::internal::GetCapturedStderr();
   EXPECT_STREQ(cerrs.c_str(), "");
-
   int ret = Cpp::Undo(100);
   #if defined(CPPINTEROP_USE_CLING)
   EXPECT_EQ(ret, 0);

--- a/unittests/CppInterOp/FunctionReflectionTest.cpp
+++ b/unittests/CppInterOp/FunctionReflectionTest.cpp
@@ -1625,7 +1625,28 @@ TEST(FunctionReflectionTest, UndoTest) {
   EXPECT_STREQ(cerrs.c_str(), "");
   Cpp::Undo();
   testing::internal::CaptureStderr();
+  Cpp::Process("int y = x;");
+  cerrs = testing::internal::GetCapturedStderr();
+  EXPECT_STREQ(
+      cerrs.c_str(),
+      "In file included from <<< inputs >>>:1:\ninput_line_2:1:9: error: use "
+      "of undeclared identifier 'x'\n    1 | int y = x;\n      |         "
+      "^\nFailed to parse via ::process:Parsing failed.\n");
+  testing::internal::CaptureStderr();
   Cpp::Process("int x = 10;");
+  cerrs = testing::internal::GetCapturedStderr();
+  EXPECT_STREQ(cerrs.c_str(), "");
+  testing::internal::CaptureStderr();
+  Cpp::Process("int y = 10;");
+  cerrs = testing::internal::GetCapturedStderr();
+  EXPECT_STREQ(cerrs.c_str(), "");
+  Cpp::Undo(2);
+  testing::internal::CaptureStderr();
+  Cpp::Process("int x = 20;");
+  cerrs = testing::internal::GetCapturedStderr();
+  EXPECT_STREQ(cerrs.c_str(), "");
+  testing::internal::CaptureStderr();
+  Cpp::Process("int y = 20;");
   cerrs = testing::internal::GetCapturedStderr();
   EXPECT_STREQ(cerrs.c_str(), "");
 }


### PR DESCRIPTION
# Description

Added ```Undo``` command for Clang-REPL. Reverts the last N operations performed by the interpreter.

## Type of change

- [x] New feature


## Testing
1. Tests in ```unittests/CppInterOp/FunctionReflectionTest.cpp```.
2. Demo - https://res.cloudinary.com/abhi9av/video/upload/v1740997292/wqgfbgqefrwpx2o7ko95.mp4


## Checklist

- [x] I have read the contribution guide recently
