### PR TITLE
Remove unimplemented toString in CppInterOpInterpreter.h

### DIFF
--- a/lib/CppInterOp/CppInterOpInterpreter.h
+++ b/lib/CppInterOp/CppInterOpInterpreter.h
@@ -448,12 +448,6 @@ public:
     return kMoreInputExpected;
   }
 
-  std::string toString(const char* type, void* obj) {
-    assert(0 && "toString is not implemented!");
-    std::string ret;
-    return ret; // TODO: Implement
-  }
-
   CompilationResult undo(unsigned N = 1) {
     if (llvm::Error Err = Undo(N)) {
       llvm::logAllUnhandledErrors(std::move(Err), llvm::errs(),


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

As far as I can tell toString was added 2 years ago unimplemented. Given it stayed implemented in that time, its probably best to remove it now.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [x] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [x] I have read the contribution guide recently
