### PR TITLE
Add `LookupConstructors` and fix logic in `IsConstructor` for templates

### DIFF
--- a/include/clang/Interpreter/CppInterOp.h
+++ b/include/clang/Interpreter/CppInterOp.h
@@ -416,13 +416,27 @@ namespace Cpp {
   CPPINTEROP_API bool ExistsFunctionTemplate(const std::string& name,
                                              TCppScope_t parent = nullptr);
 
+  /// Sets a list of all the constructor for a scope/class that is
+  /// supplied as a parameter.
+  ///\param[in] name - This string is used as a constraint, that clients can use
+  ///           to ensure the constructors match the name that they provide
+  ///\param[in] parent - Pointer to the scope/class for which the constructors
+  ///           are being looked up
+  ///           to be retrieved
+  ///\param[out] funcs - vector of handles to all constructors found under the
+  ///            given scope
+  CPPINTEROP_API void LookupConstructors(const std::string& name,
+                                         TCppScope_t parent,
+                                         std::vector<TCppFunction_t>& funcs);
+
   /// Sets a list of all the Templated Methods that are in the Class that is
   /// supplied as a parameter.
+  ///\returns true if the lookup succeeded, and false if there are no candidates
   ///\param[in] name - method name
   ///\param[in] parent - Pointer to the scope/class under which the methods have
   ///           to be retrieved
   ///\param[out] funcs - vector of function pointers matching the name
-  CPPINTEROP_API void
+  CPPINTEROP_API bool
   GetClassTemplatedMethods(const std::string& name, TCppScope_t parent,
                            std::vector<TCppFunction_t>& funcs);
 

--- a/unittests/CppInterOp/FunctionReflectionTest.cpp
+++ b/unittests/CppInterOp/FunctionReflectionTest.cpp
@@ -296,19 +296,50 @@ TEST(FunctionReflectionTest, GetClassDecls) {
   GetAllSubDecls(Decls[0], SubDecls);
 
   std::vector<Cpp::TCppFunction_t> methods;
-  std::vector<Cpp::TCppFunction_t> template_methods;
-
   Cpp::GetClassMethods(Decls[0], methods);
+
+  EXPECT_EQ(methods.size(), 10); // includes structors and operators
+  EXPECT_EQ(Cpp::GetName(methods[0]), Cpp::GetName(SubDecls[4]));
+  EXPECT_EQ(Cpp::GetName(methods[1]), Cpp::GetName(SubDecls[5]));
+  EXPECT_EQ(Cpp::GetName(methods[2]), Cpp::GetName(SubDecls[7]));
+  EXPECT_EQ(Cpp::GetName(methods[3]), Cpp::GetName(SubDecls[8]));
+}
+
+TEST(FunctionReflectionTest, GetFunctionTemplatedDecls) {
+  std::vector<Decl*> Decls, SubDecls;
+  std::string code = R"(
+    class MyTemplatedMethodClass {
+      template<class A, class B>
+      long get_size(A, B, int i = 0) {}
+
+      template<class A = int, class B = char>
+      long get_float_size(int i, A a = A(), B b = B()) {}
+           
+      template<class A>
+      void get_char_size(long k, A, char ch = 'a', double l = 0.0) {}
+
+      void f1() {}
+      void f2(int i, double d, long l, char ch) {}
+
+      template<class A>
+      void get_size(long k, A, char ch = 'a', double l = 0.0) {}
+
+      void f3(int i, double d, long l = 0, char ch = 'a') {}
+      void f4(int i = 0, double d = 0.0, long l = 0, char ch = 'a') {}
+    };
+    )";
+
+  GetAllTopLevelDecls(code, Decls);
+  GetAllSubDecls(Decls[0], SubDecls);
+
+  std::vector<Cpp::TCppFunction_t> template_methods;
   Cpp::GetFunctionTemplatedDecls(Decls[0], template_methods);
 
+  EXPECT_EQ(template_methods.size(), 4);
   EXPECT_EQ(Cpp::GetName(template_methods[0]), Cpp::GetName(SubDecls[1]));
   EXPECT_EQ(Cpp::GetName(template_methods[1]), Cpp::GetName(SubDecls[2]));
   EXPECT_EQ(Cpp::GetName(template_methods[2]), Cpp::GetName(SubDecls[3]));
-  EXPECT_EQ(Cpp::GetName(methods[0])         , Cpp::GetName(SubDecls[4]));
-  EXPECT_EQ(Cpp::GetName(methods[1])         , Cpp::GetName(SubDecls[5]));
   EXPECT_EQ(Cpp::GetName(template_methods[3]), Cpp::GetName(SubDecls[6]));
-  EXPECT_EQ(Cpp::GetName(methods[2])         , Cpp::GetName(SubDecls[7]));
-  EXPECT_EQ(Cpp::GetName(methods[3])         , Cpp::GetName(SubDecls[8]));
 }
 
 TEST(FunctionReflectionTest, GetFunctionReturnType) {


### PR DESCRIPTION
Add `LookupConstructors` and fixes logic in `IsConstructor` for templates. Accumulate constructors with this new lookup in `GetClassTemplatedMethods` enabling 8 tests. Also splits IsTemplatedFunction into `IsTemplatedFunction` for FunctionTemplateDecl, and `IsTemplateInstantiationOrSpecialization` when we have an instantiation or a specialization. 