### PR TITLE
fix: JITCall codegen to deal with enums and funcs with same name

### DIFF
--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -1837,6 +1837,7 @@ void get_type_as_string(QualType QT, std::string& type_name, ASTContext& C,
 #if CLANG_VERSION_MAJOR > 16
   Policy.SuppressElaboration = true;
 #endif
+  Policy.SuppressTagKeyword = !QT->isEnumeralType();
   Policy.FullyQualifiedName = true;
   QT.getAsStringInternal(type_name, Policy);
 }

--- a/unittests/CppInterOp/FunctionReflectionTest.cpp
+++ b/unittests/CppInterOp/FunctionReflectionTest.cpp
@@ -1994,6 +1994,21 @@ TEST(FunctionReflectionTest, GetFunctionCallWrapper) {
 
   auto tuple_tuple_callable = Cpp::MakeFunctionCallable(tuple_tuple);
   EXPECT_EQ(tuple_tuple_callable.getKind(), Cpp::JitCall::kGenericCall);
+
+  Interp->process(R"(
+    namespace EnumFunctionSameName {
+    enum foo { FOO = 42 };
+    void foo() {}
+    unsigned int bar(enum foo f) { return (unsigned int)f; }
+    }
+  )");
+
+  Cpp::TCppScope_t bar =
+      Cpp::GetNamed("bar", Cpp::GetScope("EnumFunctionSameName"));
+  EXPECT_TRUE(bar);
+
+  auto bar_callable = Cpp::MakeFunctionCallable(bar);
+  EXPECT_EQ(bar_callable.getKind(), Cpp::JitCall::kGenericCall);
 }
 
 TEST(FunctionReflectionTest, IsConstMethod) {


### PR DESCRIPTION
# Description

## Fixes # (issue)

Fixes 1 test in cppyy

## Type of change

Please tick all options which are relevant.

- [x] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

## Checklist

- [x] I have read the contribution guide recently
