### PR TITLE
[DO NOT MERGE] [MRE] successive Declare fails if InstantiateFunctionDefinition fails in MakeFunctionCallable

### DIFF
--- a/unittests/CppInterOp/FunctionReflectionTest.cpp
+++ b/unittests/CppInterOp/FunctionReflectionTest.cpp
@@ -2123,3 +2123,31 @@ TEST(FunctionReflectionTest, UndoTest) {
 #endif
 #endif
 }
+
+TEST(FunctionReflectionTest, FailingTest1) {
+  Cpp::CreateInterpreter();
+  EXPECT_FALSE(Cpp::Declare(R"(
+    class WithOutEqualOp1 {};
+    class WithOutEqualOp2 {};
+
+    WithOutEqualOp1 o1;
+    WithOutEqualOp2 o2;
+
+    template<class C1, class C2>
+    bool is_equal(const C1& c1, const C2& c2) { return (bool)(c1 == c2); }
+  )"));
+
+  Cpp::TCppType_t o1 = Cpp::GetTypeFromScope(Cpp::GetNamed("o1"));
+  Cpp::TCppType_t o2 = Cpp::GetTypeFromScope(Cpp::GetNamed("o2"));
+  std::vector<Cpp::TCppFunction_t> fns;
+  Cpp::GetClassTemplatedMethods("is_equal", Cpp::GetGlobalScope(), fns);
+  EXPECT_EQ(fns.size(), 1);
+
+  Cpp::TCppScope_t fn = Cpp::BestOverloadFunctionMatch(fns, {}, {o1, o2});
+  EXPECT_TRUE(fn);
+  Cpp::JitCall jit_call = Cpp::MakeFunctionCallable(fn);
+  EXPECT_EQ(jit_call.getKind(), Cpp::JitCall::kUnknown); // expected to fail
+  EXPECT_FALSE(Cpp::Declare("int x = 1;")); // expected to pass, but fails
+  EXPECT_FALSE(Cpp::Declare(
+      "int y = 1;")); // expected to pass, and passes on second attempt
+}


### PR DESCRIPTION
This is a bug report.

If the instantiation of a templated function fails while CodeGen ([`MakeFunctionCallable`](https://github.com/compiler-research/CppInterOp/blob/e05026a9da637451d0f01111d646ad7f1694827b/lib/CppInterOp/CppInterOp.cpp#L2460-L2476)), then successive call to `Cpp::Declare` fails.
But a second call to `Cpp::Declare` will pass.

I suspect something similar to 
```c++
#ifdef CPPINTEROP_USE_CLING
    cling::Interpreter::PushTransactionRAII RAII(&I);
#endif
```
is required?