### PR TITLE
Run Emscripten tests in a browser

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -145,6 +145,53 @@ jobs:
                 ../
         fi
         emmake make -j ${{ env.ncpus }} check-cppinterop
+        cd ./unittests/CppInterOp/
+
+        # Fresh install browsers, and run Emscripten tests in them
+        # This is to match the Emscripten build instructions, where
+        # we run in a fresh browser, to stop any extra installed
+        # stuff interferring with the running of the tests
+        # Explaination of options for emrun
+        # --browser (name of browser on path)
+        # --kill_exit makes it so that when emrun finishes,
+        # that the headless browser we create is killed along with it
+        # --timeout 60 is such that emrun is killed after 60 seconds if
+        # still running. emrun should have finished long before then,
+        # so if it is still running, something went wrong (such as a test
+        # which crashed the html file). This will cause the ci to fail,
+        # as a non 0 value of will be returned.
+        # In the case of Chrome we have the extra --no-sandbox flag, as on
+        # Ubuntu Chrome will refuse to run otherwise, as it expects to have
+        # been installed with admin privileges. This flag allows it to run
+        # in userspace.
+
+        # Install Firefox
+        wget "https://download.mozilla.org/?product=firefox-latest&os=osx&lang=en-US" -O Firefox-latest.dmg
+        hdiutil attach Firefox-latest.dmg
+        cp -r /Volumes/Firefox/Firefox.app $PWD
+        hdiutil detach /Volumes/Firefox
+        cd ./Firefox.app/Contents/MacOS/
+        export PATH="$PWD:$PATH"
+        cd -
+
+        # Install Google Chrome
+        wget https://dl.google.com/chrome/mac/stable/accept_tos%3Dhttps%253A%252F%252Fwww.google.com%252Fintl%252Fen_ph%252Fchrome%252Fterms%252F%26_and_accept_tos%3Dhttps%253A%252F%252Fpolicies.google.com%252Fterms/googlechrome.pkg
+        pkgutil --expand-full googlechrome.pkg google-chrome
+        cd ./google-chrome/GoogleChrome.pkg/Payload/Google\ Chrome.app/Contents/MacOS/
+        export PATH="$PWD:$PATH"
+        cd -
+
+        # Run tests in browsers
+        echo "Running CppInterOpTests in Firefox"
+        emrun --browser="firefox" --kill_exit --timeout 60 --browser-args="--headless"  CppInterOpTests.html
+        echo "Running DynamicLibraryManagerTests in Firefox"
+        emrun --browser="firefox" --kill_exit --timeout 60 --browser-args="--headless"  DynamicLibraryManagerTests.html
+        echo "Running CppInterOpTests in Google Chrome"
+        emrun --browser="Google Chrome" --kill_exit --timeout 60 --browser-args="--headless --no-sandbox"  CppInterOpTests.html
+        echo "Running DynamicLibraryManagerTests in Google Chrome"          
+        emrun --browser="Google Chrome" --kill_exit --timeout 60 --browser-args="--headless --no-sandbox"  DynamicLibraryManagerTests.html
+
+        cd ../../
         emmake make -j ${{ env.ncpus }} install
 
         cd ..

--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -599,6 +599,93 @@ jobs:
         fi
 
         emmake make -j ${{ env.ncpus }} check-cppinterop
