### PR TITLE
Fix Evaluate tests for emscripten build

### DIFF
--- a/unittests/CppInterOp/InterpreterTest.cpp
+++ b/unittests/CppInterOp/InterpreterTest.cpp
@@ -59,9 +59,6 @@ TEST(InterpreterTest, DebugFlag) {
 }
 
 TEST(InterpreterTest, Evaluate) {
-#ifdef EMSCRIPTEN
-  GTEST_SKIP() << "Test fails for Emscipten builds";
-#endif
 #ifdef _WIN32
   GTEST_SKIP() << "Disabled on Windows. Needs fixing.";
 #endif
@@ -71,6 +68,7 @@ TEST(InterpreterTest, Evaluate) {
   //EXPECT_TRUE(Cpp::Evaluate(I, "__cplusplus;") == 201402);
   // Due to a deficiency in the clang-repl implementation to get the value we
   // always must omit the ;
+  Cpp::CreateInterpreter();
   EXPECT_TRUE(Cpp::Evaluate("__cplusplus") == 201402);
 
   bool HadError;


### PR DESCRIPTION
# Description

I realized technically this should work. The only reason it might not is if we fail to fetch the `-std=c++14` arg which we should !

Creating the interpreter correctly should fix that I suppose 

https://github.com/compiler-research/CppInterOp/blob/e1ace5198a7a89109526820b88a427deee087630/lib/Interpreter/CppInterOp.cpp#L2917-L2923






## Type of change

Please tick all options which are relevant.

- [x] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [ ] I have read the contribution guide recently
