### PR TITLE
Add error propagation to interpreter creation logic

### DIFF
--- a/lib/Interpreter/Compatibility.h
+++ b/lib/Interpreter/Compatibility.h
@@ -294,9 +294,11 @@ createClangInterpreter(std::vector<const char*>& args) {
     return nullptr;
   }
   if (CudaEnabled) {
-    if (auto Err = (*innerOrErr)->LoadDynamicLibrary("libcudart.so"))
+    if (auto Err = (*innerOrErr)->LoadDynamicLibrary("libcudart.so")) {
       llvm::logAllUnhandledErrors(std::move(Err), llvm::errs(),
                                   "Failed load libcudart.so runtime:");
+      return nullptr;
+    }
   }
 
   return std::move(*innerOrErr);

--- a/lib/Interpreter/CppInterOp.cpp
+++ b/lib/Interpreter/CppInterOp.cpp
@@ -2957,7 +2957,15 @@ namespace Cpp {
                    std::back_inserter(ClingArgv),
                    [&](const std::string& str) { return str.c_str(); });
 
+#ifdef CPPINTEROP_USE_CLING
     auto I = new compat::Interpreter(ClingArgv.size(), &ClingArgv[0]);
+#else
+    auto Interp = compat::Interpreter::create(
+        static_cast<int>(ClingArgv.size()), ClingArgv.data());
+    if (!Interp)
+      return nullptr;
+    auto* I = Interp.release();
+#endif
 
     // Honor -mllvm.
     //

--- a/lib/Interpreter/CppInterOpInterpreter.h
+++ b/lib/Interpreter/CppInterOpInterpreter.h
@@ -25,6 +25,7 @@
 #if CLANG_VERSION_MAJOR >= 19
 #include "clang/Sema/Redeclaration.h"
 #endif
+#include "clang/Serialization/ModuleFileExtension.h"
 
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/SmallSet.h"
@@ -33,7 +34,11 @@
 #include "llvm/ExecutionEngine/Orc/LLJIT.h"
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
+#include "llvm/Support/raw_ostream.h"
 #include "llvm/Support/TargetSelect.h"
