### PR TITLE
Add smallpt example to deployment

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -241,7 +241,7 @@ jobs:
           micromamba create -n xeus-lite-host jupyterlite-core -c conda-forge
           micromamba activate xeus-lite-host
           python -m pip install jupyterlite-xeus jupyterlite-core jupyterlab notebook libarchive-c
-          jupyter lite build --XeusAddon.prefix=${{ env.PREFIX }} --contents notebooks/xeus-cpp-lite-demo.ipynb --contents notebooks/images/marie.png --contents notebooks/audio/audio.wav --output-dir dist
+          jupyter lite build --XeusAddon.prefix=${{ env.PREFIX }} --contents notebooks/xeus-cpp-lite-demo.ipynb --contents notebooks/smallpt.ipynb --contents notebooks/images/marie.png --contents notebooks/audio/audio.wav --output-dir dist
 
     - name: Upload artifact
       uses: actions/upload-pages-artifact@v3

--- a/Emscripten-build-instructions.md
+++ b/Emscripten-build-instructions.md
@@ -319,7 +319,7 @@ cd ../..
 micromamba create -n xeus-lite-host jupyterlite-core -c conda-forge
 micromamba activate xeus-lite-host
 python -m pip install jupyterlite-xeus jupyter_server
-jupyter lite build --XeusAddon.prefix=$PREFIX --contents xeus-cpp/notebooks/xeus-cpp-lite-demo.ipynb
+jupyter lite build --XeusAddon.prefix=$PREFIX --contents xeus-cpp/notebooks/xeus-cpp-lite-demo.ipynb --contents notebooks/smallpt.ipynb --contents notebooks/images/marie.png --contents notebooks/audio/audio.wav
 ```
 
 Once the Jupyter Lite site has built you can test the website locally by executing

--- a/docs/Emscripten-build-instructions.rst
+++ b/docs/Emscripten-build-instructions.rst
@@ -344,7 +344,7 @@ for testing execute the following
    micromamba create -n xeus-lite-host jupyterlite-core -c conda-forge
    micromamba activate xeus-lite-host
    python -m pip install jupyterlite-xeus jupyter_server
-   jupyter lite build --XeusAddon.prefix=$PREFIX --contents xeus-cpp/notebooks/xeus-cpp-lite-demo.ipynb
+   jupyter lite build --XeusAddon.prefix=$PREFIX --contents xeus-cpp/notebooks/xeus-cpp-lite-demo.ipynb --contents notebooks/smallpt.ipynb --contents notebooks/images/marie.png --contents notebooks/audio/audio.wav
 
 Once the Jupyter Lite site has built you can test the website locally by
 executing


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

Subject to https://github.com/compiler-research/xeus-cpp/pull/316 in xeus-cpp going in, and found to be working, this PR adds the smallpt example to xeus-cpps deployment. I used this PR as an opportunity to add '--contents notebooks/images/marie.png --contents notebooks/audio/audio.wav' to the Emscripten build instructions too since they are missing.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [x] New feature
- [x] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [x] I have read the contribution guide recently
