### PR TITLE
Update ZedThree/clang-tidy-review to version 0.21.0

### DIFF
--- a/.github/workflows/clang-tidy-review-post.yml
+++ b/.github/workflows/clang-tidy-review-post.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: Post review comments
         id: post-review
-        uses: ZedThree/clang-tidy-review/post@v0.20.1
+        uses: ZedThree/clang-tidy-review/post@v0.21.0
         with:
           max_comments: 10
 

--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -31,7 +31,7 @@ jobs:
         run: pip install lit
 
       - name: Run clang-tidy
-        uses: ZedThree/clang-tidy-review@v0.20.1
+        uses: ZedThree/clang-tidy-review@v0.21.0
         id: review
         with:
           build_dir: build

--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -47,4 +47,4 @@ jobs:
             -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
 
       - name: Upload artifacts
-        uses: ZedThree/clang-tidy-review/upload@v0.20.1
+        uses: ZedThree/clang-tidy-review/upload@v0.21.0


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

This PR updates ZedThree/clang-tidy-review to version 0.21.0 due this issue in version 0.20.1 https://github.com/ZedThree/clang-tidy-review/issues/144

I've put the same PR in xeus-cpp here https://github.com/compiler-research/xeus-cpp/pull/284

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [x] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [x] I have read the contribution guide recently
