### PR TITLE
Add `IsRestrictQualifiedType` & `GetNonRestrictQualifiedType` functions

### DIFF
--- a/include/clang/Interpreter/CppInterOp.h
+++ b/include/clang/Interpreter/CppInterOp.h
@@ -546,6 +546,12 @@ namespace Cpp {
   /// out of it.
   CPPINTEROP_API TCppType_t GetCanonicalType(TCppType_t type);
 
+  /// Get non restrict qualified version of the given type
+  CPPINTEROP_API TCppType_t GetNonRestrictQualifiedType(TCppType_t type);
+
+  /// check if the type is restrict qualified i.e. __restrict
+  CPPINTEROP_API bool IsRestrictQualifiedType(TCppType_t type);
+
   /// Used to either get the built-in type of the provided string, or
   /// use the name to lookup the actual type.
   CPPINTEROP_API TCppType_t GetType(const std::string& type);

--- a/lib/Interpreter/CppInterOp.cpp
+++ b/lib/Interpreter/CppInterOp.cpp
@@ -1657,6 +1657,25 @@ namespace Cpp {
     return QT.getCanonicalType().getAsOpaquePtr();
   }
 
+  bool IsRestrictQualifiedType(TCppType_t type) {
+    if (!type)
+      return 0;
+    QualType QT = QualType::getFromOpaquePtr(type);
+    return QT.isRestrictQualified();
+  }
+
+  TCppType_t GetNonRestrictQualifiedType(TCppType_t type) {
+    if (!type)
+      return 0;
+    QualType QT = QualType::getFromOpaquePtr(type);
+    if (QT.isRestrictQualified()) {
+      QualType NonRestrictType(QT);
+      NonRestrictType.removeLocalRestrict();
+      return NonRestrictType.getAsOpaquePtr();
+    }
+    return nullptr;
+  }
+
   // Internal functions that are not needed outside the library are
   // encompassed in an anonymous namespace as follows. This function converts
   // from a string to the actual type. It is used in the GetType() function.

--- a/unittests/CppInterOp/TypeReflectionTest.cpp
+++ b/unittests/CppInterOp/TypeReflectionTest.cpp
@@ -605,3 +605,21 @@ TEST(TypeReflectionTest, IsFunctionPointerType) {
   EXPECT_FALSE(
       Cpp::IsFunctionPointerType(Cpp::GetVariableType(Cpp::GetNamed("i"))));
 }
+
+TEST(TypeReflectionTest, RestrictQualifiedType) {
+  Cpp::CreateInterpreter();
+  Cpp::Declare(R"(
+    int *x;
+    int *__restrict y;
+  )");
+
+  Cpp::TCppType_t x = Cpp::GetVariableType(Cpp::GetNamed("x"));
+  Cpp::TCppType_t y = Cpp::GetVariableType(Cpp::GetNamed("y"));
+
+  EXPECT_FALSE(Cpp::IsRestrictQualifiedType(x));
+  EXPECT_TRUE(Cpp::IsRestrictQualifiedType(y));
+
+  EXPECT_FALSE(Cpp::GetNonRestrictQualifiedType(x));
+  EXPECT_EQ(Cpp::GetCanonicalType(Cpp::GetNonRestrictQualifiedType(y)),
+            Cpp::GetCanonicalType(x));
+}


### PR DESCRIPTION
# Description

Example `int *__restrict x`

## Fixes # (issue)

Helps fix a test case in cppyy.

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [x] New feature
- [ ] Requires documentation updates

## Testing

Added necessary tests.

## Checklist

- [x] I have read the contribution guide recently
