### PR TITLE
Reduce the Emscripten build size and reduce build time by building libclang target instead of the clang target

### DIFF
--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -327,7 +327,7 @@ jobs:
                         -DLLVM_ENABLE_THREADS=OFF                       \
                         -G Ninja                                         \
                         ../llvm
-          emmake ninja clang clangInterpreter clangStaticAnalyzerCore lld -j ${{ env.ncpus }}
+          emmake ninja libclang clangInterpreter clangStaticAnalyzerCore lld -j ${{ env.ncpus }}
         fi
         cd ../
         rm -rf $(find . -maxdepth 1 ! -name "build" ! -name "llvm" ! -name "clang" ! -name ".")

--- a/Emscripten-build-instructions.md
+++ b/Emscripten-build-instructions.md
@@ -70,8 +70,8 @@ emcmake cmake -DCMAKE_BUILD_TYPE=Release \
                         -DLLVM_INCLUDE_TESTS=OFF                        \
                         -DLLVM_ENABLE_THREADS=OFF                       \
                         ../llvm
-emmake make clang -j $(nproc --all)
-emmake make clang-repl -j $(nproc --all)
+emmake make libclang -j $(nproc --all)
+emmake make clangInterpreter clangStaticAnalyzerCore -j $(nproc --all)
 emmake make lld -j $(nproc --all)
 ```
 

--- a/docs/Emscripten-build-instructions.rst
+++ b/docs/Emscripten-build-instructions.rst
@@ -86,8 +86,8 @@ executing the following
                  -DLLVM_INCLUDE_TESTS=OFF                        \
                  -DLLVM_ENABLE_THREADS=OFF                       \
                  ../llvm
-   emmake make clang -j $(nproc --all)
-   emmake make clang-repl -j $(nproc --all)
+   emmake make libclang -j $(nproc --all)
+   emmake make clangInterpreter clangStaticAnalyzerCore -j $(nproc --all)
    emmake make lld -j $(nproc --all)
 
 Once this finishes building we need to take note of where we built our


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

Clang.js takes a while to build. We don't use clang.js, we just use the library. In theory we should be able to pass all Emscripten tests by building the libclang target instead of clang target. This will reduce the Emscripten cache (freeing up some very much needed space in the Github cache with the llvm 20 upgrade PR to come), and will speed up build times for developers. If the ci passes, then I will update the documentation accordingly. 

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [ ] New feature
- [x] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [x] I have read the contribution guide recently
