### PR TITLE
Support NixOS resource dirs

### DIFF
--- a/lib/Interpreter/CppInterOp.cpp
+++ b/lib/Interpreter/CppInterOp.cpp
@@ -3042,7 +3042,7 @@ namespace Cpp {
         CLANG_VERSION_MAJOR_STRING;
 #endif
     // We need to check if the detected resource directory is compatible.
-    if (llvm::sys::path::filename(detected_resource_dir) != version)
+    if (detected_resource_dir.find(version) == std::string::npos)
       return "";
 
     return detected_resource_dir;


### PR DESCRIPTION
Previously, CppInterOp assumed that the resource dir would end in the clang major version. This is common, but it's not always the case. On NixOS, for example, we have something like this:

```
❯ clang++ -print-resource-dir
/nix/store/xl0vlc2wdchfbq8536zs19pj2r3xdmma-clang-wrapper-19.1.5/resource-root
```

I have updated the function to check that the path contains the major version, rather than ending in it. This is still a useful version check, though it's not as precise as it was before.