+
+#include <utility>
+#include <vector>
 
 namespace clang {
 class CompilerInstance;

--- a/lib/Interpreter/CppInterOpInterpreter.h
+++ b/lib/Interpreter/CppInterOpInterpreter.h
@@ -34,8 +34,8 @@
 #include "llvm/ExecutionEngine/Orc/LLJIT.h"
 #include "llvm/Support/Compiler.h"
 #include "llvm/Support/Error.h"
-#include "llvm/Support/raw_ostream.h"
 #include "llvm/Support/TargetSelect.h"
+#include "llvm/Support/raw_ostream.h"
 
 #include <utility>
 #include <vector>

--- a/lib/Interpreter/CppInterOpInterpreter.h
+++ b/lib/Interpreter/CppInterOpInterpreter.h
@@ -136,11 +136,14 @@ class Interpreter {
 private:
   std::unique_ptr<clang::Interpreter> inner;
 
+  Interpreter(std::unique_ptr<clang::Interpreter> CI) : inner(std::move(CI)) {}
+
 public:
-  Interpreter(int argc, const char* const* argv, const char* llvmdir = 0,
-              const std::vector<std::shared_ptr<clang::ModuleFileExtension>>&
-                  moduleExtensions = {},
-              void* extraLibHandle = 0, bool noRuntime = true) {
+  static std::unique_ptr<Interpreter>
+  create(int argc, const char* const* argv, const char* llvmdir = nullptr,
+         const std::vector<std::shared_ptr<clang::ModuleFileExtension>>&
+             moduleExtensions = {},
+         void* extraLibHandle = nullptr, bool noRuntime = true) {
     // Initialize all targets (required for device offloading)
     llvm::InitializeAllTargetInfos();
     llvm::InitializeAllTargets();
@@ -150,7 +153,13 @@ public:
     std::vector<const char*> vargs(argv + 1, argv + argc);
     vargs.push_back("-include");
     vargs.push_back("new");
-    inner = compat::createClangInterpreter(vargs);
+    auto CI = compat::createClangInterpreter(vargs);
+    if (!CI) {
+      llvm::errs() << "Interpreter creation failed\n";
+      return nullptr;
+    }
+
+    return std::unique_ptr<Interpreter>(new Interpreter(std::move(CI)));
   }
 
   ~Interpreter() {}

--- a/unittests/CppInterOp/CUDATest.cpp
+++ b/unittests/CppInterOp/CUDATest.cpp
@@ -13,7 +13,7 @@ static bool HasCudaSDK() {
     // FIXME: Enable this for cling.
     return false;
 #endif // CLANG_VERSION_MAJOR < 16
-    Cpp::CreateInterpreter({}, {"--cuda"});
+    if(!Cpp::CreateInterpreter({}, {"--cuda"})) return false;
     return Cpp::Declare("__global__ void test_func() {}"
                         "test_func<<<1,1>>>();") == 0;
   };
@@ -30,7 +30,7 @@ static bool HasCudaRuntime() {
     if (!HasCudaSDK())
       return false;
 
-    Cpp::CreateInterpreter({}, {"--cuda"});
+    if(!Cpp::CreateInterpreter({}, {"--cuda"})) return false;
     if (Cpp::Declare("__global__ void test_func() {}"
                      "test_func<<<1,1>>>();"))
       return false;

--- a/unittests/CppInterOp/CUDATest.cpp
+++ b/unittests/CppInterOp/CUDATest.cpp
@@ -13,7 +13,8 @@ static bool HasCudaSDK() {
     // FIXME: Enable this for cling.
     return false;
 #endif // CLANG_VERSION_MAJOR < 16
-    if(!Cpp::CreateInterpreter({}, {"--cuda"})) return false;
+    if (!Cpp::CreateInterpreter({}, {"--cuda"}))
+      return false;
     return Cpp::Declare("__global__ void test_func() {}"
                         "test_func<<<1,1>>>();") == 0;
   };
@@ -30,7 +31,8 @@ static bool HasCudaRuntime() {
     if (!HasCudaSDK())
       return false;
 
-    if(!Cpp::CreateInterpreter({}, {"--cuda"})) return false;
+    if (!Cpp::CreateInterpreter({}, {"--cuda"}))
+      return false;
     if (Cpp::Declare("__global__ void test_func() {}"
                      "test_func<<<1,1>>>();"))
       return false;

--- a/unittests/CppInterOp/InterpreterTest.cpp
+++ b/unittests/CppInterOp/InterpreterTest.cpp
@@ -167,6 +167,22 @@ TEST(InterpreterTest, CreateInterpreter) {
 #endif
 }
 
+#ifndef CPPINTEROP_USE_CLING
+TEST(InterpreterTest, CreateInterpreterCAPI) {
+  const char* argv[] = {"-std=c++17"};
+  auto *CXI = clang_createInterpreter(argv, 1);
+  auto CLI = clang_Interpreter_getClangInterpreter(CXI);
+  EXPECT_TRUE(CLI);
+  clang_Interpreter_dispose(CXI);
+}
+
+TEST(InterpreterTest, CreateInterpreterCAPIFailure) {
+  const char* argv[] = {"-fsyntax-only", "-Xclang", "-invalid-plugin"};
+  auto *CXI = clang_createInterpreter(argv, 3);
+  EXPECT_EQ(CXI, nullptr);
+}
+#endif
+
 #ifdef LLVM_BINARY_DIR
 TEST(InterpreterTest, DetectResourceDir) {
 #ifdef EMSCRIPTEN

--- a/unittests/CppInterOp/InterpreterTest.cpp
+++ b/unittests/CppInterOp/InterpreterTest.cpp
@@ -177,6 +177,9 @@ TEST(InterpreterTest, CreateInterpreterCAPI) {
 }
 
 TEST(InterpreterTest, CreateInterpreterCAPIFailure) {
+#ifdef _WIN32
+  GTEST_SKIP() << "Disabled on Windows. Needs fixing.";
+#endif
   const char* argv[] = {"-fsyntax-only", "-Xclang", "-invalid-plugin"};
   auto *CXI = clang_createInterpreter(argv, 3);
   EXPECT_EQ(CXI, nullptr);


### PR DESCRIPTION
# Description

@Vipul-Cariappa and I were discussing a use case yesterday (especially while building with repl) and this is what we realized

1) The function responsible for creating `clang::Interpreter` is `createClangInterpreter` which can return a nullptr, for eg 
https://github.com/compiler-research/CppInterOp/blob/c3384fb9d784a3f1606b6fc20c283c1e48d9b14b/lib/Interpreter/Compatibility.h#L277

2) This is assigned to `inner` while the constructor for `compat::Interpreter` is called
https://github.com/compiler-research/CppInterOp/blob/c3384fb9d784a3f1606b6fc20c283c1e48d9b14b/lib/Interpreter/CppInterOpInterpreter.h#L153

which means `inner` can be `nullptr`

3) And then if we look at `CreateInterpreter` from the top, we're creating the `compat::Interpreter` here 

https://github.com/compiler-research/CppInterOp/blob/c3384fb9d784a3f1606b6fc20c283c1e48d9b14b/lib/Interpreter/CppInterOp.cpp#L2960

Which means `compat::Interpreter` can exist even when the underlying `clang::Interpreter` is not existing. So we can say that the Interpreter from the top is half broken

4) So if we try something like 
```
Cpp::CreateInterpreter(...)
Cpp::Parse(..)
```
We would hit the following finally
https://github.com/compiler-research/CppInterOp/blob/c3384fb9d784a3f1606b6fc20c283c1e48d9b14b/lib/Interpreter/CppInterOpInterpreter.h#L174-L176

And although the call is made to `compat::Interpreter`, we end up using the underlying `clang::Interpreter` **without checking if it is valid.**

## Type of change

Please tick all options which are relevant.

- [x] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [x] I have read the contribution guide recently
