### PR TITLE
fix operator resolution to check base classes

### DIFF
--- a/unittests/CppInterOp/ScopeReflectionTest.cpp
+++ b/unittests/CppInterOp/ScopeReflectionTest.cpp
@@ -1107,4 +1107,28 @@ TEST(ScopeReflectionTest, GetOperator) {
   Cpp::GetOperator(Cpp::GetScope("extra_ops"), Cpp::Operator::OP_Tilde, ops,
                    Cpp::OperatorArity::kBinary);
   EXPECT_EQ(ops.size(), 0);
+
+  std::string inheritance_code = R"(
+  struct Parent {
+    int x;
+    Parent operator+(const Parent& other) {
+      return Parent{x + other.x};
+    }
+  };
+
+  struct Child : Parent {
+    Child operator-(const Child& other) {
+      return Child{x - other.x};
+    }
+  };
+  )";
+  Cpp::Declare(inheritance_code.c_str());
+
+  ops.clear();
+  Cpp::GetOperator(Cpp::GetScope("Child"), Cpp::Operator::OP_Plus, ops);
+  EXPECT_EQ(ops.size(), 1);
+
+  ops.clear();
+  Cpp::GetOperator(Cpp::GetScope("Child"), Cpp::Operator::OP_Minus, ops);
+  EXPECT_EQ(ops.size(), 1);
 }

--- a/unittests/CppInterOp/ScopeReflectionTest.cpp
+++ b/unittests/CppInterOp/ScopeReflectionTest.cpp
@@ -1111,14 +1111,16 @@ TEST(ScopeReflectionTest, GetOperator) {
   std::string inheritance_code = R"(
   struct Parent {
     int x;
+    Parent(int x) : x(x) {}
     Parent operator+(const Parent& other) {
-      return Parent{x + other.x};
+      return Parent(x + other.x);
     }
   };
 
   struct Child : Parent {
+    Child(int x) : Parent(x) {}
     Child operator-(const Child& other) {
-      return Child{x - other.x};
+      return Child(x - other.x);
     }
   };
   )";


### PR DESCRIPTION
# Description

`GetOperator` now resolves the operator into the base classes. 

## Fixes # (issue)

Helps with smart pointers. Fixing 9 tests in cppyy.

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Tests included.

## Checklist

- [x] I have read the contribution guide recently
