### PR TITLE
fix GetVariableOffset for templated static variable

### DIFF
--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -1518,6 +1518,7 @@ intptr_t GetVariableOffset(compat::Interpreter& I, Decl* D,
         cling::Interpreter::PushTransactionRAII RAII(&getInterp());
 #endif // CPPINTEROP_USE_CLING
         getSema().InstantiateVariableDefinition(SourceLocation(), VD);
+        VD = VD->getDefinition();
       }
       if (VD->hasInit() &&
           (VD->isConstexpr() || VD->getType().isConstQualified())) {


### PR DESCRIPTION
This is a bug report.

```c++
template <typename T>
struct ClassWithStatic {
    static T const ref_value;
};
template <typename T>
T constexpr ClassWithStatic<T>::ref_value = 42;

ClassWithStatic<int> x;
```
```c++
Cpp::GetVariableOffset(x.ref_val); // FAILS
```

---

Will help fix a test in cppyy.