### PR TITLE
Fix api documentation readthedocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,12 +5,12 @@ sphinx:
   builder: html
 
 build:
-  os: "ubuntu-22.04"
+  os: "ubuntu-24.04"
   tools:
     python: "3.11"
   apt_packages:
-    - clang-13
+    - clang-16
     - cmake
-    - libclang-13-dev
-    - llvm-13-dev
-    - llvm-13-tools
+    - libclang-16-dev
+    - llvm-16-dev
+    - llvm-16-tools

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,8 +50,8 @@ CPPINTEROP_ROOT = os.path.abspath('..')
 html_extra_path = [CPPINTEROP_ROOT + '/build/docs/']
 
 import subprocess
-command = 'mkdir {0}/build; cd {0}/build; cmake ../ -DClang_DIR=/usr/lib/llvm-13/build/lib/cmake/clang\
-         -DLLVM_DIR=/usr/lib/llvm-13/build/lib/cmake/llvm -DCPPINTEROP_ENABLE_DOXYGEN=ON\
+command = 'mkdir {0}/build; cd {0}/build; cmake ../ -DClang_DIR=/usr/lib/llvm-16/build/lib/cmake/clang\
+         -DLLVM_DIR=/usr/lib/llvm-16/build/lib/cmake/llvm -DCPPINTEROP_ENABLE_DOXYGEN=ON\
          -DCPPINTEROP_INCLUDE_DOCS=ON'.format(CPPINTEROP_ROOT)
 subprocess.call(command, shell=True)
 subprocess.call('doxygen {0}/build/docs/doxygen.cfg'.format(CPPINTEROP_ROOT), shell=True)


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

Currently the link to the CppInterOp API documentation on readthedocs doesn't work (see https://cppinterop.readthedocs.io/en/latest/build/html/index.html ). The rest of the documentation work (see https://cppinterop.readthedocs.io/en/latest/ ) . The objective of this PR is to get the API documentation working again.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [x] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [x] I have read the contribution guide recently
