### PR TITLE
[ci] fix workflow names

### DIFF
--- a/.github/workflows/MacOS-arm.yml
+++ b/.github/workflows/MacOS-arm.yml
@@ -164,8 +164,8 @@ jobs:
         brew install gnu-sed
         pip install distro pytest
 
-
-    - uses: ./.github/actions/Build_LLVM
+    - name: Build LLVM and ${{ matrix.cling == 'On' && 'Cling' || 'Clang-REPL' }}
+      uses: ./.github/actions/Build_LLVM
       with:
         cache-hit: ${{ steps.cache.outputs.cache-hit }}
 
@@ -178,9 +178,11 @@ jobs:
           ${{ matrix.cling=='On' && 'cling' || '' }}
         key: ${{ steps.cache.outputs.cache-primary-key }}
 
-    - uses: ./.github/actions/Build_and_Test_CppInterOp
+    - name: Build and test CppInterOp
+      uses: ./.github/actions/Build_and_Test_CppInterOp
 
-    - uses: ./.github/actions/Build_and_Test_cppyy
+    - name: Build and test cppyy
+      uses: ./.github/actions/Build_and_Test_cppyy
 
     - name: Show debug info
       if: ${{ failure() }}

--- a/.github/workflows/MacOS-arm.yml
+++ b/.github/workflows/MacOS-arm.yml
@@ -102,7 +102,7 @@ jobs:
         echo "CLING_HASH=$CLING_HASH" >> $GITHUB_ENV
         echo "LLVM_HASH=$LLVM_HASH" >> $GITHUB_ENV
 
-    - name: Restore Cache LLVM/Clang runtime build directory
+    - name: Restore cached LLVM-${{ matrix.clang-runtime }} and ${{ matrix.cling == 'On' && 'Cling' || 'Clang-REPL' }} build
       uses: actions/cache/restore@v4
       id: cache
       with:
@@ -164,12 +164,12 @@ jobs:
         brew install gnu-sed
         pip install distro pytest
 
-    - name: Build LLVM and ${{ matrix.cling == 'On' && 'Cling' || 'Clang-REPL' }}
+    - name: Build LLVM-${{ matrix.clang-runtime }} and ${{ matrix.cling == 'On' && 'Cling' || 'Clang-REPL' }}
       uses: ./.github/actions/Build_LLVM
       with:
         cache-hit: ${{ steps.cache.outputs.cache-hit }}
 
-    - name: Save Cache LLVM/Clang runtime build directory
+    - name: Cache LLVM-${{ matrix.clang-runtime }} and ${{ matrix.cling == 'On' && 'Cling' || 'Clang-REPL' }} build
       uses: actions/cache/save@v4
       if: ${{ steps.cache.outputs.cache-hit != 'true' }}
       with:

--- a/.github/workflows/MacOS.yml
+++ b/.github/workflows/MacOS.yml
@@ -149,8 +149,8 @@ jobs:
         brew install gnu-sed
         pip install distro pytest
 
-
-    - uses: ./.github/actions/Build_LLVM
+    - name: Build LLVM and ${{ matrix.cling == 'On' && 'Cling' || 'Clang-REPL' }}
+      uses: ./.github/actions/Build_LLVM
       with:
         cache-hit: ${{ steps.cache.outputs.cache-hit }}
 
@@ -163,9 +163,11 @@ jobs:
           ${{ matrix.cling=='On' && 'cling' || '' }}
         key: ${{ steps.cache.outputs.cache-primary-key }}
 
-    - uses: ./.github/actions/Build_and_Test_CppInterOp
+    - name: Build and test CppInterOp
+      uses: ./.github/actions/Build_and_Test_CppInterOp
 
-    - uses: ./.github/actions/Build_and_Test_cppyy
+    - name: Build and test cppyy
+      uses: ./.github/actions/Build_and_Test_cppyy
 
     - name: Show debug info
       if: ${{ failure() }}

--- a/.github/workflows/MacOS.yml
+++ b/.github/workflows/MacOS.yml
@@ -101,7 +101,7 @@ jobs:
         echo "CLING_HASH=$CLING_HASH" >> $GITHUB_ENV
         echo "LLVM_HASH=$LLVM_HASH" >> $GITHUB_ENV
 
-    - name: Restore Cache LLVM/Clang runtime build directory
+    - name: Restore cached LLVM-${{ matrix.clang-runtime }} and ${{ matrix.cling == 'On' && 'Cling' || 'Clang-REPL' }} build
       uses: actions/cache/restore@v4
       id: cache
       with:
@@ -149,12 +149,12 @@ jobs:
         brew install gnu-sed
         pip install distro pytest
 
