### PR TITLE
[tests] Use `size_t` in variable reflection offset tests

### DIFF
--- a/unittests/CppInterOp/VariableReflectionTest.cpp
+++ b/unittests/CppInterOp/VariableReflectionTest.cpp
@@ -553,7 +553,7 @@ TEST(VariableReflectionTest, StaticConstExprDatamember) {
   EXPECT_EQ(datamembers.size(), 1);
 
   intptr_t offset = Cpp::GetVariableOffset(datamembers[0]);
-  EXPECT_EQ(3, *(int*)offset);
+  EXPECT_EQ(3, *(size_t*)offset);
 
   ASTContext& C = Interp->getCI()->getASTContext();
   std::vector<Cpp::TemplateArgInfo> template_args = {
@@ -569,7 +569,7 @@ TEST(VariableReflectionTest, StaticConstExprDatamember) {
   EXPECT_EQ(datamembers.size(), 1);
 
   offset = Cpp::GetVariableOffset(datamembers[0]);
-  EXPECT_EQ(5, *(int*)offset);
+  EXPECT_EQ(5, *(size_t*)offset);
 
   std::vector<Cpp::TemplateArgInfo> ele_template_args = {
       {C.IntTy.getAsOpaquePtr()}, {C.FloatTy.getAsOpaquePtr()}};
@@ -588,7 +588,7 @@ TEST(VariableReflectionTest, StaticConstExprDatamember) {
   EXPECT_EQ(datamembers.size(), 1);
 
   offset = Cpp::GetVariableOffset(datamembers[0]);
-  EXPECT_EQ(2, *(int*)offset);
+  EXPECT_EQ(2, *(size_t*)offset);
 }
 
 TEST(VariableReflectionTest, GetEnumConstantDatamembers) {


### PR DESCRIPTION
This fixes failures on big endian systems (s390x). Upstream of https://github.com/root-project/root/pull/18992