### PR TITLE
Add $ErrorActionPreference = "Stop" Windows Emscripten build ci

### DIFF
--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -620,6 +620,7 @@ jobs:
       if: ${{ runner.os == 'windows' }}
       shell: powershell
       run: |
+        $ErrorActionPreference = "Stop"
         micromamba create -f environment-wasm.yml --platform=emscripten-wasm32
         .\emsdk\emsdk activate ${{matrix.emsdk_ver}}
         .\emsdk\emsdk_env.ps1


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

If you look here https://github.com/compiler-research/CppInterOp/actions/runs/14671427202/job/41183123838#step:11:354 , the Windows Emscripten tests failed, but the ci failed to detect this. In the Linux/MacOS case we detect these failures using `set -e` (see https://github.com/compiler-research/CppInterOp/blob/2595a1f2d2711e1acaaa28dc5372f1230d64b3ec/.github/workflows/emscripten.yml#L547 ) . This adds to the ci the Windows equivalent of this command, so we should detect these failures in future.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [x] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [x] I have read the contribution guide recently
