### PR TITLE
fix ambiguity in ScopeReflection `GetAllCppNames` unittest

### DIFF
--- a/unittests/CppInterOp/ScopeReflectionTest.cpp
+++ b/unittests/CppInterOp/ScopeReflectionTest.cpp
@@ -789,7 +789,10 @@ TEST(ScopeReflectionTest, GetAllCppNames) {
     }
   )";
 
-  GetAllTopLevelDecls(code, Decls);
+  std::vector<const char*> interpreter_args = {"-Wno-inaccessible-base"};
+
+  GetAllTopLevelDecls(code, Decls, /*filter_implicitGenerated=*/false,
+                      interpreter_args);
 
   auto test_get_all_cpp_names =
       [](Decl* D, const std::vector<std::string>& truth_names) {


### PR DESCRIPTION
fixes the following warnings:

```
1: In file included from <<< inputs >>>:1:
1: input_line_1:5:15: warning: direct base 'A' is inaccessible due to ambiguity:
1:     class D -> A
1:     class D -> C -> A [-Winaccessible-base]
1:     5 |     class D : public A, public B, public C { int d; };
1:       |               ^~~~~~~~
1: input_line_1:5:25: warning: direct base 'B' is inaccessible due to ambiguity:
1:     class D -> B
1:     class D -> C -> B [-Winaccessible-base]
1:     5 |     class D : public A, public B, public C { int d; };
1:       |                         ^~~~~~~~
1: input_line_1:10:17: warning: direct base 'A' is inaccessible due to ambiguity:
1:     class N::D -> A
1:     class N::D -> C -> A [-Winaccessible-base]
1:    10 |       class D : public A, public B, public C { int d; };
1:       |                 ^~~~~~~~
1: input_line_1:10:27: warning: direct base 'B' is inaccessible due to ambiguity:
1:     class N::D -> B
1:     class N::D -> C -> B [-Winaccessible-base]
1:    10 |       class D : public A, public B, public C { int d; };
1:       |                           ^~~~~~~~
```
