### PR TITLE
Update clang-format standard to c++17

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,7 +1,7 @@
 BasedOnStyle: LLVM
 
 Language: Cpp
-Standard: Cpp11
+Standard: c++17
 PointerAlignment: Left
 
 IncludeCategories:


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

Since cling 1.0 support got dropped the minimum c++ standard supported by CppInterOp was c++17 . Therefore this PR updates the clang-format standard CppInterOp is using to c++17. This a valid value and was taken from xeus-cpp (see https://github.com/compiler-research/xeus-cpp/blob/7a3a24bbbdcc82f8626b71ed7a3028a637923ce3/.clang-format#L76C11-L76C16)

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [x] I have read the contribution guide recently
