### PR TITLE
Remove LLVM_ENABLE_ZSTD=OFF, LLVM_ENABLE_TERMINFO=OFF and LLVM_ENABLE_LIBXML2=OFF  options llvm native build

### DIFF
--- a/.github/workflows/MacOS-arm.yml
+++ b/.github/workflows/MacOS-arm.yml
@@ -187,9 +187,6 @@ jobs:
                 -DCLANG_ENABLE_ARCMT=OFF                           \
                 -DCLANG_ENABLE_FORMAT=OFF                          \
                 -DCLANG_ENABLE_BOOTSTRAP=OFF                       \
-                -DLLVM_ENABLE_ZSTD=OFF                             \
-                -DLLVM_ENABLE_TERMINFO=OFF                         \
-                -DLLVM_ENABLE_LIBXML2=OFF                          \
                 -G Ninja                                           \
                 ../llvm
           ninja clang -j ${{ env.ncpus }}
@@ -211,9 +208,6 @@ jobs:
                 -DCLANG_ENABLE_ARCMT=OFF                            \
                 -DCLANG_ENABLE_FORMAT=OFF                           \
                 -DCLANG_ENABLE_BOOTSTRAP=OFF                        \
-                -DLLVM_ENABLE_ZSTD=OFF                              \
-                -DLLVM_ENABLE_TERMINFO=OFF                          \
-                -DLLVM_ENABLE_LIBXML2=OFF                           \
                 -G Ninja                                            \
                 -DLLVM_INCLUDE_BENCHMARKS=OFF                   \
                 -DLLVM_INCLUDE_EXAMPLES=OFF                     \

--- a/.github/workflows/MacOS.yml
+++ b/.github/workflows/MacOS.yml
@@ -171,9 +171,6 @@ jobs:
                 -DCLANG_ENABLE_ARCMT=OFF                           \
                 -DCLANG_ENABLE_FORMAT=OFF                          \
                 -DCLANG_ENABLE_BOOTSTRAP=OFF                       \
-                -DLLVM_ENABLE_ZSTD=OFF                             \
-                -DLLVM_ENABLE_TERMINFO=OFF                         \
-                -DLLVM_ENABLE_LIBXML2=OFF                          \
                 -G Ninja                                           \
                 ../llvm
           ninja clang -j ${{ env.ncpus }}
@@ -195,9 +192,6 @@ jobs:
                 -DCLANG_ENABLE_ARCMT=OFF                            \
                 -DCLANG_ENABLE_FORMAT=OFF                           \
                 -DCLANG_ENABLE_BOOTSTRAP=OFF                        \
-                -DLLVM_ENABLE_ZSTD=OFF                              \
-                -DLLVM_ENABLE_TERMINFO=OFF                          \
-                -DLLVM_ENABLE_LIBXML2=OFF                           \
                 -G Ninja                                            \
                 -DLLVM_INCLUDE_BENCHMARKS=OFF                   \
                 -DLLVM_INCLUDE_EXAMPLES=OFF                     \

--- a/.github/workflows/Ubuntu-arm.yml
+++ b/.github/workflows/Ubuntu-arm.yml
@@ -182,9 +182,6 @@ jobs:
                 -DCLANG_ENABLE_ARCMT=OFF                           \
                 -DCLANG_ENABLE_FORMAT=OFF                          \
                 -DCLANG_ENABLE_BOOTSTRAP=OFF                       \
-                -DLLVM_ENABLE_ZSTD=OFF                             \
-                -DLLVM_ENABLE_TERMINFO=OFF                         \
-                -DLLVM_ENABLE_LIBXML2=OFF                          \
                 -G Ninja                                           \
                 ../llvm
           ninja clang -j ${{ env.ncpus }}
@@ -206,9 +203,6 @@ jobs:
                 -DCLANG_ENABLE_ARCMT=OFF                            \
                 -DCLANG_ENABLE_FORMAT=OFF                           \
                 -DCLANG_ENABLE_BOOTSTRAP=OFF                        \
-                -DLLVM_ENABLE_ZSTD=OFF                              \
-                -DLLVM_ENABLE_TERMINFO=OFF                          \
-                -DLLVM_ENABLE_LIBXML2=OFF                           \
                 -G Ninja                                            \
                 -DLLVM_INCLUDE_BENCHMARKS=OFF                   \
                 -DLLVM_INCLUDE_EXAMPLES=OFF                     \

