### PR TITLE
Fix Windows x86 badge

### DIFF
--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -1,4 +1,4 @@
-name: Windows
+name: Windows-x86
 on:
   pull_request:
     branches: [main]


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

Currently for MacOS and Ubuntu we have separate badges labelled x86 and arm. For Windows x86 we do not have x86 in the badge name, but we do have arm for the Windows arm badge. This PR fixes that.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [ ] I have read the contribution guide recently