+        cd ./unittests/CppInterOp/
+        # Fresh install browsers, and run Emscripten tests in them
+        # This is to match the Emscripten build instructions, where
+        # we run in a fresh browser, to stop any extra installed
+        # stuff interferring with the running of the tests
+        # Explaination of options for emrun
+        # --browser (name of browser on path)
+        # --kill_exit makes it so that when emrun finishes,
+        # that the headless browser we create is killed along with it
+        # --timeout 60 is such that emrun is killed after 60 seconds if
+        # still running. emrun should have finished long before then,
+        # so if it is still running, something went wrong (such as a test
+        # which crashed the html file). This will cause the ci to fail,
+        # as a non 0 value of will be returned.
+        # In the case of Chrome we have the extra --no-sandbox flag, as on
+        # Ubuntu Chrome will refuse to run otherwise, as it expects to have
+        # been installed with admin privileges. This flag allows it to run
+        # in userspace.
+        os="${{ matrix.os }}"
+        if [[ "${os}" == "macos"* ]]; then
+          # Install Firefox
+          wget "https://download.mozilla.org/?product=firefox-latest&os=osx&lang=en-US" -O Firefox-latest.dmg
+          hdiutil attach Firefox-latest.dmg
+          cp -r /Volumes/Firefox/Firefox.app $PWD
+          hdiutil detach /Volumes/Firefox
+          cd ./Firefox.app/Contents/MacOS/
+          export PATH="$PWD:$PATH"
+          cd -
+
+          # Install Google Chrome
+          wget https://dl.google.com/chrome/mac/stable/accept_tos%3Dhttps%253A%252F%252Fwww.google.com%252Fintl%252Fen_ph%252Fchrome%252Fterms%252F%26_and_accept_tos%3Dhttps%253A%252F%252Fpolicies.google.com%252Fterms/googlechrome.pkg
+          pkgutil --expand-full googlechrome.pkg google-chrome
+          cd ./google-chrome/GoogleChrome.pkg/Payload/Google\ Chrome.app/Contents/MacOS/
+          export PATH="$PWD:$PATH"
+          cd -
+
+          # Run tests in browsers
+          echo "Running CppInterOpTests in Firefox"
+          emrun --browser="firefox" --kill_exit --timeout 60 --browser-args="--headless"  CppInterOpTests.html
+          echo "Running DynamicLibraryManagerTests in Firefox"
+          emrun --browser="firefox" --kill_exit --timeout 60 --browser-args="--headless"  DynamicLibraryManagerTests.html
+          echo "Running CppInterOpTests in Google Chrome"
+          emrun --browser="Google Chrome" --kill_exit --timeout 60 --browser-args="--headless --no-sandbox"  CppInterOpTests.html
+          echo "Running DynamicLibraryManagerTests in Google Chrome"          
+          emrun --browser="Google Chrome" --kill_exit --timeout 60 --browser-args="--headless --no-sandbox"  DynamicLibraryManagerTests.html
+        else
+          export ARCHITECHURE=$(uname -m)
+          if [[ "$ARCHITECHURE" != "aarch64" ]]; then
+            # Install Google Chrome
+            wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+            dpkg-deb -x google-chrome-stable_current_amd64.deb $PWD/chrome
+            cd ./chrome/opt/google/chrome/
+            export PATH="$PWD:$PATH"
+            cd -
+
+            # Install Firefox
+            wget https://ftp.mozilla.org/pub/firefox/releases/138.0.1/linux-x86_64/en-GB/firefox-138.0.1.tar.xz
+            tar -xJf firefox-138.0.1.tar.xz
+            cd ./firefox
+            export PATH="$PWD:$PATH"
+            cd -
+
+            # Run tests in browsers
+            echo "Running CppInterOpTests in Firefox"
+            emrun --browser="firefox" --kill_exit --timeout 60 --browser-args="--headless"  CppInterOpTests.html
+            echo "Running DynamicLibraryManagerTests in Firefox"
+            emrun --browser="firefox" --kill_exit --timeout 60 --browser-args="--headless"  DynamicLibraryManagerTests.html
+            echo "Running CppInterOpTests in Google Chrome"
+            emrun --browser="google-chrome" --kill_exit --timeout 60 --browser-args="--headless --no-sandbox"  CppInterOpTests.html
+            echo "Running DynamicLibraryManagerTests in Google Chrome"          
+            emrun --browser="google-chrome" --kill_exit --timeout 60 --browser-args="--headless --no-sandbox"  DynamicLibraryManagerTests.html
+          else
+            # Install Firefox
+            wget https://ftp.mozilla.org/pub/firefox/releases/138.0.1/linux-aarch64/en-GB/firefox-138.0.1.tar.xz
+            tar -xJf firefox-138.0.1.tar.xz
+            cd ./firefox
+            export PATH="$PWD:$PATH"
+            cd -
+
+            # Run tests in browsers
+            echo "Running CppInterOpTests in Firefox"
+            emrun --browser="firefox" --kill_exit --timeout 60 --browser-args="--headless"  CppInterOpTests.html
+            echo "Running DynamicLibraryManagerTests in Firefox"
+            emrun --browser="firefox" --kill_exit --timeout 60 --browser-args="--headless"  DynamicLibraryManagerTests.html
+          fi
+        fi
+        cd ../..
         emmake make -j ${{ env.ncpus }} install
         cd ..
 