-    - name: Build LLVM and ${{ matrix.cling == 'On' && 'Cling' || 'Clang-REPL' }}
+    - name: Build LLVM-${{ matrix.clang-runtime }} and ${{ matrix.cling == 'On' && 'Cling' || 'Clang-REPL' }}
       uses: ./.github/actions/Build_LLVM
       with:
         cache-hit: ${{ steps.cache.outputs.cache-hit }}
 
-    - name: Save Cache LLVM/Clang runtime build directory
+    - name: Cache LLVM-${{ matrix.clang-runtime }} and ${{ matrix.cling == 'On' && 'Cling' || 'Clang-REPL' }} build
       uses: actions/cache/save@v4
       if: ${{ steps.cache.outputs.cache-hit != 'true' }}
       with:

--- a/.github/workflows/Ubuntu-arm.yml
+++ b/.github/workflows/Ubuntu-arm.yml
@@ -163,7 +163,9 @@ jobs:
         sudo apt install libeigen3-dev
         sudo apt install libboost-all-dev
 
-    - uses: ./.github/actions/Build_LLVM       
+    
+    - name: Build LLVM and ${{ matrix.cling == 'On' && 'Cling' || 'Clang-REPL' }}
+      uses: ./.github/actions/Build_LLVM
       with:
         cache-hit: ${{ steps.cache.outputs.cache-hit }}
 
@@ -183,7 +185,8 @@ jobs:
         echo "CODE_COVERAGE=1" >> $GITHUB_ENV
         echo "BUILD_TYPE=Debug" >> $GITHUB_ENV
 
-    - uses: ./.github/actions/Build_and_Test_CppInterOp
+    - name: Build and test CppInterOp
+      uses: ./.github/actions/Build_and_Test_CppInterOp
 
     - name: Prepare code coverage report
       if: ${{ success() && (matrix.coverage == true) }}
@@ -205,7 +208,8 @@ jobs:
         verbose: true
         token: ${{ secrets.CODECOV_TOKEN }}
 
-    - uses: ./.github/actions/Build_and_Test_cppyy        
+    - name: Build and test cppyy
+      uses: ./.github/actions/Build_and_Test_cppyy        
 
     - name: Show debug info
       if: ${{ failure() }}

--- a/.github/workflows/Ubuntu-arm.yml
+++ b/.github/workflows/Ubuntu-arm.yml
@@ -111,7 +111,7 @@ jobs:
         echo "CLING_HASH=$CLING_HASH" >> $GITHUB_ENV
         echo "LLVM_HASH=$LLVM_HASH" >> $GITHUB_ENV
 
-    - name: Restore Cache LLVM/Clang runtime build directory
+    - name: Restore cached LLVM-${{ matrix.clang-runtime }} and ${{ matrix.cling == 'On' && 'Cling' || 'Clang-REPL' }} build
       uses: actions/cache/restore@v4
       id: cache
       with:
@@ -164,12 +164,12 @@ jobs:
         sudo apt install libboost-all-dev
 
     
-    - name: Build LLVM and ${{ matrix.cling == 'On' && 'Cling' || 'Clang-REPL' }}
+    - name: Build LLVM-${{ matrix.clang-runtime }} and ${{ matrix.cling == 'On' && 'Cling' || 'Clang-REPL' }}
       uses: ./.github/actions/Build_LLVM
       with:
         cache-hit: ${{ steps.cache.outputs.cache-hit }}
 
-    - name: Save Cache LLVM/Clang runtime build directory
+    - name: Cache LLVM-${{ matrix.clang-runtime }} and ${{ matrix.cling == 'On' && 'Cling' || 'Clang-REPL' }} build
       uses: actions/cache/save@v4
       if: ${{ steps.cache.outputs.cache-hit != 'true' }}
       with:

--- a/.github/workflows/Ubuntu.yml
+++ b/.github/workflows/Ubuntu.yml
@@ -102,7 +102,7 @@ jobs:
         echo "CLING_HASH=$CLING_HASH" >> $GITHUB_ENV
         echo "LLVM_HASH=$LLVM_HASH" >> $GITHUB_ENV
 
-    - name: Restore Cache LLVM/Clang runtime build directory
+    - name: Restore cached LLVM-${{ matrix.clang-runtime }} and ${{ matrix.cling == 'On' && 'Cling' || 'Clang-REPL' }} build
       uses: actions/cache/restore@v4
       id: cache
       with:
@@ -153,12 +153,12 @@ jobs:
         sudo apt install libeigen3-dev
         sudo apt install libboost-all-dev
 
-    - name: Build LLVM and ${{ matrix.cling == 'On' && 'Cling' || 'Clang-REPL' }}
+    - name: Build LLVM-${{ matrix.clang-runtime }} and ${{ matrix.cling == 'On' && 'Cling' || 'Clang-REPL' }}
       uses: ./.github/actions/Build_LLVM
       with:
         cache-hit: ${{ steps.cache.outputs.cache-hit }}
 
