### PR TITLE
Remove continue-on-error Windows Emscripten

### DIFF
--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -735,7 +735,6 @@ jobs:
         micromamba shell hook -s cmd.exe --root-prefix C:\Users\runneradmin\micromamba-root
 
     - name: Build and Test/Install CppInterOp on Windows systems (shared library)
-      continue-on-error: true
       if: ${{ runner.os == 'windows' }}
       shell: powershell
       run: |
@@ -821,7 +820,6 @@ jobs:
         emmake make -j ${{ env.ncpus }} install
 
     - name: Build and Test/Install CppInterOp on Windows systems (static library)
-      continue-on-error: true
       if: ${{ runner.os == 'windows' }}
       shell: powershell
       run: |


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

This PR removes the continue-on-error for the Emscripten Windows build, which is counteracting the $ErrorActionPreference = "Stop" in the ci.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [x] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [x] I have read the contribution guide recently