--- a/.github/workflows/Ubuntu.yml
+++ b/.github/workflows/Ubuntu.yml
@@ -175,9 +175,6 @@ jobs:
                 -DCLANG_ENABLE_ARCMT=OFF                           \
                 -DCLANG_ENABLE_FORMAT=OFF                          \
                 -DCLANG_ENABLE_BOOTSTRAP=OFF                       \
-                -DLLVM_ENABLE_ZSTD=OFF                             \
-                -DLLVM_ENABLE_TERMINFO=OFF                         \
-                -DLLVM_ENABLE_LIBXML2=OFF                          \
                 -G Ninja                                           \
                 ../llvm
           ninja clang -j ${{ env.ncpus }}
@@ -199,9 +196,6 @@ jobs:
                 -DCLANG_ENABLE_ARCMT=OFF                            \
                 -DCLANG_ENABLE_FORMAT=OFF                           \
                 -DCLANG_ENABLE_BOOTSTRAP=OFF                        \
-                -DLLVM_ENABLE_ZSTD=OFF                              \
-                -DLLVM_ENABLE_TERMINFO=OFF                          \
-                -DLLVM_ENABLE_LIBXML2=OFF                           \
                 -G Ninja                                            \
                 -DLLVM_INCLUDE_BENCHMARKS=OFF                   \
                 -DLLVM_INCLUDE_EXAMPLES=OFF                     \

--- a/.github/workflows/Windows-arm.yml
+++ b/.github/workflows/Windows-arm.yml
@@ -158,9 +158,6 @@ jobs:
                 -DCLANG_ENABLE_ARCMT=OFF                           `
                 -DCLANG_ENABLE_FORMAT=OFF                          `
                 -DCLANG_ENABLE_BOOTSTRAP=OFF                       `
-                -DLLVM_ENABLE_ZSTD=OFF                             `
-                -DLLVM_ENABLE_TERMINFO=OFF                         `
-                -DLLVM_ENABLE_LIBXML2=OFF                          `
                 ..\llvm
           cmake --build . --config Release --target clang --parallel ${{ env.ncpus }}
           cmake --build . --config Release --target LLVMOrcDebugging --parallel ${{ env.ncpus }}
@@ -190,9 +187,6 @@ jobs:
                 -DCLANG_ENABLE_ARCMT=OFF                            `
                 -DCLANG_ENABLE_FORMAT=OFF                           `
                 -DCLANG_ENABLE_BOOTSTRAP=OFF                        `
-                -DLLVM_ENABLE_ZSTD=OFF                              `
-                -DLLVM_ENABLE_TERMINFO=OFF                          `
-                -DLLVM_ENABLE_LIBXML2=OFF                           `
                 ..\llvm
           cmake --build . --config Release --target clang clangInterpreter clangStaticAnalyzerCore --parallel ${{ env.ncpus }}
         }

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -158,9 +158,6 @@ jobs:
                 -DCLANG_ENABLE_ARCMT=OFF                           `
                 -DCLANG_ENABLE_FORMAT=OFF                          `
                 -DCLANG_ENABLE_BOOTSTRAP=OFF                       `
-                -DLLVM_ENABLE_ZSTD=OFF                             `
-                -DLLVM_ENABLE_TERMINFO=OFF                         `
-                -DLLVM_ENABLE_LIBXML2=OFF                          `
                 ..\llvm
           cmake --build . --config Release --target clang --parallel ${{ env.ncpus }}
           cmake --build . --config Release --target LLVMOrcDebugging --parallel ${{ env.ncpus }}
@@ -190,9 +187,6 @@ jobs:
                 -DCLANG_ENABLE_ARCMT=OFF                            `
                 -DCLANG_ENABLE_FORMAT=OFF                           `
                 -DCLANG_ENABLE_BOOTSTRAP=OFF                        `
-                -DLLVM_ENABLE_ZSTD=OFF                              `
-                -DLLVM_ENABLE_TERMINFO=OFF                          `
-                -DLLVM_ENABLE_LIBXML2=OFF                           `
                 ..\llvm
           cmake --build . --config Release --target clang clangInterpreter clangStaticAnalyzerCore --parallel ${{ env.ncpus }}
         }

