### PR TITLE
Use `exports.ld` to export symbols

### DIFF
--- a/lib/Interpreter/CMakeLists.txt
+++ b/lib/Interpreter/CMakeLists.txt
@@ -130,8 +130,6 @@ if(EMSCRIPTEN)
     PRIVATE "SHELL: -s WASM_BIGINT"
     PRIVATE "SHELL: -s SIDE_MODULE=1"
     PRIVATE "SHELL: ${SYMBOLS_LIST}"
-    PUBLIC "SHELL: -Wl,--export=__clang_Interpreter_SetValueNoAlloc"
-    PUBLIC "SHELL: -Wl,--export=__clang_Interpreter_SetValueWithAlloc"
   )
   if (CPPINTEROP_ENABLE_TESTING)
     # When compiling Emscripten tests the shared library it links to is expected to be in the same folder as the compiled Javascript

--- a/lib/Interpreter/exports.ld
+++ b/lib/Interpreter/exports.ld
@@ -46,3 +46,5 @@
 -Wl,--export=_ZNK5clang11DeclContext6lookupENS_15DeclarationNameE
 -Wl,--export=_ZNK5clang17ClassTemplateDecl18getSpecializationsEv
 -Wl,--export=_ZNK5clang4Sema15getStdNamespaceEv
+-Wl,--export=__clang_Interpreter_SetValueNoAlloc
+-Wl,--export=__clang_Interpreter_SetValueWithAlloc


### PR DESCRIPTION
# Description

patch for https://github.com/compiler-research/CppInterOp/pull/447#discussion_r2009932702

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [ ] I have read the contribution guide recently
