### PR TITLE
Update codecov action to use files instead of file

### DIFF
--- a/.github/workflows/Ubuntu-arm.yml
+++ b/.github/workflows/Ubuntu-arm.yml
@@ -325,7 +325,7 @@ jobs:
       if: ${{ success() && (matrix.coverage == true) }}
       uses: codecov/codecov-action@v5
       with:
-        file: ./coverage.info
+        files: ./coverage.info
         fail_ci_if_error: true
         verbose: true
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/Ubuntu.yml
+++ b/.github/workflows/Ubuntu.yml
@@ -311,7 +311,7 @@ jobs:
       if: ${{ success() && (matrix.coverage == true) }}
       uses: codecov/codecov-action@v5
       with:
-        file: ./coverage.info
+        files: ./coverage.info
         fail_ci_if_error: true
         verbose: true
         token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

We are currently getting the following warning message in the coverage workflow. It seems the file key in codecov has changes to files in a newer version. This PR fixes that, and should no longer have this warning.

![image](https://github.com/user-attachments/assets/27c98b9e-f571-4f89-bb7b-eb9b78474af8)


Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [ ] I have read the contribution guide recently
