### PR TITLE
Mention Emscripten xeus-cpp deployment in read the docs documentation

### DIFF
--- a/docs/Emscripten-build-instructions.rst
+++ b/docs/Emscripten-build-instructions.rst
@@ -3,7 +3,11 @@
 #########################
 
 It should be noted that the wasm build of CppInterOp is still
-experimental and subject to change.
+experimental and subject to change. Try a Jupyter Lite demo of xeus-cpp by clicking
+
+.. image:: https://jupyterlite.rtfd.io/en/latest/_static/badge.svg
+   :target: https://compiler-research.github.io/CppInterOp/lab/index.html
+   :alt: lite-badge
 
 ************************************
  CppInterOp Wasm Build Instructions


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

We currently only talk about the Jupyter Lite deployment in the readme file. This makes the deployment more visible
by adding a link in the main page of CppInterOp read the docs page. This has already been done in the xeus-cpp repo here https://github.com/compiler-research/xeus-cpp/pull/275

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [ ] New feature
- [x] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [x] I have read the contribution guide recently
