### PR TITLE
Revert "Fix bugs related to printing types (#661)"

### DIFF
--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -517,27 +517,17 @@ std::string GetCompleteName(TCppType_t klass) {
   auto& C = getSema().getASTContext();
   auto* D = (Decl*)klass;
 
-  PrintingPolicy Policy = C.getPrintingPolicy();
-  Policy.SuppressUnwrittenScope = true;
-  Policy.SuppressScope = true;
-  Policy.AnonymousTagLocations = false;
-  Policy.SuppressTemplateArgsInCXXConstructors = false;
-  Policy.SuppressDefaultTemplateArgs = false;
-  Policy.AlwaysIncludeTypeForTemplateArgument = true;
-
   if (auto* ND = llvm::dyn_cast_or_null<NamedDecl>(D)) {
     if (auto* TD = llvm::dyn_cast<TagDecl>(ND)) {
       std::string type_name;
       QualType QT = C.getTagDeclType(TD);
+      PrintingPolicy Policy = C.getPrintingPolicy();
+      Policy.SuppressUnwrittenScope = true;
+      Policy.SuppressScope = true;
+      Policy.AnonymousTagLocations = false;
       QT.getAsStringInternal(type_name, Policy);
+
       return type_name;
-    }
-    if (auto* FD = llvm::dyn_cast<FunctionDecl>(ND)) {
-      std::string func_name;
-      llvm::raw_string_ostream name_stream(func_name);
-      FD->getNameForDiagnostic(name_stream, Policy, false);
-      name_stream.flush();
-      return func_name;
     }
 
     return ND->getNameAsString();
@@ -3645,11 +3635,7 @@ std::string GetFunctionArgDefault(TCppFunction_t func,
   if (PI->hasDefaultArg()) {
     std::string Result;
     llvm::raw_string_ostream OS(Result);
-    Expr* DefaultArgExpr = nullptr;
-    if (PI->hasUninstantiatedDefaultArg())
-      DefaultArgExpr = PI->getUninstantiatedDefaultArg();
-    else
-      DefaultArgExpr = PI->getDefaultArg();
+    Expr* DefaultArgExpr = const_cast<Expr*>(PI->getDefaultArg());
     DefaultArgExpr->printPretty(OS, nullptr, PrintingPolicy(LangOptions()));
 
     // FIXME: Floats are printed in clang with the precision of their underlying

--- a/unittests/CppInterOp/FunctionReflectionTest.cpp
+++ b/unittests/CppInterOp/FunctionReflectionTest.cpp
@@ -2078,15 +2078,6 @@ TEST(FunctionReflectionTest, GetFunctionArgDefault) {
     template<class A>
     void get_size(long k, A, char ch = 'a', double l = 0.0) {}
 
-    template<typename T>
-    struct Other {};
-
-    template <typename T, typename S = Other<T>>
-    struct MyStruct {
-      T t;
-      S s;
-      void fn(T t, S s = S()) {}
-    };
     )";
 
   GetAllTopLevelDecls(code, Decls);
@@ -2111,20 +2102,6 @@ TEST(FunctionReflectionTest, GetFunctionArgDefault) {
   EXPECT_EQ(Cpp::GetFunctionArgDefault(Decls[4], 1), "");
   EXPECT_EQ(Cpp::GetFunctionArgDefault(Decls[4], 2), "\'a\'");
   EXPECT_EQ(Cpp::GetFunctionArgDefault(Decls[4], 3), "0.");
-
-  ASTContext& C = Interp->getCI()->getASTContext();
-  Cpp::TemplateArgInfo template_args[1] = {C.IntTy.getAsOpaquePtr()};
-  Cpp::TCppScope_t my_struct =
-      Cpp::InstantiateTemplate(Decls[6], template_args, 1);
-  EXPECT_TRUE(my_struct);
-
-  std::vector<Cpp::TCppFunction_t> fns =
-      Cpp::GetFunctionsUsingName(my_struct, "fn");
-  EXPECT_EQ(fns.size(), 1);
-
-  Cpp::TCppScope_t fn = fns[0];
-  EXPECT_EQ(Cpp::GetFunctionArgDefault(fn, 0), "");
-  EXPECT_EQ(Cpp::GetFunctionArgDefault(fn, 1), "S()");
 }
 
 TEST(FunctionReflectionTest, Construct) {

--- a/unittests/CppInterOp/ScopeReflectionTest.cpp
+++ b/unittests/CppInterOp/ScopeReflectionTest.cpp
@@ -334,9 +334,6 @@ TEST(ScopeReflectionTest, GetCompleteName) {
                         A<int> a;
 
                         enum { enum1 };
-
-                        template<typename T1, typename T2>
-                        void fn(T1 t1, T2 t2) {}
                        )";
   GetAllTopLevelDecls(code, Decls);
 
@@ -353,15 +350,7 @@ TEST(ScopeReflectionTest, GetCompleteName) {
                                              Cpp::GetVariableType(
                                                      Decls[9]))), "A<int>");
   EXPECT_EQ(Cpp::GetCompleteName(Decls[10]), "(unnamed)");
-  EXPECT_EQ(Cpp::GetCompleteName(Decls[11]), "fn");
   EXPECT_EQ(Cpp::GetCompleteName(nullptr), "<unnamed>");
-
-  ASTContext& C = Interp->getCI()->getASTContext();
-  Cpp::TemplateArgInfo template_args[2] = {C.IntTy.getAsOpaquePtr(),
-                                           C.DoubleTy.getAsOpaquePtr()};
-  Cpp::TCppScope_t fn = Cpp::InstantiateTemplate(Decls[11], template_args, 2);
-  EXPECT_TRUE(fn);
-  EXPECT_EQ(Cpp::GetCompleteName(fn), "fn<int, double>");
 }
 
 TEST(ScopeReflectionTest, GetQualifiedName) {


### PR DESCRIPTION

# Description

Please include a summary of changes, motivation and context for this PR.

This reverts commit f65f80aae774b4c8a3ee0f39c4ea64140508a12d.

@vgvassilev To make the Emscripten workflow pass for all jobs again (and by extension allow our deployment workflow to work again), either this PR needs to go in (and revert any cppyy related PRs), or this one needs to go in https://github.com/compiler-research/CppInterOp/pull/655, which fixes the Emscripten workflow without needing to revert the latest commit to CppInterOps main.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [x] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [x] I have read the contribution guide recently
