### PR TITLE
Reduce cling llvm cache (makes room for Emscripten llvm 20 builds)

### DIFF
--- a/.github/workflows/MacOS-arm.yml
+++ b/.github/workflows/MacOS-arm.yml
@@ -225,7 +225,8 @@ jobs:
           rm -rf $(find . -maxdepth 1 ! -name "include" ! -name "lib" ! -name "cmake" ! -name "utils" ! -name ".")
           cd ../clang/
           rm -rf $(find . -maxdepth 1 ! -name "include" ! -name "lib" ! -name "cmake" ! -name "utils" ! -name ".")
-          cd ../..
+          cd ../../cling/
+          rm -rf $(find . -maxdepth 1 ! -name "include" ! -name "lib" ! -name "cmake" ! -name ".")
         else # repl
           cd ./llvm/
           rm -rf $(find . -maxdepth 1 ! -name "include" ! -name "lib" ! -name "cmake" ! -name ".")

--- a/.github/workflows/MacOS.yml
+++ b/.github/workflows/MacOS.yml
@@ -209,7 +209,8 @@ jobs:
           rm -rf $(find . -maxdepth 1 ! -name "include" ! -name "lib" ! -name "cmake" ! -name "utils" ! -name ".")
           cd ../clang/
           rm -rf $(find . -maxdepth 1 ! -name "include" ! -name "lib" ! -name "cmake" ! -name "utils" ! -name ".")
-          cd ../..
+          cd ../../cling/
+          rm -rf $(find . -maxdepth 1 ! -name "include" ! -name "lib" ! -name "cmake" ! -name ".")
         else # repl
           cd ./llvm/
           rm -rf $(find . -maxdepth 1 ! -name "include" ! -name "lib" ! -name "cmake" ! -name ".")

--- a/.github/workflows/Ubuntu-arm.yml
+++ b/.github/workflows/Ubuntu-arm.yml
@@ -249,7 +249,8 @@ jobs:
           rm -rf $(find . -maxdepth 1 ! -name "include" ! -name "lib" ! -name "cmake" ! -name "utils" ! -name ".")
           cd ../clang/
           rm -rf $(find . -maxdepth 1 ! -name "include" ! -name "lib" ! -name "cmake" ! -name "utils" ! -name ".")
-          cd ../..
+          cd ../../cling/
+          rm -rf $(find . -maxdepth 1 ! -name "include" ! -name "lib" ! -name "cmake" ! -name ".")
         else # repl
           cd ./llvm/
           rm -rf $(find . -maxdepth 1 ! -name "include" ! -name "lib" ! -name "cmake" ! -name ".")

--- a/.github/workflows/Ubuntu.yml
+++ b/.github/workflows/Ubuntu.yml
@@ -249,7 +249,8 @@ jobs:
           rm -rf $(find . -maxdepth 1 ! -name "include" ! -name "lib" ! -name "cmake" ! -name "utils" ! -name ".")
           cd ../clang/
           rm -rf $(find . -maxdepth 1 ! -name "include" ! -name "lib" ! -name "cmake" ! -name "utils" ! -name ".")
-          cd ../..
+          cd ../../cling/
+          rm -rf $(find . -maxdepth 1 ! -name "include" ! -name "lib" ! -name "cmake" ! -name ".")
         else # repl
           cd ./llvm/
           rm -rf $(find . -maxdepth 1 ! -name "include" ! -name "lib" ! -name "cmake" ! -name ".")

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -196,7 +196,8 @@ jobs:
           rm -r -force $(find.exe . -maxdepth 1 ! -name "include" ! -name "lib" ! -name "cmake" ! -name "utils" ! -name ".")
           cd ..\clang\
           rm -r -force $(find.exe . -maxdepth 1 ! -name "include" ! -name "lib" ! -name "cmake" ! -name "utils" ! -name ".")
-          cd ..\..
+          cd ..\..\cling\
+          rm -r -force $(find.exe . -maxdepth 1 ! -name "include" ! -name "lib" ! -name "cmake" ! -name ".")
         }
         else
         {


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

Currently we are have just enough room in the cache to include the native builds of llvm 20 (see image below). My plan was to remove the llvm 19 Windows job to make room for the Emscripten llvm 20, but that won't be enough given we are so close to capacity. This PR should reduce the impact of the cling llvm builds enough that we have enough room for the Emscripten builds. I'll be able to quantify the impact of this PR once the workflows finish running.

![image](https://github.com/user-attachments/assets/3e2e77d9-1425-4c57-9f9e-11c5bb0deece)

## Checklist

- [x] I have read the contribution guide recently