-    - name: Save Cache LLVM/Clang runtime build directory
+    - name: Cache LLVM-${{ matrix.clang-runtime }} and ${{ matrix.cling == 'On' && 'Cling' || 'Clang-REPL' }} build
       uses: actions/cache/save@v4
       if: ${{ steps.cache.outputs.cache-hit != 'true' }}
       with:

--- a/.github/workflows/Ubuntu.yml
+++ b/.github/workflows/Ubuntu.yml
@@ -152,7 +152,9 @@ jobs:
         # Install libraries used by the cppyy test suite
         sudo apt install libeigen3-dev
         sudo apt install libboost-all-dev
-    - uses: ./.github/actions/Build_LLVM
+
+    - name: Build LLVM and ${{ matrix.cling == 'On' && 'Cling' || 'Clang-REPL' }}
+      uses: ./.github/actions/Build_LLVM
       with:
         cache-hit: ${{ steps.cache.outputs.cache-hit }}
 
@@ -172,7 +174,8 @@ jobs:
         echo "CODE_COVERAGE=1" >> $GITHUB_ENV
         echo "BUILD_TYPE=Debug" >> $GITHUB_ENV
 
-    - uses: ./.github/actions/Build_and_Test_CppInterOp
+    - name: Build and test CppInterOp
+      uses: ./.github/actions/Build_and_Test_CppInterOp
 
     - name: Prepare code coverage report
       if: ${{ success() && (matrix.coverage == true) }}
@@ -194,7 +197,8 @@ jobs:
         verbose: true
         token: ${{ secrets.CODECOV_TOKEN }}
 
-    - uses: ./.github/actions/Build_and_Test_cppyy
+    - name: Build and test cppyy
+      uses: ./.github/actions/Build_and_Test_cppyy
 
     - name: Show debug info
       if: ${{ failure() }}

--- a/.github/workflows/Windows-arm.yml
+++ b/.github/workflows/Windows-arm.yml
@@ -74,7 +74,7 @@ jobs:
         echo "CLING_HASH=$env:CLING_HASH" >> $GITHUB_ENV
         echo "LLVM_HASH=$env:LLVM_HASH" >> $GITHUB_ENV
 
-    - name: Restore Cache LLVM/Clang runtime build directory
+    - name: Restore cached LLVM-${{ matrix.clang-runtime }} and ${{ matrix.cling == 'On' && 'Cling' || 'Clang-REPL' }} build
       uses: actions/cache/restore@v4
       id: cache
       with:
@@ -117,12 +117,12 @@ jobs:
         choco install findutils
         $env:PATH="C:\Program Files (x86)\GnuWin32\bin;$env:PATH"
 
-    - name: Build LLVM and ${{ matrix.cling == 'On' && 'Cling' || 'Clang-REPL' }}
+    - name: Build LLVM-${{ matrix.clang-runtime }} and ${{ matrix.cling == 'On' && 'Cling' || 'Clang-REPL' }}
       uses: ./.github/actions/Build_LLVM
       with:
         cache-hit: ${{ steps.cache.outputs.cache-hit }}
 
-    - name: Save Cache LLVM/Clang runtime build directory
+    - name: Cache LLVM-${{ matrix.clang-runtime }} and ${{ matrix.cling == 'On' && 'Cling' || 'Clang-REPL' }} build
       uses: actions/cache/save@v4
       if: ${{ steps.cache.outputs.cache-hit != 'true' }}
       with:

--- a/.github/workflows/Windows-arm.yml
+++ b/.github/workflows/Windows-arm.yml
@@ -117,7 +117,8 @@ jobs:
         choco install findutils
         $env:PATH="C:\Program Files (x86)\GnuWin32\bin;$env:PATH"
 
-    - uses: ./.github/actions/Build_LLVM
+    - name: Build LLVM and ${{ matrix.cling == 'On' && 'Cling' || 'Clang-REPL' }}
+      uses: ./.github/actions/Build_LLVM
       with:
         cache-hit: ${{ steps.cache.outputs.cache-hit }}
 
@@ -130,7 +131,8 @@ jobs:
           ${{ matrix.cling=='On' && 'cling' || '' }}
         key: ${{ steps.cache.outputs.cache-primary-key }}
 
-    - uses: ./.github/actions/Build_and_Test_CppInterOp
+    - name: Build and test CppInterOp
+      uses: ./.github/actions/Build_and_Test_CppInterOp
 
     - name: Setup tmate session
       if: ${{ failure() && runner.debug }}

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -74,7 +74,7 @@ jobs:
         echo "CLING_HASH=$env:CLING_HASH" >> $GITHUB_ENV
         echo "LLVM_HASH=$env:LLVM_HASH" >> $GITHUB_ENV
 
