### PR TITLE
Return pointer to non-const for getExecutionEngine

### DIFF
--- a/lib/Interpreter/CppInterOpInterpreter.h
+++ b/lib/Interpreter/CppInterOpInterpreter.h
@@ -167,7 +167,7 @@ public:
     return inner->getCompilerInstance();
   }
 
-  const llvm::orc::LLJIT* getExecutionEngine() const {
+  llvm::orc::LLJIT* getExecutionEngine() const {
     return compat::getExecutionEngine(*inner);
   }
 


### PR DESCRIPTION
The `clang::Interpreter` wrapper previously returned a pointer to const, but the actual `clang::Interpreter` did not. This breaks code for anyone porting from `clang::Interpreter` to `Cpp::Interpreter`, especially since most operations on the execution engine are mutations of some sort.

Yes, the user could static cast the wrapper to the inner interpreter, but, at that point, why both exposing the `getExecutionEngine` function at all?