### PR TITLE
Enable exceptions deployment

### DIFF
--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -318,6 +318,7 @@ jobs:
           elseif ( "${{ matrix.clang-runtime }}" -imatch "20" )
           {
             git apply -v emscripten-clang20-2-shift-temporary-files-to-tmp-dir.patch
+            git apply -v emscripten-clang20-3-enable_exception_handling.patch
           }
           cd build
           echo "Apply clang${{ matrix.clang-runtime }}-*.patch patches:"

--- a/Emscripten-build-instructions.md
+++ b/Emscripten-build-instructions.md
@@ -64,6 +64,7 @@ On Windows execute the following
 cd .\llvm-project\
 cp -r ..\patches\llvm\emscripten-clang20*
 git apply -v emscripten-clang20-2-shift-temporary-files-to-tmp-dir.patch
+git apply -v emscripten-clang20-3-enable_exception_handling.patch
 ```
 
 We are now in a position to build an emscripten build of llvm by executing the following on Linux

--- a/docs/Emscripten-build-instructions.rst
+++ b/docs/Emscripten-build-instructions.rst
@@ -83,6 +83,7 @@ On Windows execute the following
    cd .\llvm-project\
    cp -r ..\patches\llvm\emscripten-clang20*
    git apply -v emscripten-clang20-2-shift-temporary-files-to-tmp-dir.patch
+   git apply -v emscripten-clang20-3-enable_exception_handling.patch
 
 We are now in a position to build an emscripten build of llvm by executing the following on Linux
 and osx

--- a/patches/llvm/emscripten-clang20-3-enable_exception_handling.patch
+++ b/patches/llvm/emscripten-clang20-3-enable_exception_handling.patch
@@ -1,0 +1,67 @@
+diff --git a/clang/lib/Interpreter/Interpreter.cpp b/clang/lib/Interpreter/Interpreter.cpp
+index 3b81f9d70..2704edb8a 100644
+--- a/clang/lib/Interpreter/Interpreter.cpp
++++ b/clang/lib/Interpreter/Interpreter.cpp
+@@ -142,6 +142,48 @@ CreateCI(const llvm::opt::ArgStringList &Argv) {
+   return std::move(Clang);
+ }
+ 
++static llvm::Error HandleFrontendOptions(const CompilerInstance &CI) {
++  const auto &FrontendOpts = CI.getFrontendOpts();
++
++  if (FrontendOpts.ShowHelp) {
++    driver::getDriverOptTable().printHelp(
++        llvm::outs(), "clang -cc1 [options] file...",
++        "LLVM 'Clang' Compiler: http://clang.llvm.org",
++        /*ShowHidden=*/false, /*ShowAllAliases=*/false,
++        llvm::opt::Visibility(driver::options::CC1Option));
++    return llvm::createStringError(llvm::errc::not_supported, "Help displayed");
++  }
++
++  if (FrontendOpts.ShowVersion) {
++    llvm::cl::PrintVersionMessage();
++    return llvm::createStringError(llvm::errc::not_supported,
++                                   "Version displayed");
++  }
++
++  if (!FrontendOpts.LLVMArgs.empty()) {
++    unsigned NumArgs = FrontendOpts.LLVMArgs.size();
++    auto Args = std::make_unique<const char *[]>(NumArgs + 2);
++    Args[0] = "clang-repl (LLVM option parsing)";
++    for (unsigned i = 0; i != NumArgs; ++i) {
++      Args[i + 1] = FrontendOpts.LLVMArgs[i].c_str();
++      // remove the leading '-' from the option name
++      if (Args[i + 1][0] == '-') {
++        auto *option = static_cast<llvm::cl::opt<bool> *>(
++            llvm::cl::getRegisteredOptions()[Args[i + 1] + 1]);
++        if (option) {
++          option->setInitialValue(true);
++        } else {
++          llvm::errs() << "Unknown LLVM option: " << Args[i + 1] << "\n";
++        }
++      }
++    }
++    Args[NumArgs + 1] = nullptr;
++    llvm::cl::ParseCommandLineOptions(NumArgs + 1, Args.get());
++  }
++
++  return llvm::Error::success();
++}
++
+ } // anonymous namespace
+ 
+ namespace clang {
+@@ -456,7 +498,12 @@ const char *const Runtimes = R"(
+ 
+ llvm::Expected<std::unique_ptr<Interpreter>>
+ Interpreter::create(std::unique_ptr<CompilerInstance> CI) {
+-  llvm::Error Err = llvm::Error::success();
++
++  llvm::Error Err = HandleFrontendOptions(*CI);
++  if (Err) {
++    return std::move(Err);
++  }
++
+   auto Interp =
+       std::unique_ptr<Interpreter>(new Interpreter(std::move(CI), Err));
+   if (Err)


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

CppInterOps xeus-cpp deployment doesn't have exception handling working due to this patch being missing from the llvm build. This patch was taken from Emscripten forge here https://github.com/emscripten-forge/recipes/blob/main/recipes/recipes_emscripten/llvm/patches/enable_exception_handling.patch . I have tested this patch locally to check it fixes the deployment.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [x] New feature
- [x] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [x] I have read the contribution guide recently