--- a/README.md
+++ b/README.md
@@ -142,9 +142,6 @@ cmake -DLLVM_ENABLE_PROJECTS=clang                                  \
                 -DCLANG_ENABLE_ARCMT=OFF                            \
                 -DCLANG_ENABLE_FORMAT=OFF                           \
                 -DCLANG_ENABLE_BOOTSTRAP=OFF                        \
-                -DLLVM_ENABLE_ZSTD=OFF                              \
-                -DLLVM_ENABLE_TERMINFO=OFF                          \
-                -DLLVM_ENABLE_LIBXML2=OFF                           \
                 ../llvm
 cmake --build . --target clang clang-repl --parallel $(nproc --all)
 ```
@@ -208,9 +205,6 @@ cmake -DLLVM_ENABLE_PROJECTS=clang                                 \
                 -DCLANG_ENABLE_ARCMT=OFF                           \
                 -DCLANG_ENABLE_FORMAT=OFF                          \
                 -DCLANG_ENABLE_BOOTSTRAP=OFF                       \
-                -DLLVM_ENABLE_ZSTD=OFF                             \
-                -DLLVM_ENABLE_TERMINFO=OFF                         \
-                -DLLVM_ENABLE_LIBXML2=OFF                          \
                 ../llvm
 cmake --build . --target clang --parallel $(nproc --all)
 cmake --build . --target cling --parallel $(nproc --all)

--- a/docs/DevelopersDocumentation.rst
+++ b/docs/DevelopersDocumentation.rst
@@ -78,9 +78,6 @@ following command
            -DCLANG_ENABLE_ARCMT=OFF                            \
            -DCLANG_ENABLE_FORMAT=OFF                           \
            -DCLANG_ENABLE_BOOTSTRAP=OFF                        \
-           -DLLVM_ENABLE_ZSTD=OFF                              \
-           -DLLVM_ENABLE_TERMINFO=OFF                          \
-           -DLLVM_ENABLE_LIBXML2=OFF                           \
            ../llvm
    cmake --build . --target clang clang-repl --parallel $(nproc --all)
 
@@ -147,9 +144,6 @@ build instructions to build on Linux and MacOS
            -DCLANG_ENABLE_ARCMT=OFF                           \
            -DCLANG_ENABLE_FORMAT=OFF                          \
            -DCLANG_ENABLE_BOOTSTRAP=OFF                       \
-           -DLLVM_ENABLE_ZSTD=OFF                             \
-           -DLLVM_ENABLE_TERMINFO=OFF                         \
-           -DLLVM_ENABLE_LIBXML2=OFF                          \
            ../llvm
    cmake --build . --target clang --parallel $(nproc --all)
    cmake --build . --target cling --parallel $(nproc --all)

--- a/docs/InstallationAndUsage.rst
+++ b/docs/InstallationAndUsage.rst
@@ -78,9 +78,6 @@ following command
            -DCLANG_ENABLE_ARCMT=OFF                            \
            -DCLANG_ENABLE_FORMAT=OFF                           \
            -DCLANG_ENABLE_BOOTSTRAP=OFF                        \
-           -DLLVM_ENABLE_ZSTD=OFF                              \
-           -DLLVM_ENABLE_TERMINFO=OFF                          \
-           -DLLVM_ENABLE_LIBXML2=OFF                           \
            ../llvm
    cmake --build . --target clang clang-repl --parallel $(nproc --all)
 
@@ -147,9 +144,6 @@ build instructions to build on Linux and MacOS
            -DCLANG_ENABLE_ARCMT=OFF                           \
            -DCLANG_ENABLE_FORMAT=OFF                          \
            -DCLANG_ENABLE_BOOTSTRAP=OFF                       \
-           -DLLVM_ENABLE_ZSTD=OFF                             \
-           -DLLVM_ENABLE_TERMINFO=OFF                         \
-           -DLLVM_ENABLE_LIBXML2=OFF                          \
            ../llvm
    cmake --build . --target clang --parallel $(nproc --all)
    cmake --build . --target cling --parallel $(nproc --all)


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

This PR remove LLVM_ENABLE_ZSTD=OFF ,LLVM_ENABLE_TERMINFO=OFF and LLVM_ENABLE_LIBXML2=OFF  options llvm native build. These options were added when CppInterOp was trying to combine the Emscripten and native llvm builds into 1.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [x] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [x] I have read the contribution guide recently
