### PR TITLE
Remove Ubuntu 22.04 jobs from ci

### DIFF
--- a/.github/workflows/Ubuntu-arm.yml
+++ b/.github/workflows/Ubuntu-arm.yml
@@ -22,42 +22,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: ubu22-arm-gcc12-clang-repl-19
-            os: ubuntu-22.04-arm
-            compiler: gcc-12
-            clang-runtime: '19'
-            cling: Off
-            llvm_enable_projects: "clang"
-            llvm_targets_to_build: "host;NVPTX"
-          - name: ubu22-arm-gcc12-clang-repl-18
-            os: ubuntu-22.04-arm
-            compiler: gcc-12
-            clang-runtime: '18'
-            cling: Off
-            llvm_enable_projects: "clang"
-            llvm_targets_to_build: "host;NVPTX"
-          - name: ubu22-arm-gcc12-clang-repl-17
-            os: ubuntu-22.04-arm
-            compiler: gcc-12
-            clang-runtime: '17'
-            cling: Off
-            llvm_enable_projects: "clang"
-            llvm_targets_to_build: "host;NVPTX"
-          - name: ubu22-arm-gcc12-clang-repl-16
-            os: ubuntu-22.04-arm
-            compiler: gcc-12
-            clang-runtime: '16'
-            cling: Off
-            llvm_enable_projects: "clang"
-            llvm_targets_to_build: "host;NVPTX"
-          - name: ubu22-arm-gcc9-clang13-cling
-            os: ubuntu-22.04-arm
-            compiler: gcc-9
-            clang-runtime: '13'
-            cling: On
-            cling-version: '1.0'
-            llvm_enable_projects: "clang"
-            llvm_targets_to_build: "host;NVPTX"
           - name: ubu24-arm-gcc12-clang-repl-19
             os: ubuntu-24.04-arm
             compiler: gcc-12
@@ -276,37 +240,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: ubu22-arm-gcc12-clang-repl-19-cppyy
-            os: ubuntu-22.04-arm
-            compiler: gcc-12
-            clang-runtime: '19'
-            cling: Off
-            cppyy: On
-          - name: ubu22-arm-gcc12-clang-repl-18-cppyy
-            os: ubuntu-22.04-arm
-            compiler: gcc-12
-            clang-runtime: '18'
-            cling: Off
-            cppyy: On
-          - name: ubu22-arm-gcc12-clang-repl-17-cppyy
-            os: ubuntu-22.04-arm
-            compiler: gcc-12
-            clang-runtime: '17'
-            cling: Off
-            cppyy: On
-          - name: ubu22-arm-gcc12-clang-repl-16
-            os: ubuntu-22.04-arm
-            compiler: gcc-12
-            clang-runtime: '16'
-            cling: Off
-            cppyy: Off
-          - name: ubu22-arm-gcc9-clang13-cling-cppyy
-            os: ubuntu-22.04-arm
-            compiler: gcc-9
-            clang-runtime: '13'
-            cling: On
-            cling-version: '1.0'
-            cppyy: On
           - name: ubu24-arm-gcc12-clang-repl-19-cppyy
             os: ubuntu-24.04-arm
             compiler: gcc-12

--- a/.github/workflows/Ubuntu.yml
+++ b/.github/workflows/Ubuntu.yml
@@ -22,42 +22,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: ubu22-x86-gcc12-clang-repl-19
-            os: ubuntu-22.04
-            compiler: gcc-12
-            clang-runtime: '19'
-            cling: Off
-            llvm_enable_projects: "clang"
-            llvm_targets_to_build: "host;NVPTX"
-          - name: ubu22-x86-gcc12-clang-repl-18
-            os: ubuntu-22.04
-            compiler: gcc-12
-            clang-runtime: '18'
-            cling: Off
-            llvm_enable_projects: "clang"
-            llvm_targets_to_build: "host;NVPTX"
-          - name: ubu22-x86-gcc12-clang-repl-17
-            os: ubuntu-22.04
-            compiler: gcc-12
-            clang-runtime: '17'
-            cling: Off
-            llvm_enable_projects: "clang"
-            llvm_targets_to_build: "host;NVPTX"
-          - name: ubu22-x86-gcc12-clang-repl-16
-            os: ubuntu-22.04
-            compiler: gcc-12
-            clang-runtime: '16'
-            cling: Off
-            llvm_enable_projects: "clang"
-            llvm_targets_to_build: "host;NVPTX"
-          - name: ubu22-x86-gcc9-clang13-cling
-            os: ubuntu-22.04
-            compiler: gcc-9
-            clang-runtime: '13'
-            cling: On
-            cling-version: '1.0'
-            llvm_enable_projects: "clang"
-            llvm_targets_to_build: "host;NVPTX"
           - name: ubu24-x86-gcc12-clang-repl-19
             os: ubuntu-24.04
             compiler: gcc-12
@@ -276,45 +240,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: ubu22-x86-gcc12-clang-repl-19-docs
-            os: ubuntu-22.04
-            compiler: gcc-12
-            clang-runtime: '19'
-            cling: Off
-            cppyy: Off
-            documentation: On
-          - name: ubu22-x86-gcc12-clang-repl-19-cppyy
-            os: ubuntu-22.04
-            compiler: gcc-12
-            clang-runtime: '19'
-            cling: Off
-            cppyy: On
-            coverage: true
-          - name: ubu22-x86-gcc12-clang-repl-18-cppyy
-            os: ubuntu-22.04
-            compiler: gcc-12
-            clang-runtime: '18'
-            cling: Off
-            cppyy: On
-          - name: ubu22-x86-gcc12-clang-repl-17-cppyy
-            os: ubuntu-22.04
-            compiler: gcc-12
-            clang-runtime: '17'
-            cling: Off
-            cppyy: On
-          - name: ubu22-x86-gcc12-clang-repl-16
-            os: ubuntu-22.04
-            compiler: gcc-12
-            clang-runtime: '16'
-            cling: Off
-            cppyy: Off
-          - name: ubu22-x86-gcc9-clang13-cling-cppyy
-            os: ubuntu-22.04
-            compiler: gcc-9
-            clang-runtime: '13'
-            cling: On
-            cling-version: '1.0'
-            cppyy: On
           - name: ubu24-x86-gcc12-clang-repl-19-cppyy
             os: ubuntu-24.04
             compiler: gcc-12


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

With the introduction of the Windows arm job to CppInterOps ci, we no longer have enough space for the llvm 20 upgrade PR. Rather than try and scrimp just enough space to make the llvm 20 PR possible again this PR removes the Ubuntu 22.04 jobs from our ci, freeing up a large amount of space. This os will continue to be supported through the cppyy related repos ci, but will give CppInterOp the room significantly more space to jobs which will be of more interest. 

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [x] I have read the contribution guide recently
