### PR TITLE
Use target_link_options instead of set_target_properties for linking

### DIFF
--- a/lib/Interpreter/CMakeLists.txt
+++ b/lib/Interpreter/CMakeLists.txt
@@ -129,9 +129,13 @@ if(EMSCRIPTEN)
   #FIXME: A patch is needed to llvm to remove -Wl,-z,defs since it is now recognised on emscripten. What needs to be removed is here
   # https://github.com/llvm/llvm-project/blob/128e2e446e90c3b1827cfc7d4d19e3c0976beff3/llvm/cmake/modules/HandleLLVMOptions.cmake#L318 . The PR to do try to do this is here 
   # https://github.com/llvm/llvm-project/pull/123396
-  set_target_properties(clangCppInterOp PROPERTIES 
-    NO_SONAME 1
-    LINK_FLAGS "-s WASM_BIGINT  -s SIDE_MODULE=1 ${SYMBOLS_LIST}"
+  set_target_properties(clangCppInterOp
+    PROPERTIES NO_SONAME 1
+  )
+  target_link_options(clangCppInterOp
+    PRIVATE "SHELL: -s WASM_BIGINT"
+    PRIVATE "SHELL: -s SIDE_MODULE=1"
+    PRIVATE "SHELL: ${SYMBOLS_LIST}"
   )
   if (CPPINTEROP_ENABLE_TESTING)
     # When compiling Emscripten tests the shared library it links to is expected to be in the same folder as the compiled Javascript

--- a/unittests/CppInterOp/TestSharedLib/CMakeLists.txt
+++ b/unittests/CppInterOp/TestSharedLib/CMakeLists.txt
@@ -11,9 +11,12 @@ set_output_directory(TestSharedLib
 
 
 if (EMSCRIPTEN)
-  set_target_properties(TestSharedLib PROPERTIES
-    NO_SONAME 1
-    LINK_FLAGS "-s WASM_BIGINT  -s SIDE_MODULE=1"
+  set_target_properties(TestSharedLib
+    PROPERTIES NO_SONAME 1
+  )
+  target_link_options(TestSharedLib
+    PRIVATE "SHELL: -s WASM_BIGINT"
+    PRIVATE "SHELL: -s SIDE_MODULE=1"
   )
 endif()
 


### PR DESCRIPTION
# Description

CppInterOp used to use `target_link_options`  before #483 went in. Not sure why this change was made. set_target_properties comes under the old style cmake and `target_link_options` and `target_compile_options` falls under mordern cmake which cmake promotes to be used with `target_link_libraries`.

This PR reverts back to what we were originally using. `add_llvm_library` internally make use of target_link_libraries and we should use `target_link_options` that goes with it .


## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [x] I have read the contribution guide recently
