### PR TITLE
Fix typos in repo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -440,8 +440,8 @@ endif()
 
 # Generate docs for CppInterOp
 option(CPPINTEROP_INCLUDE_DOCS "Generate build targets for the CppInterOp docs.")
-option(CPPINTEROP_ENABLE_DOXYGEN "Use doxygen to generate CppInterOp interal API documentation.")
-option(CPPINTEROP_ENABLE_SPHINX "Use sphinx to generage CppInterOp user documentation")
+option(CPPINTEROP_ENABLE_DOXYGEN "Use doxygen to generate CppInterOp internal API documentation.")
+option(CPPINTEROP_ENABLE_SPHINX "Use sphinx to generate CppInterOp user documentation")
 
 
 if(MSVC)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ projects such as CppInterOp. We have our documentation in the repository which i
 rendered in the [CppInterOp.readthedocs](https://cppinterop.readthedocs.io/en/latest/) website.
 Documentation modifications happen by proposing a pull request.
 
-## Creating a successfull pull request
+## Creating a successful pull request
 
 To propose a code modification we use the pull requests. Pull requests which
 review quickly and successfully share several common traits:
@@ -71,4 +71,4 @@ review quickly and successfully share several common traits:
 ### Developer Documentation  
 
 We have documented several useful hints that usually help when addressing issues
-as they come during developement time in our [developer documentation](https://cppinterop.readthedocs.io/en/latest/InstallationAndUsage.html).  
+as they come during development time in our [developer documentation](https://cppinterop.readthedocs.io/en/latest/InstallationAndUsage.html).  

--- a/cmake/modules/GoogleTest.cmake
+++ b/cmake/modules/GoogleTest.cmake
@@ -76,7 +76,7 @@ else()
 endif()
 
 # Use gmock_main instead of gtest_main because it initializes gtest as well.
-# Note: The libraries are listed in reverse order of their dependancies.
+# Note: The libraries are listed in reverse order of their dependencies.
 foreach(lib gtest gtest_main gmock gmock_main)
   add_library(${lib} IMPORTED STATIC GLOBAL)
   set_target_properties(${lib} PROPERTIES

--- a/docs/doxygen.cfg.in
+++ b/docs/doxygen.cfg.in
@@ -70,7 +70,7 @@ CREATE_SUBDIRS         = NO
 # Croatian, Czech, Danish, Dutch, Esperanto, Farsi, Finnish, French, German, 
 # Greek, Hungarian, Italian, Japanese, Japanese-en (Japanese with English 
 # messages), Korean, Korean-en, Lithuanian, Norwegian, Macedonian, Persian, 
-# Polish, Portuguese, Romanian, Russian, Serbian, Serbian-Cyrilic, Slovak, 
+# Polish, Portuguese, Romanian, Russian, Serbian, Serbian-Cyrillic, Slovak, 
 # Slovene, Spanish, Swedish, Ukrainian, and Vietnamese.
 
 OUTPUT_LANGUAGE        = English
@@ -1185,7 +1185,7 @@ EXT_LINKS_IN_WINDOW    = NO
 
 FORMULA_FONTSIZE       = 10
 
-# Use the FORMULA_TRANPARENT tag to determine whether or not the images
+# Use the FORMULA_TRANSPARENT tag to determine whether or not the images
 # generated for formulas are transparent PNGs. Transparent PNGs are not
 # supported properly for IE 6.0, but are supported on all modern browsers.
 #

--- a/docs/doxygen.css
+++ b/docs/doxygen.css
@@ -313,7 +313,7 @@ HR { height: 1px;
 
 /* 
  * LLVM Modifications.
- * Note: Everything above here is generated with "doxygen -w htlm" command. See
+ * Note: Everything above here is generated with "doxygen -w html" command. See
  * "doxygen --help" for details. What follows are CSS overrides for LLVM 
  * specific formatting. We want to keep the above so it can be replaced with
  * subsequent doxygen upgrades.

--- a/include/clang/Interpreter/CppInterOp.h
+++ b/include/clang/Interpreter/CppInterOp.h
@@ -730,7 +730,7 @@ namespace Cpp {
   ///
   ///\param[in] candidates - vector of overloads that come under the
   ///           parent scope and have the same name
-  ///\param[in] explicit_types - set of expicitly instantiated template types
+  ///\param[in] explicit_types - set of explicitly instantiated template types
   ///\param[in] arg_types - set of argument types
   ///\returns Instantiated function pointer
   CPPINTEROP_API TCppFunction_t
@@ -791,7 +791,7 @@ namespace Cpp {
   /// Append all Code completion suggestions to Results.
   ///\param[out] Results - CC suggestions for code fragment. Suggestions are
   /// appended.
-  ///\param[in] code - code fragmet to complete
+  ///\param[in] code - code fragment to complete
   ///\param[in] complete_line - position (line) in code for suggestion
   ///\param[in] complete_column - position (column) in code for suggestion
   CPPINTEROP_API void CodeComplete(std::vector<std::string>& Results,

--- a/lib/Interpreter/Compatibility.h
+++ b/lib/Interpreter/Compatibility.h
@@ -481,7 +481,7 @@ inline std::string MakeResourceDir(llvm::StringRef Dir) {
   return std::string(P.str());
 }
 
-// Clang >= 16 (=16 with Value patch) change castAs to converTo
+// Clang >= 16 (=16 with Value patch) change castAs to convertTo
 #ifdef CPPINTEROP_USE_CLING
 template <typename T> inline T convertTo(cling::Value V) {
   return V.castAs<T>();

--- a/lib/Interpreter/CppInterOp.cpp
+++ b/lib/Interpreter/CppInterOp.cpp
@@ -1421,7 +1421,7 @@ namespace Cpp {
         // not C. That means BaseCXXRD derives from C. Offset needs to be
         // calculated for Derived class
 
-        // Depth first Search is performed to the class that declears FD from
+        // Depth first Search is performed to the class that declares FD from
         // the base class
         std::vector<CXXRecordDecl*> stack;
         std::map<CXXRecordDecl*, CXXRecordDecl*> direction;
@@ -3646,7 +3646,7 @@ namespace Cpp {
       m_DupFD = dup(FD);
 
       // Flush now or can drop the buffer when dup2 is called with Fd later.
-      // This seems only neccessary when piping stdout or stderr, but do it
+      // This seems only necessary when piping stdout or stderr, but do it
       // for ttys to avoid over complicated code for minimal benefit.
       ::fflush(FD == STDOUT_FILENO ? stdout : stderr);
       if (dup2(fileno(m_TempFile.get()), FD) < 0)

--- a/lib/Interpreter/CppInterOpInterpreter.h
+++ b/lib/Interpreter/CppInterOpInterpreter.h
@@ -345,7 +345,7 @@ public:
         const_cast<const Interpreter*>(this)->getDynamicLibraryManager());
   }
 
-  ///\brief Adds multiple include paths separated by a delimter.
+  ///\brief Adds multiple include paths separated by a delimiter.
   ///
   ///\param[in] PathsStr - Path(s)
   ///\param[in] Delim - Delimiter to separate paths or NULL if a single path

--- a/lib/Interpreter/DynamicLibraryManager.cpp
+++ b/lib/Interpreter/DynamicLibraryManager.cpp
@@ -51,11 +51,12 @@ namespace Cpp {
     };
 
     // Behaviour is to not add paths that don't exist...In an interpreted env
-    // does this make sense? Path could pop into existance at any time.
+    // does this make sense? Path could pop into existence at any time.
     for (const char* Var : kSysLibraryEnv) {
       if (const char* Env = GetEnv(Var)) {
         SmallVector<StringRef, 10> CurPaths;
-        SplitPaths(Env, CurPaths, utils::kPruneNonExistant, Cpp::utils::platform::kEnvDelim);
+        SplitPaths(Env, CurPaths, utils::kPruneNonExistent,
+                   Cpp::utils::platform::kEnvDelim);
         for (const auto& Path : CurPaths)
           addSearchPath(Path);
       }
@@ -86,7 +87,7 @@ namespace Cpp {
                               StringRef libLoader) {
 
     // Handle substitutions (MacOS):
-    // @rpath - This function does not substitute @rpath, becouse
+    // @rpath - This function does not substitute @rpath, because
     //          this variable is already handled by lookupLibrary where
     //          @rpath is replaced with all paths from RPATH one by one.
     // @executable_path - Main program path.

--- a/lib/Interpreter/DynamicLibraryManager.h
+++ b/lib/Interpreter/DynamicLibraryManager.h
@@ -190,7 +190,7 @@ public:
   /// Find the first not-yet-loaded shared object that contains the symbol
   ///
   ///\param[in] mangledName - the mangled name to look for.
-  ///\param[in] searchSystem - whether to decend into system libraries.
+  ///\param[in] searchSystem - whether to descend into system libraries.
   ///
   ///\returns the library name if found, and empty string otherwise.
   ///

--- a/lib/Interpreter/DynamicLibraryManagerSymbol.cpp
+++ b/lib/Interpreter/DynamicLibraryManagerSymbol.cpp
@@ -256,7 +256,7 @@ public:
 static inline mode_t cached_lstat(const char *path) {
   static StringMap<mode_t> lstat_cache;
 
-  // If already cached - retun cached result
+  // If already cached - return cached result
   auto it = lstat_cache.find(path);
   if (it != lstat_cache.end())
     return it->second;
@@ -272,7 +272,7 @@ static inline mode_t cached_lstat(const char *path) {
 static inline StringRef cached_readlink(const char* pathname) {
   static StringMap<std::string> readlink_cache;
 
-  // If already cached - retun cached result
+  // If already cached - return cached result
   auto it = readlink_cache.find(pathname);
   if (it != readlink_cache.end())
     return StringRef(it->second);
@@ -304,7 +304,7 @@ std::string cached_realpath(StringRef path, StringRef base_path = "",
     return "";
   }
 
-  // If already cached - retun cached result
+  // If already cached - return cached result
   static StringMap<std::pair<std::string,int>> cache;
   bool relative_path = llvm::sys::path::is_relative(path);
   if (!relative_path) {
@@ -606,10 +606,12 @@ namespace Cpp {
           Deps.push_back(Data + Dyn.d_un.d_val);
           break;
         case ELF::DT_RPATH:
-          SplitPaths(Data + Dyn.d_un.d_val, RPath, utils::kAllowNonExistant, Cpp::utils::platform::kEnvDelim, false);
+          SplitPaths(Data + Dyn.d_un.d_val, RPath, utils::kAllowNonExistent,
+                     Cpp::utils::platform::kEnvDelim, false);
           break;
         case ELF::DT_RUNPATH:
-          SplitPaths(Data + Dyn.d_un.d_val, RunPath, utils::kAllowNonExistant, Cpp::utils::platform::kEnvDelim, false);
+          SplitPaths(Data + Dyn.d_un.d_val, RunPath, utils::kAllowNonExistent,
+                     Cpp::utils::platform::kEnvDelim, false);
           break;
         case ELF::DT_FLAGS_1:
           // Check if this is not a pie executable.
@@ -757,7 +759,9 @@ namespace Cpp {
               }
               else if (Command.C.cmd == MachO::LC_RPATH) {
                 MachO::rpath_command rpathCmd = Obj->getRpathCommand(Command);
-                SplitPaths(Command.Ptr + rpathCmd.path, RPath, utils::kAllowNonExistant, Cpp::utils::platform::kEnvDelim, false);
+                SplitPaths(Command.Ptr + rpathCmd.path, RPath,
+                           utils::kAllowNonExistent,
+                           Cpp::utils::platform::kEnvDelim, false);
               }
             }
           } else if (BinObjF->isCOFF()) {

--- a/lib/Interpreter/Paths.cpp
+++ b/lib/Interpreter/Paths.cpp
@@ -231,8 +231,8 @@ void CopyIncludePaths(const clang::HeaderSearchOptions& Opts,
     incpaths.push_back("-v");
 }
 
-void LogNonExistantDirectory(llvm::StringRef Path) {
-#define DEBUG_TYPE "LogNonExistantDirectory"
+void LogNonExistentDirectory(llvm::StringRef Path) {
+#define DEBUG_TYPE "LogNonExistentDirectory"
   LLVM_DEBUG(dbgs() << "  ignoring nonexistent directory \"" << Path << "\"\n");
 #undef  DEBUG_TYPE
 }
@@ -276,27 +276,27 @@ bool SplitPaths(llvm::StringRef PathStr,
       AllExisted = AllExisted && Exists;
 
       if (!Exists) {
-        if (Mode == kFailNonExistant) {
+        if (Mode == kFailNonExistent) {
           if (Verbose) {
-            // Exiting early, but still log all non-existant paths that we have
-            LogNonExistantDirectory(Split.first);
+            // Exiting early, but still log all non-existent paths that we have
+            LogNonExistentDirectory(Split.first);
             while (!Split.second.empty()) {
               Split = PathStr.split(Delim);
               if (llvm::sys::fs::is_directory(Split.first)) {
                 LLVM_DEBUG(dbgs() << "  ignoring directory that exists \""
                                   << Split.first << "\"\n");
               } else
-                LogNonExistantDirectory(Split.first);
+                LogNonExistentDirectory(Split.first);
               Split = Split.second.split(Delim);
             }
             if (!llvm::sys::fs::is_directory(Split.first))
-              LogNonExistantDirectory(Split.first);
+              LogNonExistentDirectory(Split.first);
           }
           return false;
-        } else if (Mode == kAllowNonExistant)
+        } else if (Mode == kAllowNonExistent)
           Paths.push_back(Split.first);
         else if (Verbose)
-          LogNonExistantDirectory(Split.first);
+          LogNonExistentDirectory(Split.first);
       } else
         Paths.push_back(Split.first);
     }
@@ -311,10 +311,10 @@ bool SplitPaths(llvm::StringRef PathStr,
   if (!PathStr.empty()) {
     if (!llvm::sys::fs::is_directory(PathStr)) {
       AllExisted = false;
-      if (Mode == kAllowNonExistant)
+      if (Mode == kAllowNonExistent)
         Paths.push_back(PathStr);
       else if (Verbose)
-        LogNonExistantDirectory(PathStr);
+        LogNonExistentDirectory(PathStr);
     } else
       Paths.push_back(PathStr);
   }
@@ -331,7 +331,7 @@ void AddIncludePaths(llvm::StringRef PathStr,
 
   llvm::SmallVector<llvm::StringRef, 10> Paths;
   if (Delim && *Delim)
-    SplitPaths(PathStr, Paths, kAllowNonExistant, Delim, HOpts.Verbose);
+    SplitPaths(PathStr, Paths, kAllowNonExistent, Delim, HOpts.Verbose);
   else
     Paths.push_back(PathStr);
 

--- a/lib/Interpreter/Paths.h
+++ b/lib/Interpreter/Paths.h
@@ -60,30 +60,30 @@ void DLClose(void* Lib, std::string* Err = nullptr);
 } // namespace platform
 
 enum SplitMode {
-  kPruneNonExistant, ///< Don't add non-existant paths into output
-  kFailNonExistant,  ///< Fail on any non-existant paths
-  kAllowNonExistant  ///< Add all paths whether they exist or not
+  kPruneNonExistent, ///< Don't add non-existent paths into output
+  kFailNonExistent,  ///< Fail on any non-existent paths
+  kAllowNonExistent  ///< Add all paths whether they exist or not
 };
 
-///\brief Collect the constituant paths from a PATH string.
+///\brief Collect the constituent paths from a PATH string.
 /// /bin:/usr/bin:/usr/local/bin -> {/bin, /usr/bin, /usr/local/bin}
 ///
 /// All paths returned existed at the time of the call
 /// \param [in] PathStr - The PATH string to be split
 /// \param [out] Paths - All the paths in the string that exist
 /// \param [in] Mode - If any path doesn't exist stop and return false
-/// \param [in] Delim - The delimeter to use
+/// \param [in] Delim - The delimiter to use
 /// \param [in] Verbose - Whether to print out details as 'clang -v' would
 ///
 /// \return true if all paths existed, otherwise false
 ///
 bool SplitPaths(llvm::StringRef PathStr,
                 llvm::SmallVectorImpl<llvm::StringRef>& Paths,
-                SplitMode Mode = kPruneNonExistant,
+                SplitMode Mode = kPruneNonExistent,
                 llvm::StringRef Delim = Cpp::utils::platform::kEnvDelim,
                 bool Verbose = false);
 
-///\brief Adds multiple include paths separated by a delimter into the
+///\brief Adds multiple include paths separated by a delimiter into the
 /// given HeaderSearchOptions.  This adds the paths but does no further
 /// processing. See Interpreter::AddIncludePaths or CIFactory::createCI
 /// for examples of what needs to be done once the paths have been added.
@@ -98,7 +98,7 @@ void AddIncludePaths(llvm::StringRef PathStr, clang::HeaderSearchOptions& HOpts,
 ///\brief Write to cling::errs that directory does not exist in a format
 /// matching what 'clang -v' would do
 ///
-void LogNonExistantDirectory(llvm::StringRef Path);
+void LogNonExistentDirectory(llvm::StringRef Path);
 
 ///\brief Copies the current include paths into the HeaderSearchOptions.
 ///

--- a/unittests/CppInterOp/CMakeLists.txt
+++ b/unittests/CppInterOp/CMakeLists.txt
@@ -1,7 +1,7 @@
 if (EMSCRIPTEN)
   # Omitting CUDATest.cpp since Emscripten build currently has no GPU support
   # For Emscripten builds linking to gtest_main will not suffice for gtest to run
-  # the tests and an explictly main.cpp is needed
+  # the tests and an explicitly main.cpp is needed
   set(EXTRA_TEST_SOURCE_FILES main.cpp)
 else()
   # Do not need main.cpp for native builds, but we do have GPU support for native builds


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

There was many typos in CppInterOp including in the names of variables and functions in the code. This PR fixes these typos.

A similar PR fixing typos in xeus-cpp is here https://github.com/compiler-research/xeus-cpp/pull/285

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [x] Bug fix
- [ ] New feature
- [x] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [x] I have read the contribution guide recently
