### PR TITLE
Backport enable exception handling patch to llvm 19

### DIFF
--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -314,6 +314,7 @@ jobs:
           {
             git apply -v emscripten-clang19-2-shift-temporary-files-to-tmp-dir.patch
             git apply -v emscripten-clang19-3-remove-zdefs.patch
+            git apply -v emscripten-clang19-4-enable_exception_handling.patch
           }
           elseif ( "${{ matrix.clang-runtime }}" -imatch "20" )
           {

--- a/patches/llvm/emscripten-clang19-4-enable_exception_handling.patch
+++ b/patches/llvm/emscripten-clang19-4-enable_exception_handling.patch
@@ -1,0 +1,67 @@
+diff --git a/clang/lib/Interpreter/Interpreter.cpp b/clang/lib/Interpreter/Interpreter.cpp
+index 985d0b7c0..20a727893 100644
+--- a/clang/lib/Interpreter/Interpreter.cpp
++++ b/clang/lib/Interpreter/Interpreter.cpp
+@@ -135,6 +135,48 @@ CreateCI(const llvm::opt::ArgStringList &Argv) {
+   return std::move(Clang);
+ }
+ 
++static llvm::Error HandleFrontendOptions(const CompilerInstance &CI) {
++  const auto &FrontendOpts = CI.getFrontendOpts();
++
++  if (FrontendOpts.ShowHelp) {
++    driver::getDriverOptTable().printHelp(
++        llvm::outs(), "clang -cc1 [options] file...",
++        "LLVM 'Clang' Compiler: http://clang.llvm.org",
++        /*ShowHidden=*/false, /*ShowAllAliases=*/false,
++        llvm::opt::Visibility(driver::options::CC1Option));
++    return llvm::createStringError(llvm::errc::not_supported, "Help displayed");
++  }
++
++  if (FrontendOpts.ShowVersion) {
++    llvm::cl::PrintVersionMessage();
++    return llvm::createStringError(llvm::errc::not_supported,
++                                   "Version displayed");
++  }
++
++  if (!FrontendOpts.LLVMArgs.empty()) {
++    unsigned NumArgs = FrontendOpts.LLVMArgs.size();
++    auto Args = std::make_unique<const char *[]>(NumArgs + 2);
++    Args[0] = "clang-repl (LLVM option parsing)";
++    for (unsigned i = 0; i != NumArgs; ++i) {
++      Args[i + 1] = FrontendOpts.LLVMArgs[i].c_str();
++      // remove the leading '-' from the option name
++      if (Args[i + 1][0] == '-') {
++        auto *option = static_cast<llvm::cl::opt<bool> *>(
++            llvm::cl::getRegisteredOptions()[Args[i + 1] + 1]);
++        if (option) {
++          option->setInitialValue(true);
++        } else {
++          llvm::errs() << "Unknown LLVM option: " << Args[i + 1] << "\n";
++        }
++      }
++    }
++    Args[NumArgs + 1] = nullptr;
++    llvm::cl::ParseCommandLineOptions(NumArgs + 1, Args.get());
++  }
++
++  return llvm::Error::success();
++}
++
+ } // anonymous namespace
+ 
+ llvm::Expected<std::unique_ptr<CompilerInstance>>
+@@ -306,7 +348,12 @@ const char *const Runtimes = R"(
+ 
+ llvm::Expected<std::unique_ptr<Interpreter>>
+ Interpreter::create(std::unique_ptr<CompilerInstance> CI) {
+-  llvm::Error Err = llvm::Error::success();
++
++  llvm::Error Err = HandleFrontendOptions(*CI);
++  if (Err) {
++    return std::move(Err);
++  }
++
+   auto Interp =
+       std::unique_ptr<Interpreter>(new Interpreter(std::move(CI), Err));
+   if (Err)


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

This PR backports the enable exception handling patch to llvm 19, and according to my local testing will allow the failing test in https://github.com/compiler-research/CppInterOp/pull/678 to pass, so that the emscripten workflow will go green. For this to work, you would need to clear the cache on main of Emscripten llvm 19 builds, merge this in, and once the workflow on main has rebuilt the cache, rebase that PR.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [x] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [x] I have read the contribution guide recently
