### PR TITLE
Change lld target to lldWasm target Emscripten build

### DIFF
--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -327,7 +327,7 @@ jobs:
                         -DLLVM_ENABLE_THREADS=OFF                       \
                         -G Ninja                                         \
                         ../llvm
-          emmake ninja libclang clangInterpreter clangStaticAnalyzerCore lld -j ${{ env.ncpus }}
+          emmake ninja libclang clangInterpreter clangStaticAnalyzerCore lldWasm -j ${{ env.ncpus }}
         fi
         cd ../
         rm -rf $(find . -maxdepth 1 ! -name "build" ! -name "llvm" ! -name "clang" ! -name ".")

--- a/Emscripten-build-instructions.md
+++ b/Emscripten-build-instructions.md
@@ -72,7 +72,7 @@ emcmake cmake -DCMAKE_BUILD_TYPE=Release \
                         ../llvm
 emmake make libclang -j $(nproc --all)
 emmake make clangInterpreter clangStaticAnalyzerCore -j $(nproc --all)
-emmake make lld -j $(nproc --all)
+emmake make lldWasm -j $(nproc --all)
 ```
 
 Once this finishes building we need to take note of where we built our llvm build. This can be done by executing the following

--- a/docs/Emscripten-build-instructions.rst
+++ b/docs/Emscripten-build-instructions.rst
@@ -88,7 +88,7 @@ executing the following
                  ../llvm
    emmake make libclang -j $(nproc --all)
    emmake make clangInterpreter clangStaticAnalyzerCore -j $(nproc --all)
-   emmake make lld -j $(nproc --all)
+   emmake make lldWasm -j $(nproc --all)
 
 Once this finishes building we need to take note of where we built our
 llvm build. This can be done by executing the following


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

Just like https://github.com/compiler-research/CppInterOp/pull/531 did for the clang target, this PR swaps out the lld target for the lldWasm target, speeding up the Emscripten llvm build time, and reducing the size the build takes up in the cache.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [ ] New feature
- [x] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [x] I have read the contribution guide recently
