### PR TITLE
Enable clang resource dir headers access for cppinterop's deployment

### DIFF
--- a/environment-wasm.yml
+++ b/environment-wasm.yml
@@ -9,3 +9,4 @@ dependencies:
   - cpp-argparse
   - pugixml
   - doctest
+  - clang-resource-headers


### PR DESCRIPTION
# Description

This should fix the failing CI for cppinterop

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [x] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [ ] I have read the contribution guide recently
