### PR TITLE
Update GoogleTest used to 1.17.0

### DIFF
--- a/cmake/modules/GoogleTest.cmake
+++ b/cmake/modules/GoogleTest.cmake
@@ -36,7 +36,7 @@ ExternalProject_Add(
   googletest
   GIT_REPOSITORY https://github.com/google/googletest.git
   GIT_SHALLOW 1
-  GIT_TAG v1.16.0
+  GIT_TAG v1.17.0
   UPDATE_COMMAND ""
   # # Force separate output paths for debug and release builds to allow easy
   # # identification of correct lib in subsequent TARGET_LINK_LIBRARIES commands


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

Googletests most recent version 1.17.0 got released a few days ago. Unlike previous versions they have made the minimum required c++ standard c++17 for this version. As we don't use the googletest that comes with CppInterOp for the cling 1.0 job, we should be able to upgrade to this new version.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [x] I have read the contribution guide recently
