### PR TITLE
Use pragma for deprecated warning message MSVC compiler

### DIFF
--- a/include/clang/Interpreter/CppInterOp.h
+++ b/include/clang/Interpreter/CppInterOp.h
@@ -2,7 +2,12 @@
 #define CLANG_CPPINTEROP_H
 
 #include "CppInterOp/CppInterOp.h"
+#if defined(_MSC_VER)
+#pragma message(                                                               \
+    "#include <clang/Interpreter/CppInterOp.h> is deprecated; use #include <CppInterOp/CppInterOp.h")
+#else
 #warning                                                                       \
     "#include <clang/Interpreter/CppInterOp.h> is deprecated; use #include <CppInterOp/CppInterOp.h"
+#endif
 
 #endif // CLANG_CPPINTEROP_H


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

While investigating how to get a Windows build of cppyy here https://github.com/compiler-research/CppInterOp/pull/605 I found that the deprecation message is not understood by the MSVC compiler. Without this fix anything built on top of CppInterOp on Windows using the MSVC compiler will not work.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [x] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [x] I have read the contribution guide recently
