### PR TITLE
Stop cuda tests being run twice

### DIFF
--- a/unittests/CppInterOp/CMakeLists.txt
+++ b/unittests/CppInterOp/CMakeLists.txt
@@ -76,6 +76,11 @@ export_executable_symbols(CppInterOpTests)
 
 unset(LLVM_LINK_COMPONENTS)
 
+if (NOT EMSCRIPTEN)
+  set(EXTRA_TEST_SOURCE_FILES "")
+  set(EXTRA_PATH_TEST_BINARIES /TestSharedLib/unittests/bin/$<CONFIG>/)
+endif()
+
 add_cppinterop_unittest(DynamicLibraryManagerTests DynamicLibraryManagerTest.cpp ${EXTRA_TEST_SOURCE_FILES})
 
 target_link_libraries(DynamicLibraryManagerTests
@@ -93,10 +98,6 @@ if(EMSCRIPTEN)
     PUBLIC "SHELL: -s INITIAL_MEMORY=128mb"
     PUBLIC "SHELL: --preload-file ${SYSROOT_PATH}/include@/include"
   )
-endif()
-
- if (NOT EMSCRIPTEN)
-  set(EXTRA_PATH_TEST_BINARIES /TestSharedLib/unittests/bin/$<CONFIG>/)
 endif()
 
 set_output_directory(DynamicLibraryManagerTests


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

While looking at https://github.com/compiler-research/CppInterOp/actions/runs/14514284970/job/40723447067?pr=491 I noticed that the cuda tests are being run twice, due to EXTRA_TEST_SOURCE_FILES not being reset between setup for the 2 sets of tests. This PR should fix the issue. It only should be reset for the native build, because main.cpp is needed in both test runs for the Emscripten build.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [x] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [x] I have read the contribution guide recently
