### PR TITLE
Remove unused LLVM_LINK_COMPONENTS unittests folder

### DIFF
--- a/unittests/CppInterOp/CMakeLists.txt
+++ b/unittests/CppInterOp/CMakeLists.txt
@@ -1,6 +1,3 @@
-set(LLVM_LINK_COMPONENTS
-  Support
-)
 if (EMSCRIPTEN)
   # Omitting CUDATest.cpp since Emscripten build currently has no GPU support
   # For Emscripten builds linking to gtest_main will not suffice for gtest to run


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

I believe this reference to LLVM_LINK_COMPONENTS in the unittests folder is unused. 

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [x] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [x] I have read the contribution guide recently
