### PR TITLE
Add test for verifying exception handling for emscripten builds

### DIFF
--- a/lib/Interpreter/exports.ld
+++ b/lib/Interpreter/exports.ld
@@ -2,6 +2,7 @@
 -Wl,--export=_ZN4llvm11raw_ostream16SetBufferAndModeEPcmNS0_10BufferKindE
 -Wl,--export=_ZN4llvm11raw_ostream5writeEPKcm
 -Wl,--export=_ZN4llvm11raw_ostreamD2Ev
+-Wl,--export=_ZN4llvm11raw_ostreamlsEm
 -Wl,--export=_ZN4llvm15SmallVectorBaseIjE8grow_podEPvmm
 -Wl,--export=_ZN4llvm15allocate_bufferEmm
 -Wl,--export=_ZN4llvm21logAllUnhandledErrorsENS_5ErrorERNS_11raw_ostreamENS_5TwineE

--- a/unittests/CppInterOp/CMakeLists.txt
+++ b/unittests/CppInterOp/CMakeLists.txt
@@ -43,6 +43,7 @@ if(EMSCRIPTEN)
   # --preload-file ${SYSROOT_PATH}/include@/include:
   # Preloads the system include directory into the Emscripten virtual filesystem to make headers accessible at runtime.
   target_link_options(CppInterOpTests
+    PUBLIC "SHELL: -fexceptions"
     PUBLIC "SHELL: -s MAIN_MODULE=1"
     PUBLIC "SHELL: -s WASM_BIGINT"
     PUBLIC "SHELL: -s ALLOW_MEMORY_GROWTH=1"

--- a/unittests/CppInterOp/InterpreterTest.cpp
+++ b/unittests/CppInterOp/InterpreterTest.cpp
@@ -104,6 +104,34 @@ TEST(InterpreterTest, Process) {
   clang_Interpreter_dispose(CXI);
 }
 
+TEST(InterpreterTest, EmscriptenExceptionHandling) {
+#ifndef EMSCRIPTEN
+  GTEST_SKIP() << "This test is intended to check exception handling for Emscripten builds.";
+#endif
+
+  std::vector<const char*> Args = {
+    "-std=c++20",
+    "-v",
+    "-fexceptions",
+    "-fcxx-exceptions",
+    "-mllvm", "-enable-emscripten-cxx-exceptions",
+    "-mllvm", "-enable-emscripten-sjlj"
+  };
+
+  auto* I = Cpp::CreateInterpreter(Args);
+
+  // Should compile and execute successfully
+  const char* tryCatchCode = R"(
+    try {
+      throw 1;
+    } catch (...) {
+      0;
+    }
+  )";
+
+  EXPECT_TRUE(Cpp::Process(tryCatchCode) == 0);
+}
+
 TEST(InterpreterTest, CreateInterpreter) {
   auto* I = Cpp::CreateInterpreter();
   EXPECT_TRUE(I);

--- a/unittests/CppInterOp/InterpreterTest.cpp
+++ b/unittests/CppInterOp/InterpreterTest.cpp
@@ -118,9 +118,8 @@ TEST(InterpreterTest, EmscriptenExceptionHandling) {
     "-mllvm", "-enable-emscripten-sjlj"
   };
 
-  auto* I = Cpp::CreateInterpreter(Args);
+  Cpp::CreateInterpreter(Args);
 
-  // Should compile and execute successfully
   const char* tryCatchCode = R"(
     try {
       throw 1;


### PR DESCRIPTION
Hey @vgvassilev, 

If you remember, we were discussing the changes needed to handle the LLVMargs from FrontendOpts for clang-repl the other day.

This led to me coming up with this PR on llvm https://github.com/llvm/llvm-project/pull/132670

But I think CppInterOp does take some inspiration from the above in the past and has added a block for handling the LLVM args

https://github.com/compiler-research/CppInterOp/blob/e1ace5198a7a89109526820b88a427deee087630/lib/Interpreter/CppInterOp.cpp#L2962-L2975

Hence we should be able to process any exception handling case for our emscripten build through cppinterop (though clang-repl in the browser itself won't be able to handle these) 

This adds a simple test case for the same. Which we can possibly remove along with the above code block .... once this in completely done in clang-repl itself (possibly like how I tried to achieve it in the above linked PR)