--- a/Emscripten-build-instructions.md
+++ b/Emscripten-build-instructions.md
@@ -165,7 +165,7 @@ $env:CMAKE_PREFIX_PATH=$env:PREFIX
 $env:CMAKE_SYSTEM_PREFIX_PATH=$env:PREFIX
 ```
 
-on Windows. Now to build and test your Emscripten build of CppInterOp on Linux and osx execute the following
+on Windows. Now to build and test your Emscripten build of CppInterOp using node on Linux and osx execute the following
 
 ```bash
 mkdir build
@@ -182,7 +182,7 @@ emcmake cmake -DCMAKE_BUILD_TYPE=Release    \
 emmake make -j $(nproc --all) check-cppinterop
 ```
 
-To build and test your Emscripten build of CppInterOp on Windows execute the following
+To build and test your Emscripten build of CppInterOp on using node Windows execute the following
 
 ```powershell
 emcmake cmake -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }}    `
@@ -200,9 +200,85 @@ emcmake cmake -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }}    `
     emmake make -j $(nproc --all) check-cppinterop
 ```
 
+It is possible to run the Emscripten tests in a headless browser on Linux and osx (in future we plan to include instructions on how to run the tests in a browser on Windows too). To do this we will first move to the tests directory
+
+
+```bash
+    cd ./unittests/CppInterOp/
+```
+
+We will run our tests in a fresh installed browser. Installing the browsers, and running the tests within the installed browsers will be platform dependent. To do this on MacOS execute the following
+
+```bash
+wget "https://download.mozilla.org/?product=firefox-latest&os=osx&lang=en-US" -O Firefox-latest.dmg
+hdiutil attach Firefox-latest.dmg
+cp -r /Volumes/Firefox/Firefox.app $PWD
+hdiutil detach /Volumes/Firefox
+cd ./Firefox.app/Contents/MacOS/
+export PATH="$PWD:$PATH"
+cd -
+
+wget https://dl.google.com/chrome/mac/stable/accept_tos%3Dhttps%253A%252F%252Fwww.google.com%252Fintl%252Fen_ph%252Fchrome%252Fterms%252F%26_and_accept_tos%3Dhttps%253A%252F%252Fpolicies.google.com%252Fterms/googlechrome.pkg
+pkgutil --expand-full googlechrome.pkg google-chrome
+cd ./google-chrome/GoogleChrome.pkg/Payload/Google\ Chrome.app/Contents/MacOS/
+export PATH="$PWD:$PATH"
+cd -
+
+echo "Running CppInterOpTests in Firefox"
+emrun --browser="firefox" --kill_exit --timeout 60 --browser-args="--headless"  CppInterOpTests.html
+echo "Running DynamicLibraryManagerTests in Firefox"
+emrun --browser="firefox" --kill_exit --timeout 60 --browser-args="--headless"  DynamicLibraryManagerTests.html
+echo "Running CppInterOpTests in Google Chrome"
+emrun --browser="Google Chrome" --kill_exit --timeout 60 --browser-args="--headless --no-sandbox"  CppInterOpTests.html
+echo "Running DynamicLibraryManagerTests in Google Chrome"          
+emrun --browser="Google Chrome" --kill_exit --timeout 60 --browser-args="--headless --no-sandbox"  DynamicLibraryManagerTests.html
+```
+
+To do this on Ubuntu x86 execute the following
+
+```bash
+wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+dpkg-deb -x google-chrome-stable_current_amd64.deb $PWD/chrome
+cd ./chrome/opt/google/chrome/
+export PATH="$PWD:$PATH"
+cd -
+
+wget https://ftp.mozilla.org/pub/firefox/releases/138.0.1/linux-x86_64/en-GB/firefox-138.0.1.tar.xz
+tar -xJf firefox-138.0.1.tar.xz
+cd ./firefox
+export PATH="$PWD:$PATH"
+cd -
+
+echo "Running CppInterOpTests in Firefox"
+emrun --browser="firefox" --kill_exit --timeout 60 --browser-args="--headless"  CppInterOpTests.html
+echo "Running DynamicLibraryManagerTests in Firefox"
+emrun --browser="firefox" --kill_exit --timeout 60 --browser-args="--headless"  DynamicLibraryManagerTests.html
+echo "Running CppInterOpTests in Google Chrome"
+emrun --browser="google-chrome" --kill_exit --timeout 60 --browser-args="--headless --no-sandbox"  CppInterOpTests.html
+echo "Running DynamicLibraryManagerTests in Google Chrome"          
+emrun --browser="google-chrome" --kill_exit --timeout 60 --browser-args="--headless --no-sandbox"  DynamicLibraryManagerTests.html
+```
+
+and on Ubuntu Arm execute the following (Google Chrome is not available on Ubuntu arm,
+so we currently only run in Firefox on this platform, unlike other plaforms)
+
+```bash
+wget https://ftp.mozilla.org/pub/firefox/releases/138.0.1/linux-aarch64/en-GB/firefox-138.0.1.tar.xz
+tar -xJf firefox-138.0.1.tar.xz
+cd ./firefox
+export PATH="$PWD:$PATH"
+cd -
+
+echo "Running CppInterOpTests in Firefox"
+emrun --browser="firefox" --kill_exit --timeout 60 --browser-args="--headless"  CppInterOpTests.html
+echo "Running DynamicLibraryManagerTests in Firefox"
+emrun --browser="firefox" --kill_exit --timeout 60 --browser-args="--headless"  DynamicLibraryManagerTests.html
+```
+
 Assuming it passes all test you can install by executing the following
 
 ```bash
