### PR TITLE
[cmake] Fix bugs if CppInterOp is a non-standalone build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -293,16 +293,15 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 # In rare cases we might want to have clang installed in a different place
 # than llvm and the header files should be found first (even though the
 # LLVM_INCLUDE_DIRS) contain clang headers, too.
-if (CPPINTEROP_USE_CLING)
+if(CPPINTEROP_USE_CLING)
   add_definitions(-DCPPINTEROP_USE_CLING)
   include_directories(SYSTEM ${CLING_INCLUDE_DIRS})
-  else()
-  if (NOT CPPINTEROP_USE_REPL)
-  message(FATAL_ERROR "We need either CPPINTEROP_USE_CLING or CPPINTEROP_USE_REPL")
-  endif()
+elseif(CPPINTEROP_USE_REPL)
   add_definitions(-DCPPINTEROP_USE_REPL)
+else()
+  message(FATAL_ERROR "We need either CPPINTEROP_USE_CLING or CPPINTEROP_USE_REPL")
+endif()
 
-endif(CPPINTEROP_USE_CLING)
 include_directories(SYSTEM ${CLANG_INCLUDE_DIRS})
 include_directories(SYSTEM ${LLVM_INCLUDE_DIRS})
 separate_arguments(LLVM_DEFINITIONS_LIST NATIVE_COMMAND ${LLVM_DEFINITIONS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,16 @@ set(CMAKE_MODULE_PATH
   "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules"
   )
 
+enable_language(CXX)
+set(CMAKE_CXX_EXTENSIONS NO)
+
+option(CPPINTEROP_USE_CLING "Use Cling as backend" OFF)
+option(CPPINTEROP_USE_REPL "Use clang-repl as backend" ON)
+option(CPPINTEROP_ENABLE_TESTING "Enable the CppInterOp testing infrastructure." ON)
+
+if (CPPINTEROP_USE_CLING AND CPPINTEROP_USE_REPL)
+message(FATAL_ERROR "We can only use Cling (${CPPINTEROP_USE_CLING}=On) or Repl (CPPINTEROP_USE_REPL=On), but not both of them.")
+endif()
 # If we are not building as a part of LLVM, build CppInterOp as a standalone
 # project, using LLVM as an external library:
 if( CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR )
@@ -54,17 +64,7 @@ if( CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR )
     endif()
   endif()
 
-enable_language(CXX)
-set(CMAKE_CXX_EXTENSIONS NO)
 include(GNUInstallDirs)
-  option(CPPINTEROP_USE_CLING "Use Cling as backend" OFF)
-  option(CPPINTEROP_USE_REPL "Use clang-repl as backend" ON)
-  option(CPPINTEROP_ENABLE_TESTING "Enable the CppInterOp testing infrastructure." ON)
-
-  if (CPPINTEROP_USE_CLING AND CPPINTEROP_USE_REPL)
-    message(FATAL_ERROR "We can only use Cling (CPPINTEROP_USE_CLING=On) or Repl (CPPINTEROP_USE_REPL=On), but not both of them.")
-  endif()
-  
   ## Define supported version of clang and llvm
 
   set(CLANG_MIN_SUPPORTED 13.0)


### PR DESCRIPTION
# Description

This PR includes a set of changes fixing bugs in the CMake:

Move interpreter and testing options outside the standalone build condition: The options are not correctly propagated (or defined) and CppInterOp does not configure or check the flags when it is not built standalone. This has more fatal consequences, currently in a non-standalone built like in ROOT you can set both `USE_CLING` and `USE_REPL` ON. This sets both definitions and include directories, since the check only happens inside the standalone block.

Improve the check when both interpreter modes are OFF: When having both modes ON, I noticed the style of [CMakeLists.txt#L296-L305](https://github.com/compiler-research/CppInterOp/blob/7caf10b1ccae74e62600b1b5fe05dc4e71db93bb/CMakeLists.txt#L296-L305 ) is not optimal and can be clearer with an elseif for `USE_REPL`