### PR TITLE
[cmake] Drop unecessary Cling and LLVM path messages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -307,13 +307,6 @@ include_directories(SYSTEM ${LLVM_INCLUDE_DIRS})
 separate_arguments(LLVM_DEFINITIONS_LIST NATIVE_COMMAND ${LLVM_DEFINITIONS})
 add_definitions(${LLVM_DEFINITIONS_LIST})
 
-if (CPPINTEROP_USE_CLING)
-  message(STATUS "CLING_INCLUDE_DIRS: ${CLING_INCLUDE_DIRS}")
-endif(CPPINTEROP_USE_CLING)
-message(STATUS "CLANG_INCLUDE_DIRS: ${CLANG_INCLUDE_DIRS}")
-message(STATUS "LLVM_INCLUDE_DIRS: ${LLVM_INCLUDE_DIRS}")
-message(STATUS "LLVM_DEFINITIONS_LIST: ${LLVM_DEFINITIONS_LIST}")
-
 # If the llvm sources are present add them with higher priority.
 if (LLVM_BUILD_MAIN_SRC_DIR)
   # LLVM_INCLUDE_DIRS contains the include paths to both LLVM's source and


### PR DESCRIPTION
This PR drops messages that seem like they are used for debugging, making the build less verbose.

Closes #520 