+cd ../..
 emmake make -j $(nproc --all) install
 ```
 

--- a/docs/Emscripten-build-instructions.rst
+++ b/docs/Emscripten-build-instructions.rst
@@ -224,6 +224,80 @@ To build and test your Emscripten build of CppInterOp on Windows execute the fol
                 ..\
    emmake make -j $(nproc --all) check-cppinterop
 
+It is possible to run the Emscripten tests in a headless browser on Linux and osx (in future we plan to include instructions on how to run the tests in a browser on Windows too). To do this we will first move to the tests directory
+
+.. code:: bash
+
+   cd ./unittests/CppInterOp/
+
+We will run our tests in a fresh installed browser. Installing the browsers, and running the tests within the installed browsers will be platform dependent. To do this on MacOS execute the following
+
+.. code:: bash
+
+   wget "https://download.mozilla.org/?product=firefox-latest&os=osx&lang=en-US" -O Firefox-latest.dmg
+   hdiutil attach Firefox-latest.dmg
+   cp -r /Volumes/Firefox/Firefox.app $PWD
+   hdiutil detach /Volumes/Firefox
+   cd ./Firefox.app/Contents/MacOS/
+   export PATH="$PWD:$PATH"
+   cd -
+
+   wget https://dl.google.com/chrome/mac/stable/accept_tos%3Dhttps%253A%252F%252Fwww.google.com%252Fintl%252Fen_ph%252Fchrome%252Fterms%252F%26_and_accept_tos%3Dhttps%253A%252F%252Fpolicies.google.com%252Fterms/googlechrome.pkg
+   pkgutil --expand-full googlechrome.pkg google-chrome
+   cd ./google-chrome/GoogleChrome.pkg/Payload/Google\ Chrome.app/Contents/MacOS/
+   export PATH="$PWD:$PATH"
+   cd -
+
+   echo "Running CppInterOpTests in Firefox"
+   emrun --browser="firefox" --kill_exit --timeout 60 --browser-args="--headless"  CppInterOpTests.html
+   echo "Running DynamicLibraryManagerTests in Firefox"
+   emrun --browser="firefox" --kill_exit --timeout 60 --browser-args="--headless"  DynamicLibraryManagerTests.html
+   echo "Running CppInterOpTests in Google Chrome"
+   emrun --browser="Google Chrome" --kill_exit --timeout 60 --browser-args="--headless --no-sandbox"  CppInterOpTests.html
+   echo "Running DynamicLibraryManagerTests in Google Chrome"          
+   emrun --browser="Google Chrome" --kill_exit --timeout 60 --browser-args="--headless --no-sandbox"  DynamicLibraryManagerTests.html
+
+To do this on Ubuntu x86 execute the following
+
+.. code:: bash
+
+   wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+   dpkg-deb -x google-chrome-stable_current_amd64.deb $PWD/chrome
+   cd ./chrome/opt/google/chrome/
+   export PATH="$PWD:$PATH"
+   cd -
+
+   wget https://ftp.mozilla.org/pub/firefox/releases/138.0.1/linux-x86_64/en-GB/firefox-138.0.1.tar.xz
+   tar -xJf firefox-138.0.1.tar.xz
+   cd ./firefox
+   export PATH="$PWD:$PATH"
+   cd -
+
+   echo "Running CppInterOpTests in Firefox"
+   emrun --browser="firefox" --kill_exit --timeout 60 --browser-args="--headless"  CppInterOpTests.html
+   echo "Running DynamicLibraryManagerTests in Firefox"
+   emrun --browser="firefox" --kill_exit --timeout 60 --browser-args="--headless"  DynamicLibraryManagerTests.html
+   echo "Running CppInterOpTests in Google Chrome"
+   emrun --browser="google-chrome" --kill_exit --timeout 60 --browser-args="--headless --no-sandbox"  CppInterOpTests.html
+   echo "Running DynamicLibraryManagerTests in Google Chrome"          
+   emrun --browser="google-chrome" --kill_exit --timeout 60 --browser-args="--headless --no-sandbox"  DynamicLibraryManagerTests.html
+
+and on Ubuntu Arm execute the following (Google Chrome is not available on Ubuntu arm,
+so we currently only run the tests using Firefox on this platform, unlike other plaforms)
+
+.. code:: bash
+
+   wget https://ftp.mozilla.org/pub/firefox/releases/138.0.1/linux-aarch64/en-GB/firefox-138.0.1.tar.xz
+   tar -xJf firefox-138.0.1.tar.xz
+   cd ./firefox
+   export PATH="$PWD:$PATH"
+   cd -
+
+   echo "Running CppInterOpTests in Firefox"
+   emrun --browser="firefox" --kill_exit --timeout 60 --browser-args="--headless"  CppInterOpTests.html
+   echo "Running DynamicLibraryManagerTests in Firefox"
+   emrun --browser="firefox" --kill_exit --timeout 60 --browser-args="--headless"  DynamicLibraryManagerTests.html
+
 Assuming it passes all test you can install by executing the following. 
 
 .. code:: bash

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -34,7 +34,13 @@ if(WIN32)
 else()
   target_link_libraries(${name} PRIVATE ${ARG_LIBRARIES} ${gtest_libs} ${link_pthreads_lib})
 endif()
+if(EMSCRIPTEN)
+  # Without this cmake will try and get node to run the html file.
+  # This guarantees that it runs the js file, and uses emsdks node.
+  add_test(NAME cppinterop-${name} COMMAND $ENV{EMSDK_NODE} ${name}.js)
+else()
   add_test(NAME cppinterop-${name} COMMAND ${name})
+endif()
   set_tests_properties(cppinterop-${name} PROPERTIES
                        TIMEOUT "${TIMEOUT_VALUE}"
                        ENVIRONMENT "CPLUS_INCLUDE_PATH=${CMAKE_BINARY_DIR}/etc"

--- a/unittests/CppInterOp/CMakeLists.txt
+++ b/unittests/CppInterOp/CMakeLists.txt
@@ -1,4 +1,6 @@
 if (EMSCRIPTEN)
+  # So we create a html file, as well as the javascript file
+  set(CMAKE_EXECUTABLE_SUFFIX ".html")
   # Omitting CUDATest.cpp since Emscripten build currently has no GPU support
   # For Emscripten builds linking to gtest_main will not suffice for gtest to run
   # the tests and an explicitly main.cpp is needed
@@ -42,6 +44,10 @@ if(EMSCRIPTEN)
   #
   # --preload-file ${SYSROOT_PATH}/include@/include:
   # Preloads the system include directory into the Emscripten virtual filesystem to make headers accessible at runtime.
+  #
+  # --emrun
+  # Makes it so that we run the html file created by this target, that we can capture the standard output
+  # and output to the terminal
   target_link_options(CppInterOpTests
     PUBLIC "SHELL: -fexceptions"
     PUBLIC "SHELL: -s MAIN_MODULE=1"
@@ -50,6 +56,7 @@ if(EMSCRIPTEN)
     PUBLIC "SHELL: -s STACK_SIZE=32mb"
     PUBLIC "SHELL: -s INITIAL_MEMORY=128mb"
     PUBLIC "SHELL: --preload-file ${SYSROOT_PATH}/include@/include"
+    PUBLIC "SHELL: --emrun"
   )
 endif()
 
@@ -97,6 +104,7 @@ if(EMSCRIPTEN)
     PUBLIC "SHELL: -s STACK_SIZE=32mb"
     PUBLIC "SHELL: -s INITIAL_MEMORY=128mb"
     PUBLIC "SHELL: --preload-file ${SYSROOT_PATH}/include@/include"
+    PUBLIC "SHELL: --emrun"
   )
 endif()
 


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

This PR adds the ability to run the Emscripten tests in a browser. This partially contributes to the goal of https://github.com/compiler-research/CppInterOp/issues/500 , which is to run a c++ tutorial html file utilising CppInterOp, as part of automated testing.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [x] New feature
- [x] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [x] I have read the contribution guide recently