-    - name: Restore Cache LLVM/Clang runtime build directory
+    - name: Restore cached LLVM-${{ matrix.clang-runtime }} and ${{ matrix.cling == 'On' && 'Cling' || 'Clang-REPL' }} build
       uses: actions/cache/restore@v4
       id: cache
       with:
@@ -117,12 +117,12 @@ jobs:
         choco install findutils
         $env:PATH="C:\Program Files (x86)\GnuWin32\bin;$env:PATH"
 
-    - name: Build LLVM and ${{ matrix.cling == 'On' && 'Cling' || 'Clang-REPL' }}
+    - name: Build LLVM-${{ matrix.clang-runtime }} and ${{ matrix.cling == 'On' && 'Cling' || 'Clang-REPL' }}
       uses: ./.github/actions/Build_LLVM
       with:
         cache-hit: ${{ steps.cache.outputs.cache-hit }}
 
-    - name: Save Cache LLVM/Clang runtime build directory
+    - name: Cache LLVM-${{ matrix.clang-runtime }} and ${{ matrix.cling == 'On' && 'Cling' || 'Clang-REPL' }} build
       uses: actions/cache/save@v4
       if: ${{ steps.cache.outputs.cache-hit != 'true' }}
       with:

--- a/.github/workflows/Windows.yml
+++ b/.github/workflows/Windows.yml
@@ -117,7 +117,8 @@ jobs:
         choco install findutils
         $env:PATH="C:\Program Files (x86)\GnuWin32\bin;$env:PATH"
 
-    - uses: ./.github/actions/Build_LLVM
+    - name: Build LLVM and ${{ matrix.cling == 'On' && 'Cling' || 'Clang-REPL' }}
+      uses: ./.github/actions/Build_LLVM
       with:
         cache-hit: ${{ steps.cache.outputs.cache-hit }}
 
@@ -130,7 +131,8 @@ jobs:
           ${{ matrix.cling=='On' && 'cling' || '' }}
         key: ${{ steps.cache.outputs.cache-primary-key }}   
 
-    - uses: ./.github/actions/Build_and_Test_CppInterOp
+    - name: Build and test CppInterOp
+      uses: ./.github/actions/Build_and_Test_CppInterOp
 
     - name: Setup tmate session
       if: ${{ failure() && runner.debug }}

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -79,7 +79,7 @@ jobs:
           cd emsdk
           ./emsdk install  ${{ matrix.emsdk_ver }}
 
-    - name: Restore Cache LLVM/Clang runtime build directory
+    - name: Restore cached LLVM-${{ matrix.clang-runtime }} and ${{ matrix.cling == 'On' && 'Cling' || 'Clang-REPL' }} build
       uses: actions/cache/restore@v4
       id: cache
       with:

--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -137,7 +137,7 @@ jobs:
         echo "CLING_HASH=$env:CLING_HASH" >> $GITHUB_ENV
         echo "LLVM_HASH=$env:LLVM_HASH" >> $GITHUB_ENV
 
-    - name: Restore Cache LLVM/Clang runtime build directory (Unix like systems emscripten)
+    - name: Restore cached LLVM-${{ matrix.clang-runtime }} and ${{ matrix.cling == 'On' && 'Cling' || 'Clang-REPL' }} build (Unix like systems emscripten)
       uses: actions/cache/restore@v4
       id: cache
       with:
@@ -415,7 +415,7 @@ jobs:
           cd ..\..
         }
 
-    - name: Save Cache LLVM/Clang runtime build directory
+    - name: Cache LLVM-${{ matrix.clang-runtime }} and ${{ matrix.cling == 'On' && 'Cling' || 'Clang-REPL' }} build
       uses: actions/cache/save@v4
       if: ${{ steps.cache.outputs.cache-hit != 'true' }}
       with:
@@ -540,7 +540,7 @@ jobs:
           cd emsdk
           ./emsdk install  ${{ matrix.emsdk_ver }}
 
-    - name: Restore Cache LLVM/Clang runtime build directory
+    - name: Restore cached LLVM-${{ matrix.clang-runtime }} and ${{ matrix.cling == 'On' && 'Cling' || 'Clang-REPL' }} build
       uses: actions/cache/restore@v4
       id: cache
       with:


### PR DESCRIPTION
This PR should fix the issue of actions appearing as paths instead of names on the Github UI
The interpreter mode is now dynamically inserted (Cling/Clang-REPL)  based on the config

before:
![Screenshot from 2025-06-09 22-24-12](https://github.com/user-attachments/assets/a75c52f7-319c-4804-9ae8-edf4d0cb84aa)

after:

![Screenshot from 2025-06-09 22-22-47](https://github.com/user-attachments/assets/d37cb7bd-80b3-46a8-b032-d3b71e45f516)


