### PR TITLE
Add type info interfaces motivated by numba

### DIFF
--- a/include/CppInterOp/CppInterOp.h
+++ b/include/CppInterOp/CppInterOp.h
@@ -93,6 +93,7 @@ enum Operator : unsigned char {
 };
 
 enum OperatorArity : unsigned char { kUnary = 1, kBinary, kBoth };
+enum Signedness : unsigned char { kSigned = 1, kUnsigned, kAny };
 
 /// A class modeling function calls for functions produced by the interpreter
 /// in compiled code. It provides an information if we are calling a standard
@@ -578,6 +579,22 @@ CPPINTEROP_API bool IsRecordType(TCppType_t type);
 /// Checks if the provided parameter is a Plain Old Data Type (POD).
 CPPINTEROP_API bool IsPODType(TCppType_t type);
 
+/// Checks if type has an integer representation
+CPPINTEROP_API bool IsIntegerType(TCppType_t type,
+                                  Signedness s = Signedness::kAny);
+
+/// Checks if type has a floating representation
+CPPINTEROP_API bool IsFloatingType(TCppType_t type);
+
+/// Checks if two types are the equivalent
+/// i.e. have the same canonical type
+CPPINTEROP_API bool IsSameType(TCppType_t type_a, TCppType_t type_b);
+
+/// Checks if type is a void pointer
+CPPINTEROP_API bool IsVoidPointerType(TCppType_t type);
+
+/// Get the type handle to the unqualified type
+CPPINTEROP_API TCppType_t GetUnqualifiedType(TCppType_t type);
 /// Checks if type is a pointer
 CPPINTEROP_API bool IsPointerType(TCppType_t type);
 

--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -1619,9 +1619,42 @@ bool IsPODType(TCppType_t type) {
   return QT.isPODType(getASTContext());
 }
 
+bool IsIntegerType(TCppType_t type, Signedness s) {
+  if (!type)
+    return false;
+  QualType QT = QualType::getFromOpaquePtr(type);
+  switch (s) {
+  case Signedness::kAny:
+    return QT->hasIntegerRepresentation();
+
+  case Signedness::kSigned:
+    return QT->hasSignedIntegerRepresentation();
+
+  case Signedness::kUnsigned:
+    return QT->hasUnsignedIntegerRepresentation();
+  }
+  return false;
+}
+
+bool IsFloatingType(TCppType_t type) {
+  QualType QT = QualType::getFromOpaquePtr(type);
+  return QT->hasFloatingRepresentation();
+}
+
+bool IsSameType(TCppType_t type_a, TCppType_t type_b) {
+  clang::QualType QT1 = clang::QualType::getFromOpaquePtr(type_a);
+  clang::QualType QT2 = clang::QualType::getFromOpaquePtr(type_b);
+  return getASTContext().hasSameType(QT1, QT2);
+}
+
 bool IsPointerType(TCppType_t type) {
   QualType QT = QualType::getFromOpaquePtr(type);
   return QT->isPointerType();
+}
+
+bool IsVoidPointerType(TCppType_t type) {
+  QualType QT = QualType::getFromOpaquePtr(type);
+  return QT->isVoidPointerType();
 }
 
 TCppType_t GetPointeeType(TCppType_t type) {
@@ -1629,6 +1662,13 @@ TCppType_t GetPointeeType(TCppType_t type) {
     return nullptr;
   QualType QT = QualType::getFromOpaquePtr(type);
   return QT->getPointeeType().getAsOpaquePtr();
+}
+
+TCppType_t GetUnqualifiedType(TCppType_t type) {
+  if (!type)
+    return nullptr;
+  QualType QT = QualType::getFromOpaquePtr(type);
+  return QT.getUnqualifiedType().getAsOpaquePtr();
 }
 
 bool IsReferenceType(TCppType_t type) {
@@ -1666,6 +1706,8 @@ TCppType_t GetNonReferenceType(TCppType_t type) {
 }
 
 TCppType_t GetUnderlyingType(TCppType_t type) {
+  if (!type)
+    return nullptr;
   QualType QT = QualType::getFromOpaquePtr(type);
   QT = QT->getCanonicalTypeUnqualified();
 


### PR DESCRIPTION
- Add `IsSameType` used for matching arg types between numba inferred signatures and CppOverloads in cppyy.
- Add type info reflection interfaces for integer, void pointer, signed and unsigned types.
- Also added interfaces `IsIntegral` and `IsFloating` that check if types have the respective representations. Used in the case of Numba where scoring based on reflection is required.

will add tests