### PR TITLE
Add `BestOverloadFunctionMatch` & `IsFunction` Remove `BestTemplateFunctionMatch`

### DIFF
--- a/include/clang/Interpreter/CppInterOp.h
+++ b/include/clang/Interpreter/CppInterOp.h
@@ -210,6 +210,9 @@ namespace Cpp {
   /// Checks if the scope is a class or not.
   CPPINTEROP_API bool IsClass(TCppScope_t scope);
 
+  /// Checks if the scope is a function.
+  CPPINTEROP_API bool IsFunction(TCppScope_t scope);
+
   /// Checks if the type is a function pointer.
   CPPINTEROP_API bool IsFunctionPointerType(TCppType_t type);
 
@@ -706,17 +709,16 @@ namespace Cpp {
   CPPINTEROP_API TCppFunction_t
   InstantiateTemplateFunctionFromString(const char* function_template);
 
-  /// Finds best template match based on explicit template parameters and
-  /// argument types
+  /// Finds best overload match based on explicit template parameters (if any)
+  /// and argument types.
   ///
-  ///\param[in] candidates - Vector of suitable candidates that come under the
-  ///           parent scope and have the same name (obtained using
-  ///           GetClassTemplatedMethods)
+  ///\param[in] candidates - vector of overloads that come under the
+  ///           parent scope and have the same name
   ///\param[in] explicit_types - set of expicitly instantiated template types
   ///\param[in] arg_types - set of argument types
   ///\returns Instantiated function pointer
   CPPINTEROP_API TCppFunction_t
-  BestTemplateFunctionMatch(const std::vector<TCppFunction_t>& candidates,
+  BestOverloadFunctionMatch(const std::vector<TCppFunction_t>& candidates,
                             const std::vector<TemplateArgInfo>& explicit_types,
                             const std::vector<TemplateArgInfo>& arg_types);
 

--- a/lib/Interpreter/CMakeLists.txt
+++ b/lib/Interpreter/CMakeLists.txt
@@ -140,4 +140,5 @@ endif()
 string(REPLACE ";" "\;" _VER CPPINTEROP_VERSION)
 set_source_files_properties(CppInterOp.cpp PROPERTIES COMPILE_DEFINITIONS
   "LLVM_BINARY_DIR=\"${LLVM_BINARY_DIR}\";CPPINTEROP_VERSION=\"${_VAR}\""
+  COMPILE_FLAGS "-Wno-vla"
 )

--- a/lib/Interpreter/CMakeLists.txt
+++ b/lib/Interpreter/CMakeLists.txt
@@ -141,9 +141,3 @@ string(REPLACE ";" "\;" _VER CPPINTEROP_VERSION)
 set_source_files_properties(CppInterOp.cpp PROPERTIES COMPILE_DEFINITIONS
   "LLVM_BINARY_DIR=\"${LLVM_BINARY_DIR}\";CPPINTEROP_VERSION=\"${_VAR}\""
 )
-
-if(NOT WIN32)
-  set_source_files_properties(CppInterOp.cpp PROPERTIES
-    COMPILE_FLAGS "-Wno-vla"
-  )
-endif()

--- a/lib/Interpreter/CMakeLists.txt
+++ b/lib/Interpreter/CMakeLists.txt
@@ -140,5 +140,10 @@ endif()
 string(REPLACE ";" "\;" _VER CPPINTEROP_VERSION)
 set_source_files_properties(CppInterOp.cpp PROPERTIES COMPILE_DEFINITIONS
   "LLVM_BINARY_DIR=\"${LLVM_BINARY_DIR}\";CPPINTEROP_VERSION=\"${_VAR}\""
-  COMPILE_FLAGS "-Wno-vla"
 )
+
+if(NOT WIN32)
+  set_source_files_properties(CppInterOp.cpp PROPERTIES
+    COMPILE_FLAGS "-Wno-vla"
+  )
+endif()

--- a/lib/Interpreter/CppInterOp.cpp
+++ b/lib/Interpreter/CppInterOp.cpp
@@ -1075,7 +1075,7 @@ namespace Cpp {
     struct WrapperExpr : public OpaqueValueExpr {
       WrapperExpr() : OpaqueValueExpr(clang::Stmt::EmptyShell()) {}
     };
-    WrapperExpr Exprs[arg_types.size()];
+    auto* Exprs = new WrapperExpr[arg_types.size()];
     llvm::SmallVector<Expr*> Args;
     Args.reserve(arg_types.size());
     size_t idx = 0;
@@ -1135,7 +1135,9 @@ namespace Cpp {
     OverloadCandidateSet::iterator Best;
     Overloads.BestViableFunction(S, SourceLocation(), Best);
 
-    return Best != Overloads.end() ? Best->Function : nullptr;
+    FunctionDecl* Result = Best != Overloads.end() ? Best->Function : nullptr;
+    delete[] Exprs;
+    return Result;
   }
 
   // Gets the AccessSpecifier of the function and checks if it is equal to

--- a/lib/Interpreter/CppInterOp.cpp
+++ b/lib/Interpreter/CppInterOp.cpp
@@ -900,7 +900,7 @@ namespace Cpp {
       if (Type->isUndeducedAutoType() && IsTemplatedFunction(FD) &&
           !FD->isDefined()) {
 #ifdef CPPINTEROP_USE_CLING
-        cling::Interpreter::PushTransactionRAII RAII(&I);
+        cling::Interpreter::PushTransactionRAII RAII(&getInterp());
 #endif
         getSema().InstantiateFunctionDefinition(SourceLocation(), FD, true,
                                                 true);
@@ -1061,6 +1061,10 @@ namespace Cpp {
                             const std::vector<TemplateArgInfo>& arg_types) {
     auto& S = getSema();
     auto& C = S.getASTContext();
+
+#ifdef CPPINTEROP_USE_CLING
+    cling::Interpreter::PushTransactionRAII RAII(&getInterp());
+#endif
 
     llvm::SmallVector<Expr*> Args;
     for (auto i : arg_types) {

--- a/lib/Interpreter/CppInterOp.cpp
+++ b/lib/Interpreter/CppInterOp.cpp
@@ -1055,6 +1055,7 @@ namespace Cpp {
         funcs.push_back(Found);
   }
 
+  // Adapted from inner workings of Sema::BuildCallExpr
   TCppFunction_t
   BestOverloadFunctionMatch(const std::vector<TCppFunction_t>& candidates,
                             const std::vector<TemplateArgInfo>& explicit_types,

--- a/lib/Interpreter/CppInterOp.cpp
+++ b/lib/Interpreter/CppInterOp.cpp
@@ -13,16 +13,29 @@
 
 #include "clang/AST/CXXInheritance.h"
 #include "clang/AST/Decl.h"
+#include "clang/AST/DeclAccessPair.h"
+#include "clang/AST/DeclBase.h"
 #include "clang/AST/DeclCXX.h"
+#include "clang/AST/DeclarationName.h"
+#include "clang/AST/Expr.h"
+#include "clang/AST/ExprCXX.h"
 #include "clang/AST/GlobalDecl.h"
 #include "clang/AST/Mangle.h"
+#include "clang/AST/NestedNameSpecifier.h"
 #include "clang/AST/QualTypeNames.h"
 #include "clang/AST/RecordLayout.h"
+#include "clang/AST/Stmt.h"
+#include "clang/AST/Type.h"
 #include "clang/Basic/DiagnosticSema.h"
 #include "clang/Basic/Linkage.h"
+#include "clang/Basic/OperatorKinds.h"
+#include "clang/Basic/SourceLocation.h"
+#include "clang/Basic/Specifiers.h"
 #include "clang/Basic/Version.h"
 #include "clang/Frontend/CompilerInstance.h"
 #include "clang/Sema/Lookup.h"
+#include "clang/Sema/Overload.h"
+#include "clang/Sema/Ownership.h"
 #include "clang/Sema/Sema.h"
 #if CLANG_VERSION_MAJOR >= 19
 #include "clang/Sema/Redeclaration.h"
@@ -208,6 +221,11 @@ namespace Cpp {
   bool IsClass(TCppScope_t scope) {
     Decl *D = static_cast<Decl*>(scope);
     return isa<CXXRecordDecl>(D);
+  }
+
+  bool IsFunction(TCppScope_t scope) {
+    Decl* D = static_cast<Decl*>(scope);
+    return isa<FunctionDecl>(D);
   }
 
   bool IsFunctionPointerType(TCppType_t type) {
@@ -877,8 +895,19 @@ namespace Cpp {
   TCppType_t GetFunctionReturnType(TCppFunction_t func)
   {
     auto *D = (clang::Decl *) func;
-    if (auto* FD = llvm::dyn_cast_or_null<clang::FunctionDecl>(D))
-      return FD->getReturnType().getAsOpaquePtr();
+    if (auto* FD = llvm::dyn_cast_or_null<clang::FunctionDecl>(D)) {
+      QualType Type = FD->getReturnType();
+      if (Type->isUndeducedAutoType() && IsTemplatedFunction(FD) &&
+          !FD->isDefined()) {
+#ifdef CPPINTEROP_USE_CLING
+        cling::Interpreter::PushTransactionRAII RAII(&I);
+#endif
+        getSema().InstantiateFunctionDefinition(SourceLocation(), FD, true,
+                                                true);
+        Type = FD->getReturnType();
+      }
+      return Type.getAsOpaquePtr();
+    }
 
     if (auto* FD = llvm::dyn_cast_or_null<clang::FunctionTemplateDecl>(D))
       return (FD->getTemplatedDecl())->getReturnType().getAsOpaquePtr();
@@ -1027,61 +1056,74 @@ namespace Cpp {
   }
 
   TCppFunction_t
-  BestTemplateFunctionMatch(const std::vector<TCppFunction_t>& candidates,
+  BestOverloadFunctionMatch(const std::vector<TCppFunction_t>& candidates,
                             const std::vector<TemplateArgInfo>& explicit_types,
                             const std::vector<TemplateArgInfo>& arg_types) {
+    auto& S = getSema();
+    auto& C = S.getASTContext();
 
-    for (const auto& candidate : candidates) {
-      auto* TFD = (FunctionTemplateDecl*)candidate;
-      clang::TemplateParameterList* tpl = TFD->getTemplateParameters();
-
-      // template parameter size does not match
-      if (tpl->size() < explicit_types.size())
-        continue;
-
-      // right now uninstantiated functions give template typenames instead of
-      // actual types. We make this match solely based on count
-
-      const FunctionDecl* func = TFD->getTemplatedDecl();
-
-#ifdef CPPINTEROP_USE_CLING
-      if (func->getNumParams() > arg_types.size())
-        continue;
-#else // CLANG_REPL
-      if (func->getMinRequiredArguments() > arg_types.size())
-        continue;
-#endif
-
-      // TODO(aaronj0) : first score based on the type similarity before forcing
-      // instantiation.
-
-      TCppFunction_t instantiated =
-          InstantiateTemplate(candidate, arg_types.data(), arg_types.size());
-      if (instantiated)
-        return instantiated;
-
-      // Force the instantiation with template params in case of no args
-      // maybe steer instantiation better with arg set returned from
-      // TemplateProxy?
-      instantiated = InstantiateTemplate(candidate, explicit_types.data(),
-                                          explicit_types.size());
-      if (instantiated)
-        return instantiated;
-
-      // join explicit and arg_types
-      std::vector<TemplateArgInfo> total_arg_set;
-      total_arg_set.reserve(explicit_types.size() + arg_types.size());
-      total_arg_set.insert(total_arg_set.end(), explicit_types.begin(),
-                           explicit_types.end());
-      total_arg_set.insert(total_arg_set.end(), arg_types.begin(),
-                           arg_types.end());
-
-      instantiated = InstantiateTemplate(candidate, total_arg_set.data(),
-                                         total_arg_set.size());
-      if (instantiated)
-        return instantiated;
+    llvm::SmallVector<Expr*> Args;
+    for (auto i : arg_types) {
+      QualType Type = QualType::getFromOpaquePtr(i.m_Type);
+      ExprValueKind ExprKind = ExprValueKind::VK_PRValue;
+      if (Type->isReferenceType())
+        ExprKind = ExprValueKind::VK_LValue;
+      Args.push_back(new (getSema().getASTContext())
+                         OpaqueValueExpr(SourceLocation::getFromRawEncoding(1),
+                                         Type.getNonReferenceType(), ExprKind));
     }
-    return nullptr;
+
+    // Create a list of template arguments.
+    llvm::SmallVector<TemplateArgument> TemplateArgs;
+    TemplateArgs.reserve(explicit_types.size());
+    for (auto explicit_type : explicit_types) {
+      QualType ArgTy = QualType::getFromOpaquePtr(explicit_type.m_Type);
+      if (explicit_type.m_IntegralValue) {
+        // We have a non-type template parameter. Create an integral value from
+        // the string representation.
+        auto Res = llvm::APSInt(explicit_type.m_IntegralValue);
+        Res = Res.extOrTrunc(C.getIntWidth(ArgTy));
+        TemplateArgs.push_back(TemplateArgument(C, Res, ArgTy));
+      } else {
+        TemplateArgs.push_back(ArgTy);
+      }
+    }
+
+    TemplateArgumentListInfo TLI{};
+    for (auto TA : TemplateArgs)
+      TLI.addArgument(
+          S.getTrivialTemplateArgumentLoc(TA, QualType(), SourceLocation()));
+
+    OverloadCandidateSet Overloads(
+        SourceLocation(), OverloadCandidateSet::CandidateSetKind::CSK_Normal);
+    for (void* i : candidates) {
+      Decl* D = static_cast<Decl*>(i);
+      if (auto* MD = dyn_cast<CXXMethodDecl>(D)) {
+        S.AddMethodCandidate(
+            MD, DeclAccessPair::make(MD, MD->getAccess()), MD->getParent(),
+            C.getTypeDeclType(MD->getParent()),
+            Expr::Classification::makeSimpleLValue(), Args, Overloads);
+      } else if (auto* FD = dyn_cast<FunctionDecl>(D)) {
+        S.AddOverloadCandidate(FD, DeclAccessPair::make(FD, FD->getAccess()),
+                               Args, Overloads);
+      } else if (auto* FTD = dyn_cast<FunctionTemplateDecl>(D)) {
+        if (auto* CXXRD =
+                dyn_cast<CXXRecordDecl>(FTD->getTemplatedDecl()->getParent())) {
+          S.AddMethodTemplateCandidate(
+              FTD, DeclAccessPair::make(FTD, FTD->getAccess()), CXXRD, &TLI,
+              C.getTypeDeclType(CXXRD),
+              Expr::Classification::makeSimpleLValue(), Args, Overloads);
+        } else {
+          S.AddTemplateOverloadCandidate(
+              FTD, DeclAccessPair::make(FTD, FTD->getAccess()), &TLI, Args,
+              Overloads);
+        }
+      }
+    }
+    OverloadCandidateSet::iterator Best;
+    Overloads.BestViableFunction(S, SourceLocation(), Best);
+
+    return Best != Overloads.end() ? Best->Function : nullptr;
   }
 
   // Gets the AccessSpecifier of the function and checks if it is equal to

--- a/lib/Interpreter/CppInterOp.cpp
+++ b/lib/Interpreter/CppInterOp.cpp
@@ -1121,6 +1121,11 @@ namespace Cpp {
         S.AddOverloadCandidate(FD, DeclAccessPair::make(FD, FD->getAccess()),
                                Args, Overloads);
       } else if (auto* FTD = dyn_cast<FunctionTemplateDecl>(D)) {
+        // AddTemplateOverloadCandidate is causing a memory leak
+        // It is a known bug at clang
+        // call stack: AddTemplateOverloadCandidate -> MakeDeductionFailureInfo
+        // source:
+        // https://github.com/llvm/llvm-project/blob/release/19.x/clang/lib/Sema/SemaOverload.cpp#L731-L756
         S.AddTemplateOverloadCandidate(
             FTD, DeclAccessPair::make(FTD, FTD->getAccess()),
             &ExplicitTemplateArgs, Args, Overloads);

--- a/unittests/CppInterOp/FunctionReflectionTest.cpp
+++ b/unittests/CppInterOp/FunctionReflectionTest.cpp
@@ -590,7 +590,7 @@ TEST(FunctionReflectionTest, InstantiateTemplateMethod) {
   EXPECT_TRUE(TA1.getAsType()->isIntegerType());
 }
 
-TEST(FunctionReflectionTest, BestTemplateFunctionMatch) {
+TEST(FunctionReflectionTest, BestOverloadFunctionMatch1) {
   std::vector<Decl*> Decls;
   std::string code = R"(
     class MyTemplatedMethodClass {
@@ -598,7 +598,7 @@ TEST(FunctionReflectionTest, BestTemplateFunctionMatch) {
           template<class A> long get_size(A&);
           template<class A> long get_size();
           template<class A, class B> long get_size(A a, B b);
-          template<class A> long add_size(float a);
+          template<class A> long get_size(float a);
       };
 
       template<class A>
@@ -612,7 +612,7 @@ TEST(FunctionReflectionTest, BestTemplateFunctionMatch) {
       }
 
       template<class A>
-      long MyTemplatedMethodClass::add_size(float a) {
+      long MyTemplatedMethodClass::get_size(float a) {
           return sizeof(A) + long(a);
       }
 
@@ -631,17 +631,22 @@ TEST(FunctionReflectionTest, BestTemplateFunctionMatch) {
   ASTContext& C = Interp->getCI()->getASTContext();
 
   std::vector<Cpp::TemplateArgInfo> args0;
-  std::vector<Cpp::TemplateArgInfo> args1 = {C.IntTy.getAsOpaquePtr()};
+  std::vector<Cpp::TemplateArgInfo> args1 = {
+      C.getLValueReferenceType(C.IntTy).getAsOpaquePtr()};
   std::vector<Cpp::TemplateArgInfo> args2 = {C.CharTy.getAsOpaquePtr(), C.FloatTy.getAsOpaquePtr()};
   std::vector<Cpp::TemplateArgInfo> args3 = {C.FloatTy.getAsOpaquePtr()};
 
   std::vector<Cpp::TemplateArgInfo> explicit_args0;
   std::vector<Cpp::TemplateArgInfo> explicit_args1 = {C.IntTy.getAsOpaquePtr()};
 
-  Cpp::TCppFunction_t func1 = Cpp::BestTemplateFunctionMatch(candidates, explicit_args0, args1);
-  Cpp::TCppFunction_t func2 = Cpp::BestTemplateFunctionMatch(candidates, explicit_args1, args0);
-  Cpp::TCppFunction_t func3 = Cpp::BestTemplateFunctionMatch(candidates, explicit_args0, args2);
-  Cpp::TCppFunction_t func4 = Cpp::BestTemplateFunctionMatch(candidates, explicit_args1, args3);
+  Cpp::TCppFunction_t func1 =
+      Cpp::BestOverloadFunctionMatch(candidates, explicit_args0, args1);
+  Cpp::TCppFunction_t func2 =
+      Cpp::BestOverloadFunctionMatch(candidates, explicit_args1, args0);
+  Cpp::TCppFunction_t func3 =
+      Cpp::BestOverloadFunctionMatch(candidates, explicit_args0, args2);
+  Cpp::TCppFunction_t func4 =
+      Cpp::BestOverloadFunctionMatch(candidates, explicit_args1, args3);
 
   EXPECT_EQ(Cpp::GetFunctionSignature(func1),
             "template<> long MyTemplatedMethodClass::get_size<int>(int &)");
@@ -650,7 +655,226 @@ TEST(FunctionReflectionTest, BestTemplateFunctionMatch) {
   EXPECT_EQ(Cpp::GetFunctionSignature(func3),
             "template<> long MyTemplatedMethodClass::get_size<char, float>(char a, float b)");
   EXPECT_EQ(Cpp::GetFunctionSignature(func4),
-            "template<> long MyTemplatedMethodClass::get_size<float>(float &)");
+            "template<> long MyTemplatedMethodClass::get_size<int>(float a)");
+}
+
+TEST(FunctionReflectionTest, BestOverloadFunctionMatch2) {
+  std::vector<Decl*> Decls;
+  std::string code = R"(
+    template<typename T>
+    struct A { T value; };
+
+    A<int> a;
+
+    template<typename T>
+    void somefunc(A<T> arg) {}
+
+    template<typename T>
+    void somefunc(T arg) {}
+
+    template<typename T>
+    void somefunc(A<T> arg1, A<T> arg2) {}
+
+    template<typename T>
+    void somefunc(T arg1, T arg2) {}
+
+    void somefunc(int arg1, double arg2) {}
+  )";
+
+  GetAllTopLevelDecls(code, Decls);
+  std::vector<Cpp::TCppFunction_t> candidates;
+
+  for (auto decl : Decls)
+    if (Cpp::IsFunction(decl) || Cpp::IsTemplatedFunction(decl))
+      candidates.push_back((Cpp::TCppFunction_t)decl);
+
+  EXPECT_EQ(candidates.size(), 5);
+
+  ASTContext& C = Interp->getCI()->getASTContext();
+
+  std::vector<Cpp::TemplateArgInfo> args1 = {C.IntTy.getAsOpaquePtr()};
+  std::vector<Cpp::TemplateArgInfo> args2 = {
+      Cpp::GetVariableType(Cpp::GetNamed("a"))};
+  std::vector<Cpp::TemplateArgInfo> args3 = {C.IntTy.getAsOpaquePtr(),
+                                             C.IntTy.getAsOpaquePtr()};
+  std::vector<Cpp::TemplateArgInfo> args4 = {
+      Cpp::GetVariableType(Cpp::GetNamed("a")),
+      Cpp::GetVariableType(Cpp::GetNamed("a"))};
+  std::vector<Cpp::TemplateArgInfo> args5 = {C.IntTy.getAsOpaquePtr(),
+                                             C.DoubleTy.getAsOpaquePtr()};
+
+  std::vector<Cpp::TemplateArgInfo> explicit_args;
+
+  Cpp::TCppFunction_t func1 =
+      Cpp::BestOverloadFunctionMatch(candidates, explicit_args, args1);
+  Cpp::TCppFunction_t func2 =
+      Cpp::BestOverloadFunctionMatch(candidates, explicit_args, args2);
+  Cpp::TCppFunction_t func3 =
+      Cpp::BestOverloadFunctionMatch(candidates, explicit_args, args3);
+  Cpp::TCppFunction_t func4 =
+      Cpp::BestOverloadFunctionMatch(candidates, explicit_args, args4);
+  Cpp::TCppFunction_t func5 =
+      Cpp::BestOverloadFunctionMatch(candidates, explicit_args, args5);
+
+  EXPECT_EQ(Cpp::GetFunctionSignature(func1),
+            "template<> void somefunc<int>(int arg)");
+  EXPECT_EQ(Cpp::GetFunctionSignature(func2),
+            "template<> void somefunc<int>(A<int> arg)");
+  EXPECT_EQ(Cpp::GetFunctionSignature(func3),
+            "template<> void somefunc<int>(int arg1, int arg2)");
+  EXPECT_EQ(Cpp::GetFunctionSignature(func4),
+            "template<> void somefunc<int>(A<int> arg1, A<int> arg2)");
+  EXPECT_EQ(Cpp::GetFunctionSignature(func5),
+            "void somefunc(int arg1, double arg2)");
+}
+
+TEST(FunctionReflectionTest, BestOverloadFunctionMatch3) {
+  std::vector<Decl*> Decls;
+  std::string code = R"(
+    template<typename T>
+    struct A {
+      T value;
+      
+      template<typename TT>
+      A<TT> operator-(A<TT> rhs) {
+        return A<TT>{value - rhs.value};
+      }
+    };
+
+    A<int> a;
+
+    template<typename T>
+    A<T> operator+(A<T> lhs, A<T> rhs) {
+      return A<T>{lhs.value + rhs.value};
+    }
+
+    template<typename T>
+    A<T> operator+(A<T> lhs, int rhs) {
+      return A<T>{lhs.value + rhs};
+    }
+  )";
+
+  GetAllTopLevelDecls(code, Decls);
+  std::vector<Cpp::TCppFunction_t> candidates;
+
+  for (auto decl : Decls)
+    if (Cpp::IsTemplatedFunction(decl))
+      candidates.push_back((Cpp::TCppFunction_t)decl);
+
+  EXPECT_EQ(candidates.size(), 2);
+
+  ASTContext& C = Interp->getCI()->getASTContext();
+
+  std::vector<Cpp::TemplateArgInfo> args1 = {
+      Cpp::GetVariableType(Cpp::GetNamed("a")),
+      Cpp::GetVariableType(Cpp::GetNamed("a"))};
+  std::vector<Cpp::TemplateArgInfo> args2 = {
+      Cpp::GetVariableType(Cpp::GetNamed("a")), C.IntTy.getAsOpaquePtr()};
+  std::vector<Cpp::TemplateArgInfo> args3 = {
+      Cpp::GetVariableType(Cpp::GetNamed("a")), C.DoubleTy.getAsOpaquePtr()};
+
+  std::vector<Cpp::TemplateArgInfo> explicit_args;
+
+  Cpp::TCppFunction_t func1 =
+      Cpp::BestOverloadFunctionMatch(candidates, explicit_args, args1);
+  Cpp::TCppFunction_t func2 =
+      Cpp::BestOverloadFunctionMatch(candidates, explicit_args, args2);
+  Cpp::TCppFunction_t func3 =
+      Cpp::BestOverloadFunctionMatch(candidates, explicit_args, args3);
+
+  candidates.clear();
+  Cpp::GetOperator(
+      Cpp::GetScopeFromType(Cpp::GetVariableType(Cpp::GetNamed("a"))),
+      Cpp::Operator::OP_Minus, candidates);
+
+  EXPECT_EQ(candidates.size(), 1);
+
+  std::vector<Cpp::TemplateArgInfo> args4 = {
+      Cpp::GetVariableType(Cpp::GetNamed("a"))};
+
+  Cpp::TCppFunction_t func4 =
+      Cpp::BestOverloadFunctionMatch(candidates, explicit_args, args4);
+
+  EXPECT_EQ(Cpp::GetFunctionSignature(func1),
+            "template<> A<int> operator+<int>(A<int> lhs, A<int> rhs)");
+  EXPECT_EQ(Cpp::GetFunctionSignature(func2),
+            "template<> A<int> operator+<int>(A<int> lhs, int rhs)");
+  EXPECT_EQ(Cpp::GetFunctionSignature(func3),
+            "template<> A<int> operator+<int>(A<int> lhs, int rhs)");
+
+  EXPECT_EQ(Cpp::GetFunctionSignature(func4),
+            "template<> A<int> A<int>::operator-<int>(A<int> rhs)");
+}
+
+TEST(FunctionReflectionTest, BestOverloadFunctionMatch4) {
+  std::vector<Decl*> Decls, SubDecls;
+  std::string code = R"(
+    template<typename T>
+    struct A { T value; };
+
+    class B {
+    public:
+      void fn() {}
+      template <typename T>
+      void fn(T x) {}
+      template <typename T>
+      void fn(A<T> x) {}
+      template <typename T1, typename T2>
+      void fn(A<T1> x, A<T2> y) {}
+    };
+
+    A<int> a;
+    A<double> b;
+  )";
+
+  GetAllTopLevelDecls(code, Decls);
+  GetAllSubDecls(Decls[1], SubDecls);
+  std::vector<Cpp::TCppFunction_t> candidates;
+  for (auto i : SubDecls) {
+    if ((Cpp::IsFunction(i) || Cpp::IsTemplatedFunction(i)) &&
+        Cpp::GetName(i) == "fn")
+      candidates.push_back(i);
+  }
+
+  EXPECT_EQ(candidates.size(), 4);
+
+  ASTContext& C = Interp->getCI()->getASTContext();
+
+  std::vector<Cpp::TemplateArgInfo> args1 = {};
+  std::vector<Cpp::TemplateArgInfo> args2 = {C.IntTy.getAsOpaquePtr()};
+  std::vector<Cpp::TemplateArgInfo> args3 = {
+      Cpp::GetVariableType(Cpp::GetNamed("a"))};
+  std::vector<Cpp::TemplateArgInfo> args4 = {
+      Cpp::GetVariableType(Cpp::GetNamed("a")),
+      Cpp::GetVariableType(Cpp::GetNamed("b"))};
+  std::vector<Cpp::TemplateArgInfo> args5 = {
+      Cpp::GetVariableType(Cpp::GetNamed("a")),
+      Cpp::GetVariableType(Cpp::GetNamed("a"))};
+
+  std::vector<Cpp::TemplateArgInfo> explicit_args1;
+  std::vector<Cpp::TemplateArgInfo> explicit_args2 = {C.IntTy.getAsOpaquePtr(),
+                                                      C.IntTy.getAsOpaquePtr()};
+
+  Cpp::TCppFunction_t func1 =
+      Cpp::BestOverloadFunctionMatch(candidates, explicit_args1, args1);
+  Cpp::TCppFunction_t func2 =
+      Cpp::BestOverloadFunctionMatch(candidates, explicit_args1, args2);
+  Cpp::TCppFunction_t func3 =
+      Cpp::BestOverloadFunctionMatch(candidates, explicit_args1, args3);
+  Cpp::TCppFunction_t func4 =
+      Cpp::BestOverloadFunctionMatch(candidates, explicit_args1, args4);
+  Cpp::TCppFunction_t func5 =
+      Cpp::BestOverloadFunctionMatch(candidates, explicit_args2, args5);
+
+  EXPECT_EQ(Cpp::GetFunctionSignature(func1), "void B::fn()");
+  EXPECT_EQ(Cpp::GetFunctionSignature(func2),
+            "template<> void B::fn<int>(int x)");
+  EXPECT_EQ(Cpp::GetFunctionSignature(func3),
+            "template<> void B::fn<int>(A<int> x)");
+  EXPECT_EQ(Cpp::GetFunctionSignature(func4),
+            "template<> void B::fn<int, double>(A<int> x, A<double> y)");
+  EXPECT_EQ(Cpp::GetFunctionSignature(func5),
+            "template<> void B::fn<int, int>(A<int> x, A<int> y)");
 }
 
 TEST(FunctionReflectionTest, IsPublicMethod) {


### PR DESCRIPTION
# Description

Resolve and instantiate (if templated) overload from vector of overloads for the given template parameter types and argument types.
With these changes, we replicate clang's overload resolution and template instantiation.

## Fixes # (issue)

Fixes 10 test cases in cppyy.
Can close https://github.com/compiler-research/CppInterOp/pull/352 and https://github.com/compiler-research/CppInterOp/pull/511.

## Type of change

Please tick all options which are relevant.

- [x] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Included tests

## Checklist

- [x] I have read the contribution guide recently
