### PR TITLE
Remove references to CPPINTEROP_BUILD_DIR in Emscripten build

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -116,7 +116,6 @@ jobs:
         # Build CppInterOp next to cling and llvm-project.
         mkdir build
         cd build
-        export CPPINTEROP_BUILD_DIR=$PWD
 
         if [[ "${cling_on}" == "ON" ]]; then
           emcmake  cmake -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }}        \
@@ -153,7 +152,6 @@ jobs:
 
         echo "SYSROOT_PATH=$SYSROOT_PATH" >> $GITHUB_ENV        
         echo "CB_PYTHON_DIR=$CB_PYTHON_DIR" >> $GITHUB_ENV
-        echo "CPPINTEROP_BUILD_DIR=$CPPINTEROP_BUILD_DIR" >> $GITHUB_ENV
         echo "CPPINTEROP_DIR=$CPPINTEROP_DIR" >> $GITHUB_ENV
         echo "LLVM_BUILD_DIR=$LLVM_BUILD_DIR" >> $GITHUB_ENV
         echo "CPLUS_INCLUDE_PATH=$CPLUS_INCLUDE_PATH" >> $GITHUB_ENV
@@ -177,7 +175,6 @@ jobs:
           -DCMAKE_INSTALL_PREFIX=${{ env.PREFIX }}          \
           -DXEUS_CPP_EMSCRIPTEN_WASM_BUILD=ON               \
           -DCMAKE_FIND_ROOT_PATH_MODE_PACKAGE=ON            \
-          -DCppInterOp_DIR="${{ env.CPPINTEROP_BUILD_DIR }}/lib/cmake/CppInterOp"  \
           -DSYSROOT_PATH=${{ env.SYSROOT_PATH }}                     \
           ..
         emmake make -j ${{ env.ncpus }} install

--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -571,7 +571,6 @@ jobs:
         # Build CppInterOp next to cling and llvm-project.
         mkdir build
         cd build
-        export CPPINTEROP_BUILD_DIR=$PWD
         if [[ "${cling_on}" == "ON" ]]; then
           emcmake cmake -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }}        \
                 -DCPPINTEROP_USE_CLING=ON                                  \
@@ -609,7 +608,6 @@ jobs:
 
         echo "SYSROOT_PATH=$SYSROOT_PATH" >> $GITHUB_ENV
         echo "CB_PYTHON_DIR=$CB_PYTHON_DIR" >> $GITHUB_ENV
-        echo "CPPINTEROP_BUILD_DIR=$CPPINTEROP_BUILD_DIR" >> $GITHUB_ENV
         echo "CPPINTEROP_DIR=$CPPINTEROP_DIR" >> $GITHUB_ENV
         echo "LLVM_BUILD_DIR=$LLVM_BUILD_DIR" >> $GITHUB_ENV
         echo "CPLUS_INCLUDE_PATH=$CPLUS_INCLUDE_PATH" >> $GITHUB_ENV
@@ -633,7 +631,6 @@ jobs:
           -DCMAKE_INSTALL_PREFIX=${{ env.PREFIX }}          \
           -DXEUS_CPP_EMSCRIPTEN_WASM_BUILD=ON               \
           -DCMAKE_FIND_ROOT_PATH_MODE_PACKAGE=ON            \
-          -DCppInterOp_DIR="${{ env.CPPINTEROP_BUILD_DIR }}/lib/cmake/CppInterOp"  \
           -DSYSROOT_PATH=${{ env.SYSROOT_PATH }}                     \
           ..
         emmake make -j ${{ env.ncpus }} install

--- a/Emscripten-build-instructions.md
+++ b/Emscripten-build-instructions.md
@@ -121,12 +121,6 @@ Assuming it passes all test you can install by executing the following
 emmake make -j $(nproc --all) install
 ```
 
-Once this finishes building we need to take note of where we built CppInterOp. This can be done by executing the following
-
-```bash
-export CPPINTEROP_BUILD_DIR=$PWD
-```
-
 ## Xeus-cpp-lite Wasm Build Instructions
 
 A project which makes use of the wasm build of CppInterOp is xeus-cpp. xeus-cpp is a C++ Jupyter kernel. Assuming you are in  
@@ -144,7 +138,6 @@ emcmake cmake \
           -DCMAKE_INSTALL_PREFIX=$PREFIX                                 \
           -DXEUS_CPP_EMSCRIPTEN_WASM_BUILD=ON                            \
           -DCMAKE_FIND_ROOT_PATH_MODE_PACKAGE=ON                         \
-          -DCppInterOp_DIR="$CPPINTEROP_BUILD_DIR/lib/cmake/CppInterOp"  \
           -DSYSROOT_PATH=$SYSROOT_PATH                                   \
           ..
  emmake make -j $(nproc --all) install

--- a/docs/Emscripten-build-instructions.rst
+++ b/docs/Emscripten-build-instructions.rst
@@ -139,13 +139,6 @@ Assuming it passes all test you can install by executing the following.
 
    emmake make -j $(nproc --all) install
 
-Once this finishes building we need to take note of where we built
-CppInterOp. This can be done by executing the following
-
-.. code:: bash
-
-   export CPPINTEROP_BUILD_DIR=$PWD
-
 ## Xeus-cpp-lite Wasm Build Instructions
 
 A project which makes use of the wasm build of CppInterOp is xeus-cpp.
@@ -165,7 +158,6 @@ build folder, you can build the wasm version of xeus-cpp by executing
            -DCMAKE_INSTALL_PREFIX=$PREFIX                                 \
            -DXEUS_CPP_EMSCRIPTEN_WASM_BUILD=ON                            \
            -DCMAKE_FIND_ROOT_PATH_MODE_PACKAGE=ON                         \
-           -DCppInterOp_DIR="$CPPINTEROP_BUILD_DIR/lib/cmake/CppInterOp"  \
            -DSYSROOT_PATH=$SYSROOT_PATH                                   \
            ..
    emmake make -j $(nproc --all) install


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

Given we need to install CppInterOp as part of the xeus-cpp-lite build process we don't really need to reference CPPINTEROP_BUILD_DIR anymore, since it will be found in the PREFIX folder.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [x] Bug fix
- [ ] New feature
- [x] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [x] I have read the contribution guide recently
