### PR TITLE
Pin nlohmann_json to 3.12.0

### DIFF
--- a/environment-wasm.yml
+++ b/environment-wasm.yml
@@ -3,7 +3,7 @@ channels:
   - https://repo.prefix.dev/emscripten-forge-dev
 dependencies:
   - emscripten-abi==3.1.73
-  - nlohmann_json
+  - nlohmann_json=3.12.0
   - xeus-lite
   - xeus
   - cpp-argparse

--- a/environment-wasm.yml
+++ b/environment-wasm.yml
@@ -3,9 +3,9 @@ channels:
   - https://repo.prefix.dev/emscripten-forge-dev
 dependencies:
   - emscripten-abi==3.1.73
-  - nlohmann_json=3.11.3
+  - nlohmann_json
   - xeus-lite
-  - xeus=5.2.0
+  - xeus
   - cpp-argparse
   - pugixml
   - doctest

--- a/environment-wasm.yml
+++ b/environment-wasm.yml
@@ -3,7 +3,7 @@ channels:
   - https://repo.prefix.dev/emscripten-forge-dev
 dependencies:
   - emscripten-abi==3.1.73
-  - nlohmann_json=3.11.3
+  - nlohmann_json
   - xeus-lite
   - xeus
   - cpp-argparse

--- a/environment-wasm.yml
+++ b/environment-wasm.yml
@@ -3,9 +3,9 @@ channels:
   - https://repo.prefix.dev/emscripten-forge-dev
 dependencies:
   - emscripten-abi==3.1.73
-  - nlohmann_json
+  - nlohmann_json=3.11.3
   - xeus-lite
-  - xeus
+  - xeus=5.2.0
   - cpp-argparse
   - pugixml
   - doctest


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

The latest release of xeus got released, and requires nlohmann_json to be 3.12.0 . Until this PR is in the ci will fail
(see https://github.com/compiler-research/xeus-cpp/actions/runs/14604191183/job/40969335106#step:5:97).

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [x] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [x] I have read the contribution guide recently
