### PR TITLE
[Thread-Safety] Add Mutex per Interpreter

### DIFF
--- a/docs/DevelopersDocumentation.rst
+++ b/docs/DevelopersDocumentation.rst
@@ -423,12 +423,54 @@ library files and run pytest:
    python -m pip install pytest
    python -m pytest -sv
 
-***********************************
+###################################
  CppInterOp Internal Documentation
-***********************************
+###################################
 
 CppInterOp maintains an internal Doxygen documentation of its components.
 Internal documentation aims to capture intrinsic details and overall usage of
 code components. The goal of internal documentation is to make the codebase
 easier to understand for the new developers. Internal documentation can be
 visited : `here <build/html/index.html>`_
+
+**************************************
+ Multiple Interpreter & Thread-Safety
+**************************************
+
+CppInterOp allows the user to create multiple interpreters at a time and
+use those interpreters. The interpreters that are created are stored in a
+stack and a map. The stack is used to enable the model where the user
+wants to create a temporary interpreter and destroy it after performing a
+few operations. In such a use case, the top of the stack is the only
+interpreter in use at any given point in time.
+
+The map is used to store the mapping from :code:`clang::ASTContext` to
+:code:`Cpp::InterpreterInfo`. This is required to figure out which
+interpreter an object belongs to. Say the library user performs the
+following operations:
+
+1. Create an Interpreter
+2. Compile some code with variable :code:`a`
+3. Create another Interpreter
+4. Performs :code:`Cpp::GetVariableOffset(a)`
+
+In step 4, the top of the stack is an interpreter without the definition of
+:code:`a`. And we cannot use it to figure out the address of :code:`a`.
+The :code:`clang::Decl` passed to :code:`Cpp::GetVariableOffset` is used to
+retrieve the :code:`clang::ASTContext`, using
+:code:`clang::Decl::getASTContext`. We then use the map to figure out the
+exact Interpreter Instance this :code:`clang::Decl` belongs to and perform
+the operation.
+
+A shortcoming of this is that if the CppInterOp accepts a
+:code:`clang::QualType` instead of :code:`clang::Decl`, then it is not
+possible to get the :code:`clang::ASTContext` from the :code:`clang::QualType`.
+In such cases, we iterate over the Allocator of all the Interpreters in our
+stack and figure out which :code:`clang::ASTContext` allocated this
+:code:`clang::QualType`. This is a very expensive operation. But there is no
+alternative to this.
+
+For **thread-safety**, we introduce a lock for each of the interpreters we
+create. And lock only that one specific interpreter when required. We also
+have 2 global locks, one for LLVM, and another is used to lock operations
+performed on the interpreter stack and the map itself.

--- a/include/CppInterOp/CppInterOp.h
+++ b/include/CppInterOp/CppInterOp.h
@@ -389,7 +389,7 @@ CPPINTEROP_API std::string GetQualifiedCompleteName(TCppScope_t klass);
 CPPINTEROP_API std::vector<TCppScope_t> GetUsingNamespaces(TCppScope_t scope);
 
 /// Gets the global scope of the whole C++  instance.
-CPPINTEROP_API TCppScope_t GetGlobalScope();
+CPPINTEROP_API TCppScope_t GetGlobalScope(TInterp_t interp = nullptr);
 
 /// Strips the typedef and returns the underlying class, and if the
 /// underlying decl is not a class it returns the input unchanged.
@@ -398,18 +398,28 @@ CPPINTEROP_API TCppScope_t GetUnderlyingScope(TCppScope_t scope);
 /// Gets the namespace or class (by stripping typedefs) for the name
 /// passed as a parameter, and if the parent is not passed,
 /// then global scope will be assumed.
+/// Looks up the name in parent, if parent is nullptr,
+/// interp is used to select the interpreter if multiple in-use.
+/// interp is ignored if parent is non-null.
 CPPINTEROP_API TCppScope_t GetScope(const std::string& name,
-                                    TCppScope_t parent = nullptr);
+                                    TCppScope_t parent = nullptr,
+                                    TInterp_t interp = nullptr);
 
 /// When the namespace is known, then the parent doesn't need
 /// to be specified. This will probably be phased-out in
 /// future versions of the interop library.
-CPPINTEROP_API TCppScope_t GetScopeFromCompleteName(const std::string& name);
+/// interp is used to select the interpreter if multiple in-use.
+CPPINTEROP_API TCppScope_t GetScopeFromCompleteName(const std::string& name,
+                                                    TInterp_t interp = nullptr);
 
 /// This function performs a lookup within the specified parent,
 /// a specific named entity (functions, enums, etcetera).
+/// Looks up the name in parent, if parent is nullptr,
+/// interp is used to select the interpreter if multiple in-use.
+/// interp is ignored if parent is non-null.
 CPPINTEROP_API TCppScope_t GetNamed(const std::string& name,
-                                    TCppScope_t parent = nullptr);
+                                    TCppScope_t parent = nullptr,
+                                    TInterp_t interp = nullptr);
 
 /// Gets the parent of the scope that is passed as a parameter.
 CPPINTEROP_API TCppScope_t GetParentScope(TCppScope_t scope);
@@ -493,8 +503,12 @@ CPPINTEROP_API bool IsTemplatedFunction(TCppFunction_t func);
 
 /// This function performs a lookup to check if there is a
 /// templated function of that type.
+/// Looks up the name in parent, if parent is nullptr,
+/// interp is used to select the interpreter if multiple in-use.
+/// interp is ignored if parent is non-null.
 CPPINTEROP_API bool ExistsFunctionTemplate(const std::string& name,
-                                           TCppScope_t parent = nullptr);
+                                           TCppScope_t parent = nullptr,
+                                           TInterp_t interp = nullptr);
 
 /// Sets a list of all the constructor for a scope/class that is
 /// supplied as a parameter.
@@ -542,7 +556,8 @@ CPPINTEROP_API bool IsDestructor(TCppConstFunction_t method);
 CPPINTEROP_API bool IsStaticMethod(TCppConstFunction_t method);
 
 ///\returns the address of the function given its potentially mangled name.
-CPPINTEROP_API TCppFuncAddr_t GetFunctionAddress(const char* mangled_name);
+CPPINTEROP_API TCppFuncAddr_t GetFunctionAddress(const char* mangled_name,
+                                                 TInterp_t interp = nullptr);
 
 ///\returns the address of the function given its function declaration.
 CPPINTEROP_API TCppFuncAddr_t GetFunctionAddress(TCppFunction_t method);
@@ -643,7 +658,9 @@ CPPINTEROP_API TCppType_t GetCanonicalType(TCppType_t type);
 
 /// Used to either get the built-in type of the provided string, or
 /// use the name to lookup the actual type.
-CPPINTEROP_API TCppType_t GetType(const std::string& type);
+/// interp is used to select the interpreter if multiple in-use.
+CPPINTEROP_API TCppType_t GetType(const std::string& type,
+                                  TInterp_t interp = nullptr);
 
 ///\returns the complex of the provided type.
 CPPINTEROP_API TCppType_t GetComplexType(TCppType_t element_type);
@@ -727,10 +744,10 @@ CPPINTEROP_API void UseExternalInterpreter(TInterp_t I);
 
 /// Adds a Search Path for the Interpreter to get the libraries.
 CPPINTEROP_API void AddSearchPath(const char* dir, bool isUser = true,
-                                  bool prepend = false);
+                                  bool prepend = false, TInterp_t I = nullptr);
 
 /// Returns the resource-dir path (for headers).
-CPPINTEROP_API const char* GetResourceDir();
+CPPINTEROP_API const char* GetResourceDir(TInterp_t I = nullptr);
 
 /// Uses the underlying clang compiler to detect the resource directory.
 /// In essence calling clang -print-resource-dir and checks if it ends with
@@ -751,46 +768,52 @@ DetectSystemCompilerIncludePaths(std::vector<std::string>& Paths,
 
 /// Secondary search path for headers, if not found using the
 /// GetResourceDir() function.
-CPPINTEROP_API void AddIncludePath(const char* dir);
+CPPINTEROP_API void AddIncludePath(const char* dir, TInterp_t I = nullptr);
 
 // Gets the currently used include paths
 ///\param[out] IncludePaths - the list of include paths
 ///
 CPPINTEROP_API void GetIncludePaths(std::vector<std::string>& IncludePaths,
                                     bool withSystem = false,
-                                    bool withFlags = false);
+                                    bool withFlags = false,
+                                    TInterp_t I = nullptr);
 
 /// Only Declares a code snippet in \c code and does not execute it.
 ///\returns 0 on success
-CPPINTEROP_API int Declare(const char* code, bool silent = false);
+CPPINTEROP_API int Declare(const char* code, bool silent = false,
+                           TInterp_t I = nullptr);
 
 /// Declares and executes a code snippet in \c code.
 ///\returns 0 on success
-CPPINTEROP_API int Process(const char* code);
+CPPINTEROP_API int Process(const char* code, TInterp_t I = nullptr);
 
 /// Declares, executes and returns the execution result as a intptr_t.
 ///\returns the expression results as a intptr_t.
-CPPINTEROP_API intptr_t Evaluate(const char* code, bool* HadError = nullptr);
+CPPINTEROP_API intptr_t Evaluate(const char* code, bool* HadError = nullptr,
+                                 TInterp_t I = nullptr);
 
 /// Looks up the library if access is enabled.
 ///\returns the path to the library.
-CPPINTEROP_API std::string LookupLibrary(const char* lib_name);
+CPPINTEROP_API std::string LookupLibrary(const char* lib_name,
+                                         TInterp_t I = nullptr);
 
 /// Finds \c lib_stem considering the list of search paths and loads it by
 /// calling dlopen.
 /// \returns true on success.
-CPPINTEROP_API bool LoadLibrary(const char* lib_stem, bool lookup = true);
+CPPINTEROP_API bool LoadLibrary(const char* lib_stem, bool lookup = true,
+                                TInterp_t I = nullptr);
 
 /// Finds \c lib_stem considering the list of search paths and unloads it by
 /// calling dlclose.
 /// function.
-CPPINTEROP_API void UnloadLibrary(const char* lib_stem);
+CPPINTEROP_API void UnloadLibrary(const char* lib_stem, TInterp_t I = nullptr);
 
 /// Scans all libraries on the library search path for a given potentially
 /// mangled symbol name.
 ///\returns the path to the first library that contains the symbol definition.
-CPPINTEROP_API std::string
-SearchLibrariesForSymbol(const char* mangled_name, bool search_system /*true*/);
+CPPINTEROP_API std::string SearchLibrariesForSymbol(const char* mangled_name,
+                                                    bool search_system /*true*/,
+                                                    TInterp_t I = nullptr);
 
 /// Inserts or replaces a symbol in the JIT with the one provided. This is
 /// useful for providing our own implementations of facilities such as printf.
@@ -801,7 +824,8 @@ SearchLibrariesForSymbol(const char* mangled_name, bool search_system /*true*/);
 ///
 ///\returns true on failure.
 CPPINTEROP_API bool InsertOrReplaceJitSymbol(const char* linker_mangled_name,
-                                             uint64_t address);
+                                             uint64_t address,
+                                             TInterp_t I = nullptr);
 
 /// Tries to load provided objects in a string format (prettyprint).
 CPPINTEROP_API std::string ObjToString(const char* type, void* obj);
@@ -838,9 +862,10 @@ GetClassTemplateInstantiationArgs(TCppScope_t templ_instance,
 
 /// Instantiates a function template from a given string representation. This
 /// function also does overload resolution.
+///\param[in] interp - is used to select the interpreter if multiple in-use.
 ///\returns the instantiated function template declaration.
-CPPINTEROP_API TCppFunction_t
-InstantiateTemplateFunctionFromString(const char* function_template);
+CPPINTEROP_API TCppFunction_t InstantiateTemplateFunctionFromString(
+    const char* function_template, TInterp_t interp = nullptr);
 
 /// Finds best overload match based on explicit template parameters (if any)
 /// and argument types.
@@ -937,7 +962,7 @@ CPPINTEROP_API void CodeComplete(std::vector<std::string>& Results,
 /// Reverts the last N operations performed by the interpreter.
 ///\param[in] N The number of operations to undo. Defaults to 1.
 ///\returns 0 on success, non-zero on failure.
-CPPINTEROP_API int Undo(unsigned N = 1);
+CPPINTEROP_API int Undo(unsigned N = 1, TInterp_t interp = nullptr);
 
 } // end namespace Cpp
 

--- a/include/CppInterOp/CppInterOp.h
+++ b/include/CppInterOp/CppInterOp.h
@@ -702,6 +702,11 @@ CreateInterpreter(const std::vector<const char*>& Args = {},
 ///\returns false on failure or if \c I is not tracked in the stack.
 CPPINTEROP_API bool DeleteInterpreter(TInterp_t I = nullptr);
 
+/// Take ownership of an interpreter instance.
+///\param[in] I - the interpreter to be taken, if nullptr, returns the last.
+///\returns nullptr on failure or if \c I is not tracked in the stack.
+CPPINTEROP_API TInterp_t TakeInterpreter(TInterp_t I = nullptr);
+
 /// Activates an instance of an interpreter to handle subsequent API requests
 ///\param[in] I - the interpreter to be activated.
 ///\returns false on failure.

--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -54,6 +54,7 @@
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/Error.h"
+#include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/ManagedStatic.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/raw_ostream.h"
@@ -138,16 +139,16 @@ struct InterpreterInfo {
   InterpreterInfo& operator=(const InterpreterInfo&) = delete;
 };
 
-// NOLINTBEGIN
+// NOLINTBEGIN(cppcoreguidelines-avoid-non-const-global-variables)
 // std::deque avoids relocations and calling the dtor of InterpreterInfo.
-static llvm::ManagedStatic<std::deque<std::shared_ptr<InterpreterInfo>>>
+static llvm::ManagedStatic<std::deque<std::unique_ptr<InterpreterInfo>>>
     sInterpreters;
 static llvm::ManagedStatic<
-    std::unordered_map<clang::ASTContext*, std::weak_ptr<InterpreterInfo>>>
+    std::unordered_map<clang::ASTContext*, InterpreterInfo*>>
     sInterpreterASTMap;
 static std::recursive_mutex InterpreterStackLock;
 static std::recursive_mutex LLVMLock;
-// NOLINTEND
+// NOLINTEND(cppcoreguidelines-avoid-non-const-global-variables)
 
 static InterpreterInfo& getInterpInfo() {
   std::lock_guard<std::recursive_mutex> Lock(InterpreterStackLock);
@@ -161,17 +162,20 @@ static InterpreterInfo& getInterpInfo(const clang::Decl* D) {
     return getInterpInfo();
   if (sInterpreters->size() == 1)
     return *sInterpreters->back();
-  return *(*sInterpreterASTMap)[&D->getASTContext()].lock();
+  return *(*sInterpreterASTMap)[&D->getASTContext()];
 }
 static InterpreterInfo& getInterpInfo(const void* D) {
   std::lock_guard<std::recursive_mutex> Lock(InterpreterStackLock);
+  QualType QT = QualType::getFromOpaquePtr(D);
+  if (auto* D = QT->getAsTagDecl())
+    return getInterpInfo(D);
   if (!D)
     return getInterpInfo();
   if (sInterpreters->size() == 1)
     return *sInterpreters->back();
   for (auto& item : *sInterpreterASTMap) {
     if (item.first->getAllocator().identifyObject(D))
-      return *item.second.lock();
+      return *item.second;
   }
   llvm_unreachable(
       "This pointer does not belong to any interpreter instance.\n");
@@ -189,7 +193,7 @@ static compat::Interpreter& getInterp(const clang::Decl* D) {
     return getInterp();
   if (sInterpreters->size() == 1)
     return *sInterpreters->back()->Interpreter;
-  return *(*sInterpreterASTMap)[&D->getASTContext()].lock()->Interpreter;
+  return *(*sInterpreterASTMap)[&D->getASTContext()]->Interpreter;
 }
 static compat::Interpreter& getInterp(const void* D) {
   return *getInterpInfo(D).Interpreter;
@@ -3338,6 +3342,8 @@ static std::string MakeResourcesPath() {
 TInterp_t CreateInterpreter(const std::vector<const char*>& Args /*={}*/,
                             const std::vector<const char*>& GpuArgs /*={}*/) {
   std::lock_guard<std::recursive_mutex> Lock(InterpreterStackLock);
+  assert(sInterpreters->size() == sInterpreterASTMap->size());
+
   std::string MainExecutableName = sys::fs::getMainExecutable(nullptr, nullptr);
   std::string ResourceDir = MakeResourcesPath();
   std::vector<const char*> ClingArgv = {"-resource-dir", ResourceDir.c_str(),
@@ -3414,40 +3420,71 @@ TInterp_t CreateInterpreter(const std::vector<const char*>& Args /*={}*/,
   )");
 
   sInterpreters->emplace_back(
-      std::make_shared<InterpreterInfo>(I, /*Owned=*/true));
+      std::make_unique<InterpreterInfo>(I, /*Owned=*/true));
   sInterpreterASTMap->insert(
       {&sInterpreters->back()->Interpreter->getSema().getASTContext(),
-       sInterpreters->back()});
+       sInterpreters->back().get()});
 
+  assert(sInterpreters->size() == sInterpreterASTMap->size());
   return I;
+}
+
+static inline auto find_interpreter_in_stack(TInterp_t I) {
+  return std::find_if(
+      sInterpreters->begin(), sInterpreters->end(),
+      [&I](const auto& Info) { return Info->Interpreter == I; });
+}
+
+static inline auto find_interpreter_in_map(InterpreterInfo* I) {
+  return std::find_if(sInterpreterASTMap->begin(), sInterpreterASTMap->end(),
+                      [&](const auto& Item) { return Item.second == I; });
 }
 
 bool DeleteInterpreter(TInterp_t I /*=nullptr*/) {
   std::lock_guard<std::recursive_mutex> Lock(InterpreterStackLock);
+  assert(sInterpreters->size() == sInterpreterASTMap->size());
 
   if (!I) {
-    auto foundAST =
-        std::find_if(sInterpreterASTMap->begin(), sInterpreterASTMap->end(),
-                     [](const auto& Item) {
-                       return Item.second.lock() == sInterpreters->back();
-                     });
+    auto foundAST = find_interpreter_in_map(sInterpreters->back().get());
+    assert(foundAST != sInterpreterASTMap->end());
     sInterpreterASTMap->erase(foundAST);
     sInterpreters->pop_back();
     return true;
   }
 
-  auto found =
-      std::find_if(sInterpreters->begin(), sInterpreters->end(),
-                   [&I](const auto& Info) { return Info->Interpreter == I; });
+  auto found = find_interpreter_in_stack(I);
   if (found == sInterpreters->end())
     return false; // failure
 
-  auto foundAST = std::find_if(
-      sInterpreterASTMap->begin(), sInterpreterASTMap->end(),
-      [&found](const auto& Item) { return Item.second.lock() == *found; });
+  auto foundAST = find_interpreter_in_map((*found).get());
+  assert(foundAST != sInterpreterASTMap->end());
   sInterpreterASTMap->erase(foundAST);
   sInterpreters->erase(found);
   return true;
+}
+
+TInterp_t TakeInterpreter(TInterp_t I /*=nullptr*/) {
+  std::lock_guard<std::recursive_mutex> Lock(InterpreterStackLock);
+  assert(sInterpreters->size() == sInterpreterASTMap->size());
+
+  if (!I) {
+    auto foundAST = find_interpreter_in_map(sInterpreters->back().get());
+    sInterpreterASTMap->erase(foundAST);
+    InterpreterInfo* res = sInterpreters->back().release();
+    sInterpreters->pop_back();
+    return res->Interpreter;
+  }
+
+  auto found = find_interpreter_in_stack(I);
+  if (found == sInterpreters->end())
+    return nullptr; // failure
+
+  auto foundAST = find_interpreter_in_map((*found).get());
+  sInterpreterASTMap->erase(foundAST);
+  InterpreterInfo* res = (*found).release();
+  sInterpreters->erase(found);
+  assert(sInterpreters->size() == sInterpreterASTMap->size());
+  return res->Interpreter;
 }
 
 bool ActivateInterpreter(TInterp_t I) {
@@ -3477,10 +3514,13 @@ TInterp_t GetInterpreter() {
 
 void UseExternalInterpreter(TInterp_t I) {
   std::lock_guard<std::recursive_mutex> Lock(InterpreterStackLock);
-  assert(sInterpreters->empty() && "sInterpreter already in use!");
   sInterpreters->emplace_back(
-      std::make_shared<InterpreterInfo>(static_cast<compat::Interpreter*>(I),
+      std::make_unique<InterpreterInfo>(static_cast<compat::Interpreter*>(I),
                                         /*isOwned=*/false));
+  sInterpreterASTMap->insert(
+      {&sInterpreters->back()->Interpreter->getSema().getASTContext(),
+       sInterpreters->back().get()});
+  assert(sInterpreters->size() == sInterpreterASTMap->size());
 }
 
 void AddSearchPath(const char* dir, bool isUser, bool prepend) {
@@ -3734,9 +3774,9 @@ std::string ObjToString(const char* type, void* obj) {
   return getInterp(NULLPTR).toString(type, obj);
 }
 
-Decl* InstantiateTemplate(TemplateDecl* TemplateD,
-                          TemplateArgumentListInfo& TLI, Sema& S,
-                          bool instantiate_body) {
+static Decl* InstantiateTemplate(TemplateDecl* TemplateD,
+                                 TemplateArgumentListInfo& TLI, Sema& S,
+                                 bool instantiate_body) {
   LOCK(getInterpInfo());
   // This is not right but we don't have a lot of options to choose from as a
   // template instantiation requires a valid source location.

--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -65,11 +65,14 @@
 #include <iterator>
 #include <map>
 #include <memory>
+#include <mutex>
 #include <set>
 #include <sstream>
 #include <stack>
 #include <string>
+#include <unordered_map>
 #include <utility>
+#include <vector>
 
 // Stream redirect.
 #ifdef _WIN32
@@ -92,9 +95,15 @@ using namespace clang;
 using namespace llvm;
 using namespace std;
 
+#define LOCK(InterpInfo)                                                       \
+  std::lock_guard<std::recursive_mutex> interop_lock(                          \
+      (InterpInfo).InterpreterLock)
+
 struct InterpreterInfo {
   compat::Interpreter* Interpreter = nullptr;
   bool isOwned = true;
+  std::recursive_mutex InterpreterLock;
+
   InterpreterInfo(compat::Interpreter* I, bool Owned)
       : Interpreter(I), isOwned(Owned) {}
 
@@ -129,16 +138,80 @@ struct InterpreterInfo {
   InterpreterInfo& operator=(const InterpreterInfo&) = delete;
 };
 
+// NOLINTBEGIN
 // std::deque avoids relocations and calling the dtor of InterpreterInfo.
-static llvm::ManagedStatic<std::deque<InterpreterInfo>> sInterpreters;
+static llvm::ManagedStatic<std::deque<std::shared_ptr<InterpreterInfo>>>
+    sInterpreters;
+static llvm::ManagedStatic<
+    std::unordered_map<clang::ASTContext*, std::weak_ptr<InterpreterInfo>>>
+    sInterpreterASTMap;
+static std::recursive_mutex InterpreterStackLock;
+static std::recursive_mutex LLVMLock;
+// NOLINTEND
 
-static compat::Interpreter& getInterp() {
+static InterpreterInfo& getInterpInfo() {
+  std::lock_guard<std::recursive_mutex> Lock(InterpreterStackLock);
   assert(!sInterpreters->empty() &&
          "Interpreter instance must be set before calling this!");
-  return *sInterpreters->back().Interpreter;
+  return *sInterpreters->back();
 }
+static InterpreterInfo& getInterpInfo(const clang::Decl* D) {
+  std::lock_guard<std::recursive_mutex> Lock(InterpreterStackLock);
+  if (!D)
+    return getInterpInfo();
+  if (sInterpreters->size() == 1)
+    return *sInterpreters->back();
+  return *(*sInterpreterASTMap)[&D->getASTContext()].lock();
+}
+static InterpreterInfo& getInterpInfo(const void* D) {
+  std::lock_guard<std::recursive_mutex> Lock(InterpreterStackLock);
+  if (!D)
+    return getInterpInfo();
+  if (sInterpreters->size() == 1)
+    return *sInterpreters->back();
+  for (auto& item : *sInterpreterASTMap) {
+    if (item.first->getAllocator().identifyObject(D))
+      return *item.second.lock();
+  }
+  llvm_unreachable(
+      "This pointer does not belong to any interpreter instance.\n");
+}
+
+static compat::Interpreter& getInterp() {
+  std::lock_guard<std::recursive_mutex> Lock(InterpreterStackLock);
+  assert(!sInterpreters->empty() &&
+         "Interpreter instance must be set before calling this!");
+  return *sInterpreters->back()->Interpreter;
+}
+static compat::Interpreter& getInterp(const clang::Decl* D) {
+  std::lock_guard<std::recursive_mutex> Lock(InterpreterStackLock);
+  if (!D)
+    return getInterp();
+  if (sInterpreters->size() == 1)
+    return *sInterpreters->back()->Interpreter;
+  return *(*sInterpreterASTMap)[&D->getASTContext()].lock()->Interpreter;
+}
+static compat::Interpreter& getInterp(const void* D) {
+  return *getInterpInfo(D).Interpreter;
+}
+
 static clang::Sema& getSema() { return getInterp().getCI()->getSema(); }
+static clang::Sema& getSema(const clang::Decl* D) {
+  if (!D)
+    return getSema();
+  return getInterpInfo(D).Interpreter->getSema();
+}
+static clang::Sema& getSema(const void* D) { return getInterp(D).getSema(); }
+
 static clang::ASTContext& getASTContext() { return getSema().getASTContext(); }
+static clang::ASTContext& getASTContext(const clang::Decl* D) {
+  if (!D)
+    return getASTContext();
+  return getSema(D).getASTContext();
+}
+static clang::ASTContext& getASTContext(const void* D) {
+  return getSema(D).getASTContext();
+}
 
 static void ForceCodeGen(Decl* D, compat::Interpreter& I) {
   // The decl was deferred by CodeGen. Force its emission.
@@ -266,21 +339,29 @@ std::string Demangle(const std::string& mangled_name) {
   return demangle;
 }
 
-void EnableDebugOutput(bool value /* =true*/) { llvm::DebugFlag = value; }
+void EnableDebugOutput(bool value /* =true*/) {
+  std::lock_guard<std::recursive_mutex> Lock(LLVMLock);
+  llvm::DebugFlag = value;
+}
 
-bool IsDebugOutputEnabled() { return llvm::DebugFlag; }
+bool IsDebugOutputEnabled() {
+  std::lock_guard<std::recursive_mutex> Lock(LLVMLock);
+  return llvm::DebugFlag;
+}
 
 static void InstantiateFunctionDefinition(Decl* D) {
-  compat::SynthesizingCodeRAII RAII(&getInterp());
   if (auto* FD = llvm::dyn_cast_or_null<FunctionDecl>(D)) {
-    getSema().InstantiateFunctionDefinition(SourceLocation(), FD,
-                                            /*Recursive=*/true,
-                                            /*DefinitionRequired=*/true);
+    LOCK(getInterpInfo(FD));
+    compat::SynthesizingCodeRAII RAII(&getInterp(FD));
+    getSema(FD).InstantiateFunctionDefinition(SourceLocation(), FD,
+                                              /*Recursive=*/true,
+                                              /*DefinitionRequired=*/true);
   }
 }
 
 bool IsAggregate(TCppScope_t scope) {
   Decl* D = static_cast<Decl*>(scope);
+  LOCK(getInterpInfo(D));
 
   // Aggregates are only arrays or tag decls.
   if (ValueDecl* ValD = dyn_cast<ValueDecl>(D))
@@ -316,9 +397,11 @@ bool IsFunctionPointerType(TCppType_t type) {
 
 bool IsClassPolymorphic(TCppScope_t klass) {
   Decl* D = static_cast<Decl*>(klass);
-  if (auto* CXXRD = llvm::dyn_cast<CXXRecordDecl>(D))
+  if (auto* CXXRD = llvm::dyn_cast<CXXRecordDecl>(D)) {
+    LOCK(getInterpInfo(CXXRD));
     if (auto* CXXRDD = CXXRD->getDefinition())
       return CXXRDD->isPolymorphic();
+  }
   return false;
 }
 
@@ -334,12 +417,13 @@ bool IsComplete(TCppScope_t scope) {
 
   Decl* D = static_cast<Decl*>(scope);
 
+  LOCK(getInterpInfo(D));
   if (isa<ClassTemplateSpecializationDecl>(D)) {
     QualType QT = QualType::getFromOpaquePtr(GetTypeFromScope(scope));
-    clang::Sema& S = getSema();
+    clang::Sema& S = getSema(D);
     SourceLocation fakeLoc = GetValidSLoc(S);
 #ifdef CPPINTEROP_USE_CLING
-    cling::Interpreter::PushTransactionRAII RAII(&getInterp());
+    cling::Interpreter::PushTransactionRAII RAII(&getInterp(D));
 #endif // CPPINTEROP_USE_CLING
     return S.isCompleteType(fakeLoc, QT);
   }
@@ -359,6 +443,7 @@ size_t SizeOf(TCppScope_t scope) {
     return 0;
 
   if (auto* RD = dyn_cast<RecordDecl>(static_cast<Decl*>(scope))) {
+    LOCK(getInterpInfo(RD));
     ASTContext& Context = RD->getASTContext();
     const ASTRecordLayout& Layout = Context.getASTRecordLayout(RD);
     return Layout.getSize().getQuantity();
@@ -392,8 +477,10 @@ bool IsTypedefed(TCppScope_t handle) {
 
 bool IsAbstract(TCppType_t klass) {
   auto* D = (clang::Decl*)klass;
-  if (auto* CXXRD = llvm::dyn_cast_or_null<clang::CXXRecordDecl>(D))
+  if (auto* CXXRD = llvm::dyn_cast_or_null<clang::CXXRecordDecl>(D)) {
+    LOCK(getInterpInfo(CXXRD));
     return CXXRD->isAbstract();
+  }
 
   return false;
 }
@@ -427,6 +514,7 @@ static bool isSmartPointer(const RecordType* RT) {
   };
 
   const RecordDecl* Record = RT->getDecl();
+  LOCK(getInterpInfo(Record));
   if (IsUseCountPresent(Record))
     return true;
 
@@ -494,6 +582,7 @@ std::vector<TCppScope_t> GetEnumConstants(TCppScope_t handle) {
   auto* D = (clang::Decl*)handle;
 
   if (auto* ED = llvm::dyn_cast_or_null<clang::EnumDecl>(D)) {
+    LOCK(getInterpInfo(ED));
     std::vector<TCppScope_t> enum_constants;
     for (auto* ECD : ED->enumerators()) {
       enum_constants.push_back((TCppScope_t)ECD);
@@ -531,7 +620,7 @@ size_t GetSizeOfType(TCppType_t type) {
     return SizeOf(TT->getDecl());
 
   // FIXME: Can we get the size of a non-tag type?
-  auto TI = getSema().getASTContext().getTypeInfo(QT);
+  auto TI = getASTContext(type).getTypeInfo(QT);
   size_t TypeSize = TI.Width;
   return TypeSize / 8;
 }
@@ -556,8 +645,8 @@ std::string GetName(TCppType_t klass) {
 }
 
 std::string GetCompleteName(TCppType_t klass) {
-  auto& C = getSema().getASTContext();
   auto* D = (Decl*)klass;
+  auto& C = getSema(D).getASTContext();
 
   PrintingPolicy Policy = C.getPrintingPolicy();
   Policy.SuppressUnwrittenScope = true;
@@ -607,8 +696,8 @@ std::string GetQualifiedName(TCppType_t klass) {
 
 // FIXME: Figure out how to merge with GetCompleteName.
 std::string GetQualifiedCompleteName(TCppType_t klass) {
-  auto& C = getSema().getASTContext();
   auto* D = (Decl*)klass;
+  auto& C = getSema(D).getASTContext();
 
   if (auto* ND = llvm::dyn_cast_or_null<NamedDecl>(D)) {
     if (auto* TD = llvm::dyn_cast<TagDecl>(ND)) {
@@ -637,6 +726,7 @@ std::vector<TCppScope_t> GetUsingNamespaces(TCppScope_t scope) {
   auto* D = (clang::Decl*)scope;
 
   if (auto* DC = llvm::dyn_cast_or_null<clang::DeclContext>(D)) {
+    LOCK(getInterpInfo(D));
     std::vector<TCppScope_t> namespaces;
     for (auto UD : DC->using_directives()) {
       namespaces.push_back((TCppScope_t)UD->getNominatedNamespace());
@@ -724,13 +814,14 @@ TCppScope_t GetScopeFromCompleteName(const std::string& name) {
 TCppScope_t GetNamed(const std::string& name,
                      TCppScope_t parent /*= nullptr*/) {
   clang::DeclContext* Within = 0;
+  auto* D = static_cast<clang::Decl*>(parent);
+  LOCK(getInterpInfo(D));
   if (parent) {
-    auto* D = (clang::Decl*)parent;
     D = GetUnderlyingScope(D);
     Within = llvm::dyn_cast<clang::DeclContext>(D);
   }
 
-  auto* ND = Cpp_utils::Lookup::Named(&getSema(), name, Within);
+  auto* ND = Cpp_utils::Lookup::Named(&getSema(D), name, Within);
   if (ND && ND != (clang::NamedDecl*)-1) {
     return (TCppScope_t)(ND->getCanonicalDecl());
   }
@@ -760,10 +851,13 @@ TCppScope_t GetParentScope(TCppScope_t scope) {
 TCppIndex_t GetNumBases(TCppScope_t klass) {
   auto* D = (Decl*)klass;
 
-  if (auto* CTSD = llvm::dyn_cast_or_null<ClassTemplateSpecializationDecl>(D))
+  if (auto* CTSD = llvm::dyn_cast_or_null<ClassTemplateSpecializationDecl>(D)) {
+    LOCK(getInterpInfo(CTSD));
     if (!CTSD->hasDefinition())
-      compat::InstantiateClassTemplateSpecialization(getInterp(), CTSD);
+      compat::InstantiateClassTemplateSpecialization(getInterp(CTSD), CTSD);
+  }
   if (auto* CXXRD = llvm::dyn_cast_or_null<CXXRecordDecl>(D)) {
+    LOCK(getInterpInfo(CXXRD));
     if (CXXRD->hasDefinition())
       return CXXRD->getNumBases();
   }
@@ -774,8 +868,12 @@ TCppIndex_t GetNumBases(TCppScope_t klass) {
 TCppScope_t GetBaseClass(TCppScope_t klass, TCppIndex_t ibase) {
   auto* D = (Decl*)klass;
   auto* CXXRD = llvm::dyn_cast_or_null<CXXRecordDecl>(D);
-  if (!CXXRD || CXXRD->getNumBases() <= ibase)
-    return 0;
+  if (!CXXRD)
+    return nullptr;
+
+  LOCK(getInterpInfo(CXXRD));
+  if (CXXRD->getNumBases() <= ibase)
+    return nullptr;
 
   auto type = (CXXRD->bases_begin() + ibase)->getType();
   if (auto RT = type->getAs<RecordType>())
@@ -864,12 +962,15 @@ int64_t GetBaseClassOffset(TCppScope_t derived, TCppScope_t base) {
     return -1;
   CXXRecordDecl* DCXXRD = cast<CXXRecordDecl>(DD);
   CXXRecordDecl* BCXXRD = cast<CXXRecordDecl>(BD);
+
+  LOCK(getInterpInfo(DD));
+
   CXXBasePaths Paths(/*FindAmbiguities=*/false, /*RecordPaths=*/true,
                      /*DetectVirtual=*/false);
   DCXXRD->isDerivedFrom(BCXXRD, Paths);
 
   // FIXME: We might want to cache these requests as they seem expensive.
-  return ComputeBaseOffset(getSema().getASTContext(), DCXXRD, Paths.front());
+  return ComputeBaseOffset(getSema(DD).getASTContext(), DCXXRD, Paths.front());
 }
 
 template <typename DeclType>
@@ -879,6 +980,7 @@ static void GetClassDecls(TCppScope_t klass,
     return;
 
   auto* D = (clang::Decl*)klass;
+  LOCK(getInterpInfo(D));
 
   if (auto* TD = dyn_cast<TypedefNameDecl>(D))
     D = GetScopeFromType(TD->getUnderlyingType());
@@ -888,11 +990,11 @@ static void GetClassDecls(TCppScope_t klass,
 
   auto* CXXRD = dyn_cast<CXXRecordDecl>(D);
 #ifdef CPPINTEROP_USE_CLING
-  cling::Interpreter::PushTransactionRAII RAII(&getInterp());
+  cling::Interpreter::PushTransactionRAII RAII(&getInterp(CXXRD));
 #endif // CPPINTEROP_USE_CLING
   if (CXXRD->hasDefinition())
     CXXRD = CXXRD->getDefinition();
-  getSema().ForceDeclarationOfImplicitMembers(CXXRD);
+  getSema(CXXRD).ForceDeclarationOfImplicitMembers(CXXRD);
   for (Decl* DI : CXXRD->decls()) {
     if (auto* MD = dyn_cast<DeclType>(DI))
       methods.push_back(MD);
@@ -918,7 +1020,7 @@ static void GetClassDecls(TCppScope_t klass,
       // Result is appended to the decls, i.e. CXXRD, iterator
       // non-shadowed decl will be push_back later
       // methods.push_back(Result);
-      getSema().findInheritingConstructor(SourceLocation(), CXXCD, CUSD);
+      getSema(CXXRD).findInheritingConstructor(SourceLocation(), CXXCD, CUSD);
     }
   }
 }
@@ -935,8 +1037,10 @@ void GetFunctionTemplatedDecls(TCppScope_t klass,
 bool HasDefaultConstructor(TCppScope_t scope) {
   auto* D = (clang::Decl*)scope;
 
-  if (auto* CXXRD = llvm::dyn_cast_or_null<CXXRecordDecl>(D))
+  if (auto* CXXRD = llvm::dyn_cast_or_null<CXXRecordDecl>(D)) {
+    LOCK(getInterpInfo(CXXRD));
     return CXXRD->hasDefaultConstructor();
+  }
 
   return false;
 }
@@ -947,18 +1051,21 @@ TCppFunction_t GetDefaultConstructor(compat::Interpreter& interp,
     return nullptr;
 
   auto* CXXRD = (clang::CXXRecordDecl*)scope;
+  LOCK(getInterpInfo(CXXRD));
   return interp.getCI()->getSema().LookupDefaultConstructor(CXXRD);
 }
 
 TCppFunction_t GetDefaultConstructor(TCppScope_t scope) {
-  return GetDefaultConstructor(getInterp(), scope);
+  auto* CXXRD = static_cast<clang::CXXRecordDecl*>(scope);
+  return GetDefaultConstructor(getInterp(CXXRD), scope);
 }
 
 TCppFunction_t GetDestructor(TCppScope_t scope) {
   auto* D = (clang::Decl*)scope;
 
   if (auto* CXXRD = llvm::dyn_cast_or_null<CXXRecordDecl>(D)) {
-    getSema().ForceDeclarationOfImplicitMembers(CXXRD);
+    LOCK(getInterpInfo(CXXRD));
+    getSema(CXXRD).ForceDeclarationOfImplicitMembers(CXXRD);
     return CXXRD->getDestructor();
   }
 
@@ -977,12 +1084,14 @@ std::vector<TCppFunction_t> GetFunctionsUsingName(TCppScope_t scope,
   if (!scope || name.empty())
     return {};
 
+  LOCK(getInterpInfo(D));
+
   D = GetUnderlyingScope(D);
 
   std::vector<TCppFunction_t> funcs;
   llvm::StringRef Name(name);
-  auto& S = getSema();
-  DeclarationName DName = &getASTContext().Idents.get(name);
+  auto& S = getSema(D);
+  DeclarationName DName = &S.getASTContext().Idents.get(name);
   clang::LookupResult R(S, DName, SourceLocation(), Sema::LookupOrdinaryName,
                         For_Visible_Redeclaration);
 
@@ -1003,6 +1112,7 @@ std::vector<TCppFunction_t> GetFunctionsUsingName(TCppScope_t scope,
 TCppType_t GetFunctionReturnType(TCppFunction_t func) {
   auto* D = (clang::Decl*)func;
   if (auto* FD = llvm::dyn_cast_or_null<clang::FunctionDecl>(D)) {
+    LOCK(getInterpInfo(FD));
     QualType Type = FD->getReturnType();
     if (Type->isUndeducedAutoType()) {
       bool needInstantiation = false;
@@ -1021,8 +1131,10 @@ TCppType_t GetFunctionReturnType(TCppFunction_t func) {
     return Type.getAsOpaquePtr();
   }
 
-  if (auto* FD = llvm::dyn_cast_or_null<clang::FunctionTemplateDecl>(D))
+  if (auto* FD = llvm::dyn_cast_or_null<clang::FunctionTemplateDecl>(D)) {
+    LOCK(getInterpInfo(FD));
     return (FD->getTemplatedDecl())->getReturnType().getAsOpaquePtr();
+  }
 
   return 0;
 }
@@ -1050,9 +1162,9 @@ TCppIndex_t GetFunctionRequiredArgs(TCppConstFunction_t func) {
 }
 
 TCppType_t GetFunctionArgType(TCppFunction_t func, TCppIndex_t iarg) {
-  auto* D = (clang::Decl*)func;
-
+  auto* D = static_cast<clang::Decl*>(func);
   if (auto* FD = llvm::dyn_cast_or_null<clang::FunctionDecl>(D)) {
+    LOCK(getInterpInfo(FD));
     if (iarg < FD->getNumParams()) {
       auto* PVD = FD->getParamDecl(iarg);
       return PVD->getOriginalType().getAsOpaquePtr();
@@ -1078,7 +1190,7 @@ std::string GetFunctionSignature(TCppFunction_t func) {
 
   std::string Signature;
   raw_string_ostream SS(Signature);
-  PrintingPolicy Policy = getASTContext().getPrintingPolicy();
+  PrintingPolicy Policy = getASTContext(D).getPrintingPolicy();
   // Skip printing the body
   Policy.TerseOutput = true;
   Policy.FullyQualifiedName = true;
@@ -1125,12 +1237,14 @@ bool IsTemplatedFunction(TCppFunction_t func) {
 // the template function exists and >1 means overloads
 bool ExistsFunctionTemplate(const std::string& name, TCppScope_t parent) {
   DeclContext* Within = 0;
+  auto* D = static_cast<Decl*>(parent);
   if (parent) {
-    auto* D = (Decl*)parent;
     Within = llvm::dyn_cast<DeclContext>(D);
   }
 
-  auto* ND = Cpp_utils::Lookup::Named(&getSema(), name, Within);
+  LOCK(getInterpInfo(D));
+
+  auto* ND = Cpp_utils::Lookup::Named(&getSema(D), name, Within);
 
   if ((intptr_t)ND == (intptr_t)0)
     return false;
@@ -1149,8 +1263,10 @@ void LookupConstructors(const std::string& name, TCppScope_t parent,
   auto* D = (Decl*)parent;
 
   if (auto* CXXRD = llvm::dyn_cast_or_null<CXXRecordDecl>(D)) {
-    getSema().ForceDeclarationOfImplicitMembers(CXXRD);
-    DeclContextLookupResult Result = getSema().LookupConstructors(CXXRD);
+    LOCK(getInterpInfo(CXXRD));
+
+    getSema(CXXRD).ForceDeclarationOfImplicitMembers(CXXRD);
+    DeclContextLookupResult Result = getSema(CXXRD).LookupConstructors(CXXRD);
     // Obtaining all constructors when we intend to lookup a method under a
     // scope can lead to crashes. We avoid that by accumulating constructors
     // only if the Decl matches the lookup name.
@@ -1166,12 +1282,14 @@ bool GetClassTemplatedMethods(const std::string& name, TCppScope_t parent,
   if (!D && name.empty())
     return false;
 
+  LOCK(getInterpInfo(D));
+
   // Accumulate constructors
   LookupConstructors(name, parent, funcs);
-  auto& S = getSema();
+  auto& S = getSema(D);
   D = GetUnderlyingScope(D);
   llvm::StringRef Name(name);
-  DeclarationName DName = &getASTContext().Idents.get(name);
+  DeclarationName DName = &S.getASTContext().Idents.get(name);
   clang::LookupResult R(S, DName, SourceLocation(), Sema::LookupOrdinaryName,
                         For_Visible_Redeclaration);
   auto* DC = clang::Decl::castToDeclContext(D);
@@ -1207,11 +1325,16 @@ TCppFunction_t
 BestOverloadFunctionMatch(const std::vector<TCppFunction_t>& candidates,
                           const std::vector<TemplateArgInfo>& explicit_types,
                           const std::vector<TemplateArgInfo>& arg_types) {
-  auto& S = getSema();
+  if (candidates.empty())
+    return nullptr;
+  InterpreterInfo& II = getInterpInfo(static_cast<clang::Decl*>(candidates[0]));
+  LOCK(II);
+
+  auto& S = II.Interpreter->getSema();
   auto& C = S.getASTContext();
 
 #ifdef CPPINTEROP_USE_CLING
-  cling::Interpreter::PushTransactionRAII RAII(&getInterp());
+  cling::Interpreter::PushTransactionRAII RAII(II.Interpreter);
 #endif
 
   // The overload resolution interfaces in Sema require a list of expressions.
@@ -1330,6 +1453,7 @@ bool IsDestructor(TCppConstFunction_t method) {
 bool IsStaticMethod(TCppConstFunction_t method) {
   const auto* D = static_cast<const Decl*>(method);
   if (auto* CXXMD = llvm::dyn_cast_or_null<CXXMethodDecl>(D)) {
+    LOCK(getInterpInfo(D));
     return CXXMD->isStatic();
   }
 
@@ -1349,7 +1473,7 @@ TCppFuncAddr_t GetFunctionAddress(const char* mangled_name) {
 
 static TCppFuncAddr_t GetFunctionAddress(const FunctionDecl* FD) {
   const auto get_mangled_name = [](const FunctionDecl* FD) {
-    auto MangleCtxt = getASTContext().createMangleContext();
+    auto* MangleCtxt = getASTContext(FD).createMangleContext();
 
     if (!MangleCtxt->shouldMangleDeclName(FD)) {
       return FD->getNameInfo().getName().getAsString();
@@ -1376,6 +1500,7 @@ static TCppFuncAddr_t GetFunctionAddress(const FunctionDecl* FD) {
 TCppFuncAddr_t GetFunctionAddress(TCppFunction_t method) {
   auto* D = static_cast<Decl*>(method);
   if (auto* FD = llvm::dyn_cast_or_null<FunctionDecl>(D)) {
+    LOCK(getInterpInfo(FD));
     if ((IsTemplateInstantiationOrSpecialization(FD) ||
          FD->getTemplatedKind() == FunctionDecl::TK_MemberSpecialization) &&
         !FD->getDefinition())
@@ -1391,6 +1516,7 @@ TCppFuncAddr_t GetFunctionAddress(TCppFunction_t method) {
 bool IsVirtualMethod(TCppFunction_t method) {
   auto* D = (Decl*)method;
   if (auto* CXXMD = llvm::dyn_cast_or_null<CXXMethodDecl>(D)) {
+    LOCK(getInterpInfo(CXXMD));
     return CXXMD->isVirtual();
   }
 
@@ -1401,7 +1527,9 @@ void GetDatamembers(TCppScope_t scope, std::vector<TCppScope_t>& datamembers) {
   auto* D = (Decl*)scope;
 
   if (auto* CXXRD = llvm::dyn_cast_or_null<CXXRecordDecl>(D)) {
-    getSema().ForceDeclarationOfImplicitMembers(CXXRD);
+    LOCK(getInterpInfo(CXXRD));
+
+    getSema(CXXRD).ForceDeclarationOfImplicitMembers(CXXRD);
     if (CXXRD->hasDefinition())
       CXXRD = CXXRD->getDefinition();
 
@@ -1448,6 +1576,11 @@ void GetEnumConstantDatamembers(TCppScope_t scope,
                                 bool include_enum_class) {
   std::vector<TCppScope_t> EDs;
   GetClassDecls<EnumDecl>(scope, EDs);
+  if (EDs.empty())
+    return;
+
+  LOCK(getInterpInfo(static_cast<clang::Decl*>(EDs[0])));
+
   for (TCppScope_t i : EDs) {
     auto* ED = static_cast<EnumDecl*>(i);
 
@@ -1462,12 +1595,13 @@ void GetEnumConstantDatamembers(TCppScope_t scope,
 
 TCppScope_t LookupDatamember(const std::string& name, TCppScope_t parent) {
   clang::DeclContext* Within = 0;
+  auto* D = static_cast<clang::Decl*>(parent);
   if (parent) {
-    auto* D = (clang::Decl*)parent;
     Within = llvm::dyn_cast<clang::DeclContext>(D);
   }
 
-  auto* ND = Cpp_utils::Lookup::Named(&getSema(), name, Within);
+  LOCK(getInterpInfo(D));
+  auto* ND = Cpp_utils::Lookup::Named(&getSema(D), name, Within);
   if (ND && ND != (clang::NamedDecl*)-1) {
     if (llvm::isa_and_nonnull<clang::FieldDecl>(ND)) {
       return (TCppScope_t)ND;
@@ -1509,9 +1643,6 @@ TCppType_t GetVariableType(TCppScope_t var) {
 
 intptr_t GetVariableOffset(compat::Interpreter& I, Decl* D,
                            CXXRecordDecl* BaseCXXRD) {
-  if (!D)
-    return 0;
-
   auto& C = I.getSema().getASTContext();
 
   if (auto* FD = llvm::dyn_cast<FieldDecl>(D)) {
@@ -1586,9 +1717,9 @@ intptr_t GetVariableOffset(compat::Interpreter& I, Decl* D,
     if (!address) {
       if (!VD->hasInit()) {
 #ifdef CPPINTEROP_USE_CLING
-        cling::Interpreter::PushTransactionRAII RAII(&getInterp());
+        cling::Interpreter::PushTransactionRAII RAII(&getInterp(VD));
 #endif // CPPINTEROP_USE_CLING
-        getSema().InstantiateVariableDefinition(SourceLocation(), VD);
+        getSema(VD).InstantiateVariableDefinition(SourceLocation(), VD);
         VD = VD->getDefinition();
       }
       if (VD->hasInit() &&
@@ -1619,8 +1750,11 @@ intptr_t GetVariableOffset(compat::Interpreter& I, Decl* D,
 
 intptr_t GetVariableOffset(TCppScope_t var, TCppScope_t parent) {
   auto* D = static_cast<Decl*>(var);
+  if (!D)
+    return 0;
+  LOCK(getInterpInfo(D));
   auto* RD = llvm::dyn_cast_or_null<CXXRecordDecl>(static_cast<Decl*>(parent));
-  return GetVariableOffset(getInterp(), D, RD);
+  return GetVariableOffset(getInterp(D), D, RD);
 }
 
 // Check if the Access Specifier of the variable matches the provided value.
@@ -1643,11 +1777,7 @@ bool IsPrivateVariable(TCppScope_t var) {
 
 bool IsStaticVariable(TCppScope_t var) {
   auto* D = (Decl*)var;
-  if (llvm::isa_and_nonnull<VarDecl>(D)) {
-    return true;
-  }
-
-  return false;
+  return llvm::isa_and_nonnull<VarDecl>(D);
 }
 
 bool IsConstVariable(TCppScope_t var) {
@@ -1671,7 +1801,7 @@ bool IsPODType(TCppType_t type) {
   if (QT.isNull())
     return false;
 
-  return QT.isPODType(getASTContext());
+  return QT.isPODType(getASTContext(type));
 }
 
 bool IsPointerType(TCppType_t type) {
@@ -1703,14 +1833,16 @@ bool IsRValueReferenceType(TCppType_t type) {
 
 TCppType_t GetPointerType(TCppType_t type) {
   QualType QT = QualType::getFromOpaquePtr(type);
-  return getASTContext().getPointerType(QT).getAsOpaquePtr();
+  return getASTContext()
+      .getPointerType(QT)
+      .getAsOpaquePtr(); // FIXME: which ASTContext?
 }
 
 TCppType_t GetReferencedType(TCppType_t type, bool rvalue) {
   QualType QT = QualType::getFromOpaquePtr(type);
   if (rvalue)
-    return getASTContext().getRValueReferenceType(QT).getAsOpaquePtr();
-  return getASTContext().getLValueReferenceType(QT).getAsOpaquePtr();
+    return getASTContext(type).getRValueReferenceType(QT).getAsOpaquePtr();
+  return getASTContext(type).getLValueReferenceType(QT).getAsOpaquePtr();
 }
 
 TCppType_t GetNonReferenceType(TCppType_t type) {
@@ -1881,6 +2013,7 @@ TCppType_t GetType(const std::string& name) {
   if (!builtin.isNull())
     return builtin.getAsOpaquePtr();
 
+  LOCK(getInterpInfo());
   auto* D = (Decl*)GetNamed(name, /* Within= */ 0);
   if (auto* TD = llvm::dyn_cast_or_null<TypeDecl>(D)) {
     return QualType(TD->getTypeForDecl(), 0).getAsOpaquePtr();
@@ -1892,7 +2025,8 @@ TCppType_t GetType(const std::string& name) {
 TCppType_t GetComplexType(TCppType_t type) {
   QualType QT = QualType::getFromOpaquePtr(type);
 
-  return getASTContext().getComplexType(QT).getAsOpaquePtr();
+  LOCK(getInterpInfo(type));
+  return getASTContext(type).getComplexType(QT).getAsOpaquePtr();
 }
 
 TCppType_t GetTypeFromScope(TCppScope_t klass) {
@@ -1900,7 +2034,7 @@ TCppType_t GetTypeFromScope(TCppScope_t klass) {
     return 0;
 
   auto* D = (Decl*)klass;
-  ASTContext& C = getASTContext();
+  ASTContext& C = getASTContext(D);
 
   if (ValueDecl* VD = dyn_cast<ValueDecl>(D))
     return VD->getType().getAsOpaquePtr();
@@ -2291,8 +2425,8 @@ void make_narg_call(const FunctionDecl* FD, const std::string& return_type,
       // available, while there is a move constructor.
 
       // include utility header if not already included for std::move
-      DeclarationName DMove = &getASTContext().Idents.get("move");
-      auto result = getSema().getStdNamespace()->lookup(DMove);
+      DeclarationName DMove = &getASTContext(FD).Idents.get("move");
+      auto result = getSema(FD).getStdNamespace()->lookup(DMove);
       if (result.empty())
         Cpp::Declare("#include <utility>");
 
@@ -2505,6 +2639,8 @@ void make_narg_call_with_return(compat::Interpreter& I, const FunctionDecl* FD,
 int get_wrapper_code(compat::Interpreter& I, const FunctionDecl* FD,
                      std::string& wrapper_name, std::string& wrapper) {
   assert(FD && "generate_wrapper called without a function decl!");
+  LOCK(getInterpInfo(FD));
+
   ASTContext& Context = FD->getASTContext();
   //
   //  Get the class or namespace name.
@@ -2925,6 +3061,8 @@ JitCall::GenericCall make_wrapper(compat::Interpreter& I,
                                   const FunctionDecl* FD) {
   static std::map<const FunctionDecl*, void*> gWrapperStore;
 
+  LOCK(getInterpInfo(FD));
+
   auto R = gWrapperStore.find(FD);
   if (R != gWrapperStore.end())
     return (JitCall::GenericCall)R->second;
@@ -3016,6 +3154,8 @@ static JitCall::DestructorCall make_dtor_wrapper(compat::Interpreter& interp,
   //--
 
   static map<const Decl*, void*> gDtorWrapperStore;
+
+  LOCK(getInterpInfo(D));
 
   auto I = gDtorWrapperStore.find(D);
   if (I != gDtorWrapperStore.end())
@@ -3165,7 +3305,8 @@ CPPINTEROP_API JitCall MakeFunctionCallable(TInterp_t I,
 }
 
 CPPINTEROP_API JitCall MakeFunctionCallable(TCppConstFunction_t func) {
-  return MakeFunctionCallable(&getInterp(), func);
+  const auto* D = static_cast<const clang::Decl*>(func);
+  return MakeFunctionCallable(&getInterp(D), func);
 }
 
 namespace {
@@ -3196,6 +3337,7 @@ static std::string MakeResourcesPath() {
 
 TInterp_t CreateInterpreter(const std::vector<const char*>& Args /*={}*/,
                             const std::vector<const char*>& GpuArgs /*={}*/) {
+  std::lock_guard<std::recursive_mutex> Lock(InterpreterStackLock);
   std::string MainExecutableName = sys::fs::getMainExecutable(nullptr, nullptr);
   std::string ResourceDir = MakeResourcesPath();
   std::vector<const char*> ClingArgv = {"-resource-dir", ResourceDir.c_str(),
@@ -3271,34 +3413,52 @@ TInterp_t CreateInterpreter(const std::vector<const char*>& Args /*={}*/,
     }  // namespace __internal_CppInterOp
   )");
 
-  sInterpreters->emplace_back(I, /*Owned=*/true);
+  sInterpreters->emplace_back(
+      std::make_shared<InterpreterInfo>(I, /*Owned=*/true));
+  sInterpreterASTMap->insert(
+      {&sInterpreters->back()->Interpreter->getSema().getASTContext(),
+       sInterpreters->back()});
 
   return I;
 }
 
 bool DeleteInterpreter(TInterp_t I /*=nullptr*/) {
+  std::lock_guard<std::recursive_mutex> Lock(InterpreterStackLock);
+
   if (!I) {
+    auto foundAST =
+        std::find_if(sInterpreterASTMap->begin(), sInterpreterASTMap->end(),
+                     [](const auto& Item) {
+                       return Item.second.lock() == sInterpreters->back();
+                     });
+    sInterpreterASTMap->erase(foundAST);
     sInterpreters->pop_back();
     return true;
   }
 
   auto found =
       std::find_if(sInterpreters->begin(), sInterpreters->end(),
-                   [&I](const auto& Info) { return Info.Interpreter == I; });
+                   [&I](const auto& Info) { return Info->Interpreter == I; });
   if (found == sInterpreters->end())
     return false; // failure
 
+  auto foundAST = std::find_if(
+      sInterpreterASTMap->begin(), sInterpreterASTMap->end(),
+      [&found](const auto& Item) { return Item.second.lock() == *found; });
+  sInterpreterASTMap->erase(foundAST);
   sInterpreters->erase(found);
   return true;
 }
 
 bool ActivateInterpreter(TInterp_t I) {
+  std::lock_guard<std::recursive_mutex> Lock(InterpreterStackLock);
+
   if (!I)
     return false;
 
   auto found =
       std::find_if(sInterpreters->begin(), sInterpreters->end(),
-                   [&I](const auto& Info) { return Info.Interpreter == I; });
+                   [&I](const auto& Info) { return Info->Interpreter == I; });
   if (found == sInterpreters->end())
     return false;
 
@@ -3309,18 +3469,22 @@ bool ActivateInterpreter(TInterp_t I) {
 }
 
 TInterp_t GetInterpreter() {
+  std::lock_guard<std::recursive_mutex> Lock(InterpreterStackLock);
   if (sInterpreters->empty())
     return nullptr;
-  return sInterpreters->back().Interpreter;
+  return sInterpreters->back()->Interpreter;
 }
 
 void UseExternalInterpreter(TInterp_t I) {
+  std::lock_guard<std::recursive_mutex> Lock(InterpreterStackLock);
   assert(sInterpreters->empty() && "sInterpreter already in use!");
-  sInterpreters->emplace_back(static_cast<compat::Interpreter*>(I),
-                              /*isOwned=*/false);
+  sInterpreters->emplace_back(
+      std::make_shared<InterpreterInfo>(static_cast<compat::Interpreter*>(I),
+                                        /*isOwned=*/false));
 }
 
 void AddSearchPath(const char* dir, bool isUser, bool prepend) {
+  LOCK(getInterpInfo());
   getInterp().getDynamicLibraryManager()->addSearchPath(dir, isUser, prepend);
 }
 
@@ -3384,7 +3548,10 @@ void DetectSystemCompilerIncludePaths(std::vector<std::string>& Paths,
   exec(cmd.c_str(), Paths);
 }
 
-void AddIncludePath(const char* dir) { getInterp().AddIncludePath(dir); }
+void AddIncludePath(const char* dir) {
+  LOCK(getInterpInfo());
+  getInterp().AddIncludePath(dir);
+}
 
 void GetIncludePaths(std::vector<std::string>& IncludePaths, bool withSystem,
                      bool withFlags) {
@@ -3421,10 +3588,14 @@ int Declare(compat::Interpreter& I, const char* code, bool silent) {
 }
 
 int Declare(const char* code, bool silent) {
+  LOCK(getInterpInfo());
   return Declare(getInterp(), code, silent);
 }
 
-int Process(const char* code) { return getInterp().process(code); }
+int Process(const char* code) {
+  LOCK(getInterpInfo());
+  return getInterp().process(code);
+}
 
 intptr_t Evaluate(const char* code, bool* HadError /*=nullptr*/) {
 #ifdef CPPINTEROP_USE_CLING
@@ -3436,6 +3607,7 @@ intptr_t Evaluate(const char* code, bool* HadError /*=nullptr*/) {
   if (HadError)
     *HadError = false;
 
+  LOCK(getInterpInfo());
   auto res = getInterp().evaluate(code, V);
   if (res != 0) { // 0 is success
     if (HadError)
@@ -3452,6 +3624,7 @@ std::string LookupLibrary(const char* lib_name) {
 }
 
 bool LoadLibrary(const char* lib_stem, bool lookup) {
+  LOCK(getInterpInfo());
   compat::Interpreter::CompilationResult res =
       getInterp().loadLibrary(lib_stem, lookup);
 
@@ -3459,11 +3632,13 @@ bool LoadLibrary(const char* lib_stem, bool lookup) {
 }
 
 void UnloadLibrary(const char* lib_stem) {
+  LOCK(getInterpInfo());
   getInterp().getDynamicLibraryManager()->unloadLibrary(lib_stem);
 }
 
 std::string SearchLibrariesForSymbol(const char* mangled_name,
                                      bool search_system /*true*/) {
+  LOCK(getInterpInfo());
   auto* DLM = getInterp().getDynamicLibraryManager();
   return DLM->searchLibrariesForSymbol(mangled_name, search_system);
 }
@@ -3549,16 +3724,20 @@ bool InsertOrReplaceJitSymbol(compat::Interpreter& I,
 
 bool InsertOrReplaceJitSymbol(const char* linker_mangled_name,
                               uint64_t address) {
+  LOCK(getInterpInfo());
   return InsertOrReplaceJitSymbol(getInterp(), linker_mangled_name, address);
 }
 
 std::string ObjToString(const char* type, void* obj) {
-  return getInterp().toString(type, obj);
+  LOCK(getInterpInfo(NULLPTR)); // FIXME: not enough information to lock the
+                                // current interpreter
+  return getInterp(NULLPTR).toString(type, obj);
 }
 
-static Decl* InstantiateTemplate(TemplateDecl* TemplateD,
-                                 TemplateArgumentListInfo& TLI, Sema& S,
-                                 bool instantiate_body) {
+Decl* InstantiateTemplate(TemplateDecl* TemplateD,
+                          TemplateArgumentListInfo& TLI, Sema& S,
+                          bool instantiate_body) {
+  LOCK(getInterpInfo());
   // This is not right but we don't have a lot of options to choose from as a
   // template instantiation requires a valid source location.
   SourceLocation fakeLoc = GetValidSLoc(S);
@@ -3653,13 +3832,16 @@ TCppScope_t InstantiateTemplate(TCppScope_t tmpl,
                                 const TemplateArgInfo* template_args,
                                 size_t template_args_size,
                                 bool instantiate_body) {
-  return InstantiateTemplate(getInterp(), tmpl, template_args,
+  auto* D = static_cast<Decl*>(tmpl);
+  LOCK(getInterpInfo(D));
+  return InstantiateTemplate(getInterp(D), tmpl, template_args,
                              template_args_size, instantiate_body);
 }
 
 void GetClassTemplateInstantiationArgs(TCppScope_t templ_instance,
                                        std::vector<TemplateArgInfo>& args) {
   auto* CTSD = static_cast<ClassTemplateSpecializationDecl*>(templ_instance);
+  LOCK(getInterpInfo(CTSD));
   for (const auto& TA : CTSD->getTemplateInstantiationArgs().asArray()) {
     switch (TA.getKind()) {
     default:
@@ -3691,6 +3873,7 @@ InstantiateTemplateFunctionFromString(const char* function_template) {
   std::string id = "__Cppyy_GetMethTmpl_" + std::to_string(var_count++);
   std::string instance = "auto " + id + " = " + function_template + ";\n";
 
+  LOCK(getInterpInfo());
   if (!Cpp::Declare(instance.c_str(), /*silent=*/false)) {
     VarDecl* VD = (VarDecl*)Cpp::GetNamed(id, 0);
     DeclRefExpr* DRE = (DeclRefExpr*)VD->getInit()->IgnoreImpCasts();
@@ -3704,6 +3887,7 @@ void GetAllCppNames(TCppScope_t scope, std::set<std::string>& names) {
   clang::DeclContext* DC;
   clang::DeclContext::decl_iterator decl;
 
+  LOCK(getInterpInfo(D));
   if (auto* TD = dyn_cast_or_null<TagDecl>(D)) {
     DC = clang::TagDecl::castToDeclContext(TD);
     decl = DC->decls_begin();
@@ -3733,6 +3917,7 @@ void GetEnums(TCppScope_t scope, std::vector<std::string>& Result) {
 
   auto* DC = llvm::dyn_cast<clang::DeclContext>(D);
 
+  LOCK(getInterpInfo(D));
   llvm::SmallVector<clang::DeclContext*, 4> DCs;
   DC->collectAllContexts(DCs);
 
@@ -3775,13 +3960,15 @@ std::vector<long int> GetDimensions(TCppType_t type) {
 }
 
 bool IsTypeDerivedFrom(TCppType_t derived, TCppType_t base) {
-  auto& S = getSema();
-  auto fakeLoc = GetValidSLoc(S);
   auto derivedType = clang::QualType::getFromOpaquePtr(derived);
   auto baseType = clang::QualType::getFromOpaquePtr(base);
+  auto* CXXRD = baseType->getAsRecordDecl();
+  LOCK(getInterpInfo(CXXRD));
+  auto& S = getSema(CXXRD);
+  auto fakeLoc = GetValidSLoc(S);
 
 #ifdef CPPINTEROP_USE_CLING
-  cling::Interpreter::PushTransactionRAII RAII(&getInterp());
+  cling::Interpreter::PushTransactionRAII RAII(&getInterp(CXXRD));
 #endif
   return S.IsDerivedFrom(fakeLoc, derivedType, baseType);
 }
@@ -3791,6 +3978,7 @@ std::string GetFunctionArgDefault(TCppFunction_t func,
   auto* D = (clang::Decl*)func;
   clang::ParmVarDecl* PI = nullptr;
 
+  LOCK(getInterpInfo(D));
   if (auto* FD = llvm::dyn_cast_or_null<clang::FunctionDecl>(D))
     PI = FD->getParamDecl(param_index);
 
@@ -3886,6 +4074,7 @@ OperatorArity GetOperatorArity(TCppFunction_t op) {
 void GetOperator(TCppScope_t scope, Operator op,
                  std::vector<TCppFunction_t>& operators, OperatorArity kind) {
   Decl* D = static_cast<Decl*>(scope);
+  LOCK(getInterpInfo(D));
   if (auto* CXXRD = llvm::dyn_cast_or_null<CXXRecordDecl>(D)) {
     auto fn = [&operators, kind, op](const RecordDecl* RD) {
       ASTContext& C = RD->getASTContext();
@@ -3901,7 +4090,7 @@ void GetOperator(TCppScope_t scope, Operator op,
     fn(CXXRD);
     CXXRD->forallBases(fn);
   } else if (auto* DC = llvm::dyn_cast_or_null<DeclContext>(D)) {
-    ASTContext& C = getSema().getASTContext();
+    ASTContext& C = getSema(D).getASTContext();
     DeclContextLookupResult Result =
         DC->lookup(C.DeclarationNames.getCXXOperatorName(
             (clang::OverloadedOperatorKind)op));
@@ -3950,7 +4139,8 @@ TCppObject_t Construct(compat::Interpreter& interp, TCppScope_t scope,
 
 TCppObject_t Construct(TCppScope_t scope, void* arena /*=nullptr*/,
                        TCppIndex_t count /*=1UL*/) {
-  return Construct(getInterp(), scope, arena, count);
+  auto* D = static_cast<clang::Decl*>(scope);
+  return Construct(getInterp(D), scope, arena, count);
 }
 
 bool Destruct(compat::Interpreter& interp, TCppObject_t This, const Decl* Class,
@@ -3966,7 +4156,7 @@ bool Destruct(compat::Interpreter& interp, TCppObject_t This, const Decl* Class,
 bool Destruct(TCppObject_t This, TCppConstScope_t scope,
               bool withFree /*=true*/, TCppIndex_t count /*=0UL*/) {
   const auto* Class = static_cast<const Decl*>(scope);
-  return Destruct(getInterp(), This, Class, withFree, count);
+  return Destruct(getInterp(Class), This, Class, withFree, count);
 }
 
 class StreamCaptureInfo {
@@ -4070,7 +4260,9 @@ std::string EndStdStreamCapture() {
 void CodeComplete(std::vector<std::string>& Results, const char* code,
                   unsigned complete_line /* = 1U */,
                   unsigned complete_column /* = 1U */) {
-  compat::codeComplete(Results, getInterp(), code, complete_line,
+  LOCK(getInterpInfo(NULLPTR)); // FIXME: Not enough info to lock the current
+                                // interpreter
+  compat::codeComplete(Results, getInterp(NULLPTR), code, complete_line,
                        complete_column);
 }
 

--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -3459,6 +3459,8 @@ static inline auto find_interpreter_in_map(InterpreterInfo* I) {
 bool DeleteInterpreter(TInterp_t I /*=nullptr*/) {
   std::lock_guard<std::recursive_mutex> Lock(InterpreterStackLock);
   assert(sInterpreters->size() == sInterpreterASTMap->size());
+  if (sInterpreters->empty())
+    return false;
 
   if (!I) {
     auto foundAST = find_interpreter_in_map(sInterpreters->back().get());

--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -100,6 +100,8 @@ using namespace std;
   std::lock_guard<std::recursive_mutex> interop_lock(                          \
       (InterpInfo).InterpreterLock)
 
+#define NULLPTR (static_cast<void*>(nullptr))
+
 struct InterpreterInfo {
   compat::Interpreter* Interpreter = nullptr;
   bool isOwned = true;
@@ -150,27 +152,21 @@ static std::recursive_mutex InterpreterStackLock;
 static std::recursive_mutex LLVMLock;
 // NOLINTEND(cppcoreguidelines-avoid-non-const-global-variables)
 
-static InterpreterInfo& getInterpInfo() {
-  std::lock_guard<std::recursive_mutex> Lock(InterpreterStackLock);
-  assert(!sInterpreters->empty() &&
-         "Interpreter instance must be set before calling this!");
-  return *sInterpreters->back();
-}
 static InterpreterInfo& getInterpInfo(const clang::Decl* D) {
   std::lock_guard<std::recursive_mutex> Lock(InterpreterStackLock);
   if (!D)
-    return getInterpInfo();
+    return *sInterpreters->back();
   if (sInterpreters->size() == 1)
     return *sInterpreters->back();
   return *(*sInterpreterASTMap)[&D->getASTContext()];
 }
 static InterpreterInfo& getInterpInfo(const void* D) {
   std::lock_guard<std::recursive_mutex> Lock(InterpreterStackLock);
+  if (!D)
+    return *sInterpreters->back();
   QualType QT = QualType::getFromOpaquePtr(D);
   if (auto* D = QT->getAsTagDecl())
     return getInterpInfo(D);
-  if (!D)
-    return getInterpInfo();
   if (sInterpreters->size() == 1)
     return *sInterpreters->back();
   for (auto& item : *sInterpreterASTMap) {
@@ -180,17 +176,22 @@ static InterpreterInfo& getInterpInfo(const void* D) {
   llvm_unreachable(
       "This pointer does not belong to any interpreter instance.\n");
 }
-
-static compat::Interpreter& getInterp() {
+static InterpreterInfo& getInterpInfo(compat::Interpreter* I) {
   std::lock_guard<std::recursive_mutex> Lock(InterpreterStackLock);
-  assert(!sInterpreters->empty() &&
-         "Interpreter instance must be set before calling this!");
-  return *sInterpreters->back()->Interpreter;
+  if (!I)
+    return *sInterpreters->back();
+  auto res =
+      std::find_if(sInterpreters->begin(), sInterpreters->end(),
+                   [&](const auto& item) { return item->Interpreter == I; });
+  if (res != sInterpreters->end())
+    return **res;
+  llvm_unreachable("Invalid State");
 }
+
 static compat::Interpreter& getInterp(const clang::Decl* D) {
   std::lock_guard<std::recursive_mutex> Lock(InterpreterStackLock);
   if (!D)
-    return getInterp();
+    return *getInterpInfo(NULLPTR).Interpreter;
   if (sInterpreters->size() == 1)
     return *sInterpreters->back()->Interpreter;
   return *(*sInterpreterASTMap)[&D->getASTContext()]->Interpreter;
@@ -199,18 +200,12 @@ static compat::Interpreter& getInterp(const void* D) {
   return *getInterpInfo(D).Interpreter;
 }
 
-static clang::Sema& getSema() { return getInterp().getCI()->getSema(); }
 static clang::Sema& getSema(const clang::Decl* D) {
-  if (!D)
-    return getSema();
   return getInterpInfo(D).Interpreter->getSema();
 }
 static clang::Sema& getSema(const void* D) { return getInterp(D).getSema(); }
 
-static clang::ASTContext& getASTContext() { return getSema().getASTContext(); }
 static clang::ASTContext& getASTContext(const clang::Decl* D) {
-  if (!D)
-    return getASTContext();
   return getSema(D).getASTContext();
 }
 static clang::ASTContext& getASTContext(const void* D) {
@@ -741,8 +736,18 @@ std::vector<TCppScope_t> GetUsingNamespaces(TCppScope_t scope) {
   return {};
 }
 
-TCppScope_t GetGlobalScope() {
-  return getSema().getASTContext().getTranslationUnitDecl()->getFirstDecl();
+TCppScope_t GetGlobalScope(TInterp_t interp) {
+  if (interp) {
+    auto* I = static_cast<compat::Interpreter*>(interp);
+    return I->getSema()
+        .getASTContext()
+        .getTranslationUnitDecl()
+        ->getFirstDecl();
+  }
+  return getSema(NULLPTR)
+      .getASTContext()
+      .getTranslationUnitDecl()
+      ->getFirstDecl();
 }
 
 static Decl* GetScopeFromType(QualType QT) {
@@ -781,15 +786,16 @@ TCppScope_t GetUnderlyingScope(TCppScope_t scope) {
   return GetUnderlyingScope((clang::Decl*)scope);
 }
 
-TCppScope_t GetScope(const std::string& name, TCppScope_t parent) {
+TCppScope_t GetScope(const std::string& name, TCppScope_t parent,
+                     TInterp_t interp) {
   // FIXME: GetScope should be replaced by a general purpose lookup
   // and filter function. The function should be like GetNamed but
   // also take in a filter parameter which determines which results
   // to pass back
   if (name == "")
-    return GetGlobalScope();
+    return GetGlobalScope(interp);
 
-  auto* ND = (NamedDecl*)GetNamed(name, parent);
+  auto* ND = static_cast<NamedDecl*>(GetNamed(name, parent, interp));
 
   if (!ND || ND == (NamedDecl*)-1)
     return 0;
@@ -802,28 +808,30 @@ TCppScope_t GetScope(const std::string& name, TCppScope_t parent) {
   return 0;
 }
 
-TCppScope_t GetScopeFromCompleteName(const std::string& name) {
+TCppScope_t GetScopeFromCompleteName(const std::string& name,
+                                     TInterp_t interp) {
   std::string delim = "::";
   size_t start = 0;
   size_t end = name.find(delim);
   TCppScope_t curr_scope = 0;
   while (end != std::string::npos) {
-    curr_scope = GetScope(name.substr(start, end - start), curr_scope);
+    curr_scope = GetScope(name.substr(start, end - start), curr_scope, interp);
     start = end + delim.length();
     end = name.find(delim, start);
   }
-  return GetScope(name.substr(start, end), curr_scope);
+  return GetScope(name.substr(start, end), curr_scope, interp);
 }
 
-TCppScope_t GetNamed(const std::string& name,
-                     TCppScope_t parent /*= nullptr*/) {
-  clang::DeclContext* Within = 0;
+TCppScope_t GetNamed(const std::string& name, TCppScope_t parent /*= nullptr*/,
+                     TInterp_t interp /*= nullptr*/) {
+  if (!parent)
+    parent = GetGlobalScope(interp);
+
   auto* D = static_cast<clang::Decl*>(parent);
   LOCK(getInterpInfo(D));
-  if (parent) {
-    D = GetUnderlyingScope(D);
-    Within = llvm::dyn_cast<clang::DeclContext>(D);
-  }
+
+  D = GetUnderlyingScope(D);
+  auto* Within = llvm::dyn_cast<clang::DeclContext>(D);
 
   auto* ND = Cpp_utils::Lookup::Named(&getSema(D), name, Within);
   if (ND && ND != (clang::NamedDecl*)-1) {
@@ -1239,13 +1247,13 @@ bool IsTemplatedFunction(TCppFunction_t func) {
 // FIXME: This lookup is broken, and should no longer be used in favour of
 // `GetClassTemplatedMethods` If the candidate set returned is =1, that means
 // the template function exists and >1 means overloads
-bool ExistsFunctionTemplate(const std::string& name, TCppScope_t parent) {
-  DeclContext* Within = 0;
-  auto* D = static_cast<Decl*>(parent);
-  if (parent) {
-    Within = llvm::dyn_cast<DeclContext>(D);
-  }
+bool ExistsFunctionTemplate(const std::string& name, TCppScope_t parent,
+                            TInterp_t interp) {
+  if (!parent)
+    parent = GetGlobalScope(interp);
 
+  auto* D = static_cast<Decl*>(parent);
+  auto* Within = llvm::dyn_cast<DeclContext>(D);
   LOCK(getInterpInfo(D));
 
   auto* ND = Cpp_utils::Lookup::Named(&getSema(D), name, Within);
@@ -1464,9 +1472,12 @@ bool IsStaticMethod(TCppConstFunction_t method) {
   return false;
 }
 
-TCppFuncAddr_t GetFunctionAddress(const char* mangled_name) {
-  auto& I = getInterp();
-  auto FDAorErr = compat::getSymbolAddress(I, mangled_name);
+TCppFuncAddr_t GetFunctionAddress(const char* mangled_name,
+                                  TInterp_t interp /*=nullptr*/) {
+  auto* I = static_cast<compat::Interpreter*>(interp);
+  if (!I)
+    I = &getInterp(NULLPTR);
+  auto FDAorErr = compat::getSymbolAddress(*I, mangled_name);
   if (llvm::Error Err = FDAorErr.takeError())
     llvm::consumeError(std::move(Err)); // nullptr if missing
   else
@@ -1509,9 +1520,9 @@ TCppFuncAddr_t GetFunctionAddress(TCppFunction_t method) {
          FD->getTemplatedKind() == FunctionDecl::TK_MemberSpecialization) &&
         !FD->getDefinition())
       InstantiateFunctionDefinition(D);
-    ASTContext& C = getASTContext();
+    ASTContext& C = getASTContext(FD);
     if (isDiscardableGVALinkage(C.GetGVALinkageForFunction(FD)))
-      ForceCodeGen(FD, getInterp());
+      ForceCodeGen(FD, getInterp(FD));
     return GetFunctionAddress(FD);
   }
   return nullptr;
@@ -1837,7 +1848,7 @@ bool IsRValueReferenceType(TCppType_t type) {
 
 TCppType_t GetPointerType(TCppType_t type) {
   QualType QT = QualType::getFromOpaquePtr(type);
-  return getASTContext()
+  return getASTContext(type)
       .getPointerType(QT)
       .getAsOpaquePtr(); // FIXME: which ASTContext?
 }
@@ -2012,13 +2023,18 @@ static QualType findBuiltinType(llvm::StringRef typeName, ASTContext& Context) {
 }
 } // namespace
 
-TCppType_t GetType(const std::string& name) {
-  QualType builtin = findBuiltinType(name, getASTContext());
+TCppType_t GetType(const std::string& name, TInterp_t interp) {
+  auto* I = static_cast<compat::Interpreter*>(interp);
+  QualType builtin;
+  if (I)
+    builtin = findBuiltinType(name, I->getSema().getASTContext());
+  else
+    builtin =
+        findBuiltinType(name, getInterp(NULLPTR).getSema().getASTContext());
   if (!builtin.isNull())
     return builtin.getAsOpaquePtr();
 
-  LOCK(getInterpInfo());
-  auto* D = (Decl*)GetNamed(name, /* Within= */ 0);
+  auto* D = static_cast<Decl*>(GetNamed(name, /*parent=*/nullptr, interp));
   if (auto* TD = llvm::dyn_cast_or_null<TypeDecl>(D)) {
     return QualType(TD->getTypeForDecl(), 0).getAsOpaquePtr();
   }
@@ -3523,13 +3539,22 @@ void UseExternalInterpreter(TInterp_t I) {
   assert(sInterpreters->size() == sInterpreterASTMap->size());
 }
 
-void AddSearchPath(const char* dir, bool isUser, bool prepend) {
-  LOCK(getInterpInfo());
-  getInterp().getDynamicLibraryManager()->addSearchPath(dir, isUser, prepend);
+void AddSearchPath(const char* dir, bool isUser, bool prepend,
+                   TInterp_t I /*=nullptr*/) {
+  auto* interp = static_cast<compat::Interpreter*>(I);
+  LOCK(getInterpInfo(interp));
+  if (interp)
+    interp->getDynamicLibraryManager()->addSearchPath(dir, isUser, prepend);
+  else
+    getInterp(NULLPTR).getDynamicLibraryManager()->addSearchPath(dir, isUser,
+                                                                 prepend);
 }
 
-const char* GetResourceDir() {
-  return getInterp().getCI()->getHeaderSearchOpts().ResourceDir.c_str();
+const char* GetResourceDir(TInterp_t I /*=nullptr*/) {
+  auto* interp = static_cast<compat::Interpreter*>(I);
+  if (interp)
+    return interp->getCI()->getHeaderSearchOpts().ResourceDir.c_str();
+  return getInterp(NULLPTR).getCI()->getHeaderSearchOpts().ResourceDir.c_str();
 }
 
 ///\returns 0 on success.
@@ -3588,15 +3613,23 @@ void DetectSystemCompilerIncludePaths(std::vector<std::string>& Paths,
   exec(cmd.c_str(), Paths);
 }
 
-void AddIncludePath(const char* dir) {
-  LOCK(getInterpInfo());
-  getInterp().AddIncludePath(dir);
+void AddIncludePath(const char* dir, TInterp_t I /*=nullptr*/) {
+  auto* interp = static_cast<compat::Interpreter*>(I);
+  LOCK(getInterpInfo(interp));
+  if (interp)
+    interp->AddIncludePath(dir);
+  else
+    getInterp(NULLPTR).AddIncludePath(dir);
 }
 
 void GetIncludePaths(std::vector<std::string>& IncludePaths, bool withSystem,
-                     bool withFlags) {
+                     bool withFlags, TInterp_t I /*=nullptr*/) {
   llvm::SmallVector<std::string> paths(1);
-  getInterp().GetIncludePaths(paths, withSystem, withFlags);
+  auto* interp = static_cast<compat::Interpreter*>(I);
+  if (interp)
+    interp->GetIncludePaths(paths, withSystem, withFlags);
+  else
+    getInterp(NULLPTR).GetIncludePaths(paths, withSystem, withFlags);
   for (auto& i : paths)
     IncludePaths.push_back(i);
 }
@@ -3627,17 +3660,24 @@ int Declare(compat::Interpreter& I, const char* code, bool silent) {
   return I.declare(code);
 }
 
-int Declare(const char* code, bool silent) {
-  LOCK(getInterpInfo());
-  return Declare(getInterp(), code, silent);
+int Declare(const char* code, bool silent, TInterp_t I /*=nullptr*/) {
+  auto* interp = static_cast<compat::Interpreter*>(I);
+  LOCK(getInterpInfo(interp));
+  if (interp)
+    return Declare(*interp, code, silent);
+  return Declare(getInterp(NULLPTR), code, silent);
 }
 
-int Process(const char* code) {
-  LOCK(getInterpInfo());
-  return getInterp().process(code);
+int Process(const char* code, TInterp_t I /*=nullptr*/) {
+  auto* interp = static_cast<compat::Interpreter*>(I);
+  LOCK(getInterpInfo(interp));
+  if (interp)
+    return interp->process(code);
+  return getInterp(NULLPTR).process(code);
 }
 
-intptr_t Evaluate(const char* code, bool* HadError /*=nullptr*/) {
+intptr_t Evaluate(const char* code, bool* HadError /*=nullptr*/,
+                  TInterp_t I /*=nullptr*/) {
 #ifdef CPPINTEROP_USE_CLING
   cling::Value V;
 #else
@@ -3647,8 +3687,14 @@ intptr_t Evaluate(const char* code, bool* HadError /*=nullptr*/) {
   if (HadError)
     *HadError = false;
 
-  LOCK(getInterpInfo());
-  auto res = getInterp().evaluate(code, V);
+  auto* interp = static_cast<compat::Interpreter*>(I);
+  compat::Interpreter::CompilationResult res;
+  LOCK(getInterpInfo(interp));
+  if (interp)
+    res = interp->evaluate(code, V);
+  else
+    res = getInterp(NULLPTR).evaluate(code, V);
+
   if (res != 0) { // 0 is success
     if (HadError)
       *HadError = true;
@@ -3659,27 +3705,42 @@ intptr_t Evaluate(const char* code, bool* HadError /*=nullptr*/) {
   return compat::convertTo<intptr_t>(V);
 }
 
-std::string LookupLibrary(const char* lib_name) {
-  return getInterp().getDynamicLibraryManager()->lookupLibrary(lib_name);
+std::string LookupLibrary(const char* lib_name, TInterp_t I /*=nullptr*/) {
+  auto* interp = static_cast<compat::Interpreter*>(I);
+  if (interp)
+    return interp->getDynamicLibraryManager()->lookupLibrary(lib_name);
+  return getInterp(NULLPTR).getDynamicLibraryManager()->lookupLibrary(lib_name);
 }
 
-bool LoadLibrary(const char* lib_stem, bool lookup) {
-  LOCK(getInterpInfo());
-  compat::Interpreter::CompilationResult res =
-      getInterp().loadLibrary(lib_stem, lookup);
+bool LoadLibrary(const char* lib_stem, bool lookup, TInterp_t I /*=nullptr*/) {
+  auto* interp = static_cast<compat::Interpreter*>(I);
+  LOCK(getInterpInfo(interp));
+  compat::Interpreter::CompilationResult res;
+  if (interp)
+    res = interp->loadLibrary(lib_stem, lookup);
+  else
+    res = getInterp(NULLPTR).loadLibrary(lib_stem, lookup);
 
   return res == compat::Interpreter::kSuccess;
 }
 
-void UnloadLibrary(const char* lib_stem) {
-  LOCK(getInterpInfo());
-  getInterp().getDynamicLibraryManager()->unloadLibrary(lib_stem);
+void UnloadLibrary(const char* lib_stem, TInterp_t I /*=nullptr*/) {
+  auto* interp = static_cast<compat::Interpreter*>(I);
+  LOCK(getInterpInfo(interp));
+  if (interp)
+    interp->getDynamicLibraryManager()->unloadLibrary(lib_stem);
+  else
+    getInterp(NULLPTR).getDynamicLibraryManager()->unloadLibrary(lib_stem);
 }
 
 std::string SearchLibrariesForSymbol(const char* mangled_name,
-                                     bool search_system /*true*/) {
-  LOCK(getInterpInfo());
-  auto* DLM = getInterp().getDynamicLibraryManager();
+                                     bool search_system /*true*/,
+                                     TInterp_t I /*=nullptr*/) {
+  auto* interp = static_cast<compat::Interpreter*>(I);
+  LOCK(getInterpInfo(interp));
+  if (!interp)
+    interp = &getInterp(NULLPTR);
+  auto* DLM = interp->getDynamicLibraryManager();
   return DLM->searchLibrariesForSymbol(mangled_name, search_system);
 }
 
@@ -3762,10 +3823,14 @@ bool InsertOrReplaceJitSymbol(compat::Interpreter& I,
   return false;
 }
 
-bool InsertOrReplaceJitSymbol(const char* linker_mangled_name,
-                              uint64_t address) {
-  LOCK(getInterpInfo());
-  return InsertOrReplaceJitSymbol(getInterp(), linker_mangled_name, address);
+bool InsertOrReplaceJitSymbol(const char* linker_mangled_name, uint64_t address,
+                              TInterp_t I /*=nullptr*/) {
+  auto* interp = static_cast<compat::Interpreter*>(I);
+  LOCK(getInterpInfo(interp));
+  if (interp)
+    return InsertOrReplaceJitSymbol(*interp, linker_mangled_name, address);
+  return InsertOrReplaceJitSymbol(getInterp(NULLPTR), linker_mangled_name,
+                                  address);
 }
 
 std::string ObjToString(const char* type, void* obj) {
@@ -3777,7 +3842,6 @@ std::string ObjToString(const char* type, void* obj) {
 static Decl* InstantiateTemplate(TemplateDecl* TemplateD,
                                  TemplateArgumentListInfo& TLI, Sema& S,
                                  bool instantiate_body) {
-  LOCK(getInterpInfo());
   // This is not right but we don't have a lot of options to choose from as a
   // template instantiation requires a valid source location.
   SourceLocation fakeLoc = GetValidSLoc(S);
@@ -3904,7 +3968,8 @@ void GetClassTemplateInstantiationArgs(TCppScope_t templ_instance,
 }
 
 TCppFunction_t
-InstantiateTemplateFunctionFromString(const char* function_template) {
+InstantiateTemplateFunctionFromString(const char* function_template,
+                                      TInterp_t interp /*=nullptr*/) {
   // FIXME: Drop this interface and replace it with the proper overload
   // resolution handling and template instantiation selection.
 
@@ -3913,11 +3978,13 @@ InstantiateTemplateFunctionFromString(const char* function_template) {
   std::string id = "__Cppyy_GetMethTmpl_" + std::to_string(var_count++);
   std::string instance = "auto " + id + " = " + function_template + ";\n";
 
-  LOCK(getInterpInfo());
-  if (!Cpp::Declare(instance.c_str(), /*silent=*/false)) {
-    VarDecl* VD = (VarDecl*)Cpp::GetNamed(id, 0);
-    DeclRefExpr* DRE = (DeclRefExpr*)VD->getInit()->IgnoreImpCasts();
-    return DRE->getDecl();
+  auto* I = static_cast<compat::Interpreter*>(interp);
+  LOCK(getInterpInfo(I));
+  if (!Cpp::Declare(instance.c_str(), /*silent=*/false, interp)) {
+    auto* VD = static_cast<VarDecl*>(Cpp::GetNamed(id, nullptr, interp));
+    Expr* E = VD->getInit()->IgnoreImpCasts();
+    if (auto* DRE = llvm::dyn_cast<DeclRefExpr>(E))
+      return DRE->getDecl();
   }
   return nullptr;
 }
@@ -4306,14 +4373,16 @@ void CodeComplete(std::vector<std::string>& Results, const char* code,
                        complete_column);
 }
 
-int Undo(unsigned N) {
+int Undo(unsigned N, TInterp_t interp) {
+  auto* I = static_cast<compat::Interpreter*>(interp);
+  if (!I)
+    I = &getInterp(NULLPTR);
 #ifdef CPPINTEROP_USE_CLING
-  auto& I = getInterp();
-  cling::Interpreter::PushTransactionRAII RAII(&I);
-  I.unload(N);
+  cling::Interpreter::PushTransactionRAII RAII(I);
+  I->unload(N);
   return compat::Interpreter::kSuccess;
 #else
-  return getInterp().undo(N);
+  return I->undo(N);
 #endif
 }
 

--- a/lib/CppInterOp/CppInterOpInterpreter.h
+++ b/lib/CppInterOp/CppInterOpInterpreter.h
@@ -140,12 +140,11 @@ namespace Cpp {
 /// CppInterOp Interpreter
 ///
 class Interpreter {
-private:
   std::unique_ptr<clang::Interpreter> inner;
 
+public:
   Interpreter(std::unique_ptr<clang::Interpreter> CI) : inner(std::move(CI)) {}
 
-public:
   static std::unique_ptr<Interpreter>
   create(int argc, const char* const* argv, const char* llvmdir = nullptr,
          const std::vector<std::shared_ptr<clang::ModuleFileExtension>>&

--- a/unittests/CppInterOp/CMakeLists.txt
+++ b/unittests/CppInterOp/CMakeLists.txt
@@ -128,6 +128,8 @@ set_output_directory(DynamicLibraryManagerTests
 )
 
 add_dependencies(DynamicLibraryManagerTests TestSharedLib)
+add_dependencies(DynamicLibraryManagerTests TestSharedLib2)
 
 #export_executable_symbols_for_plugins(TestSharedLib)
 add_subdirectory(TestSharedLib)
+add_subdirectory(TestSharedLib2)

--- a/unittests/CppInterOp/DynamicLibraryManagerTest.cpp
+++ b/unittests/CppInterOp/DynamicLibraryManagerTest.cpp
@@ -19,7 +19,7 @@ std::string GetExecutablePath(const char* Argv0) {
   return llvm::sys::fs::getMainExecutable(Argv0, MainAddr);
 }
 
-TEST(DynamicLibraryManagerTest, Sanity) {
+TEST(DynamicLibraryManagerTest, Sanity1) {
 #ifdef EMSCRIPTEN
   GTEST_SKIP() << "Test fails for Emscipten builds";
 #endif
@@ -60,6 +60,55 @@ TEST(DynamicLibraryManagerTest, Sanity) {
 #endif //__APPLE__
 
   Cpp::UnloadLibrary("TestSharedLib");
+  // We have no reliable way to check if it was unloaded because posix does not
+  // require the library to be actually unloaded but just the handle to be
+  // invalidated...
+  // EXPECT_FALSE(Cpp::GetFunctionAddress("ret_zero"));
+}
+
+TEST(DynamicLibraryManagerTest, Sanity2) {
+#ifdef EMSCRIPTEN
+  GTEST_SKIP() << "Test fails for Emscipten builds";
+#endif
+
+#if CLANG_VERSION_MAJOR == 18 && defined(CPPINTEROP_USE_CLING) &&              \
+    defined(_WIN32)
+  GTEST_SKIP() << "Test fails with Cling on Windows";
+#endif
+
+  auto* I = Cpp::CreateInterpreter();
+  EXPECT_TRUE(I);
+  EXPECT_FALSE(Cpp::GetFunctionAddress("ret_one", I));
+
+  std::string BinaryPath = GetExecutablePath(/*Argv0=*/nullptr);
+  llvm::StringRef Dir = llvm::sys::path::parent_path(BinaryPath);
+  Cpp::AddSearchPath(Dir.str().c_str(), true, false, I);
+
+  // FIXME: dlsym on mach-o takes the C-level name, however, the macho-o format
+  // adds an additional underscore (_) prefix to the lowered names. Figure out
+  // how to harmonize that API.
+#ifdef __APPLE__
+  std::string PathToTestSharedLib =
+      Cpp::SearchLibrariesForSymbol("_ret_one", /*system_search=*/false, I);
+#else
+  std::string PathToTestSharedLib =
+      Cpp::SearchLibrariesForSymbol("ret_one", /*system_search=*/false, I);
+#endif // __APPLE__
+
+  EXPECT_STRNE("", PathToTestSharedLib.c_str())
+      << "Cannot find: '" << PathToTestSharedLib << "' in '" << Dir.str()
+      << "'";
+
+  EXPECT_TRUE(Cpp::LoadLibrary(PathToTestSharedLib.c_str(), true, I));
+  // Force ExecutionEngine to be created.
+  Cpp::Process("", I);
+  Cpp::Declare("", I);
+  // FIXME: Conda returns false to run this code on osx.
+#ifndef __APPLE__
+  EXPECT_TRUE(Cpp::GetFunctionAddress("ret_one", I));
+#endif //__APPLE__
+
+  Cpp::UnloadLibrary("TestSharedLib2", I);
   // We have no reliable way to check if it was unloaded because posix does not
   // require the library to be actually unloaded but just the handle to be
   // invalidated...

--- a/unittests/CppInterOp/FunctionReflectionTest.cpp
+++ b/unittests/CppInterOp/FunctionReflectionTest.cpp
@@ -1014,6 +1014,8 @@ TEST(FunctionReflectionTest, BestOverloadFunctionMatch1) {
   GetAllTopLevelDecls(code, Decls);
   std::vector<Cpp::TCppFunction_t> candidates;
 
+  EXPECT_FALSE(Cpp::BestOverloadFunctionMatch({}, {}, {}));
+
   for (auto decl : Decls)
     if (Cpp::IsTemplatedFunction(decl)) candidates.push_back((Cpp::TCppFunction_t)decl);
 

--- a/unittests/CppInterOp/InterpreterTest.cpp
+++ b/unittests/CppInterOp/InterpreterTest.cpp
@@ -361,3 +361,26 @@ if (llvm::sys::RunningOnValgrind())
   delete ExtInterp;
 #endif
 }
+
+TEST(InterpreterTest, MultipleInterpreter) {
+#if CLANG_VERSION_MAJOR < 20 && defined(EMSCRIPTEN)
+  GTEST_SKIP() << "Test fails for Emscipten LLVM 20 builds";
+#endif
+
+  EXPECT_TRUE(Cpp::CreateInterpreter());
+  Cpp::Declare(R"(
+  void f() {}
+  )");
+  Cpp::TCppScope_t f = Cpp::GetNamed("f");
+
+  EXPECT_TRUE(Cpp::CreateInterpreter());
+  Cpp::Declare(R"(
+  void ff() {}
+  )");
+  Cpp::TCppScope_t ff = Cpp::GetNamed("ff");
+
+  auto f_callable = Cpp::MakeFunctionCallable(f);
+  EXPECT_EQ(f_callable.getKind(), Cpp::JitCall::Kind::kGenericCall);
+  auto ff_callable = Cpp::MakeFunctionCallable(ff);
+  EXPECT_EQ(ff_callable.getKind(), Cpp::JitCall::Kind::kGenericCall);
+}

--- a/unittests/CppInterOp/TestSharedLib2/CMakeLists.txt
+++ b/unittests/CppInterOp/TestSharedLib2/CMakeLists.txt
@@ -1,0 +1,23 @@
+add_llvm_library(TestSharedLib2
+  SHARED
+  DISABLE_LLVM_LINK_LLVM_DYLIB
+  BUILDTREE_ONLY
+  TestSharedLib.cpp)
+# Put TestSharedLib2 next to the unit test executable.
+set_output_directory(TestSharedLib2
+  BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/../TestSharedLib/unittests/bin/$<CONFIG>/
+  LIBRARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/../TestSharedLib/unittests/bin/$<CONFIG>/
+  )
+
+
+if (EMSCRIPTEN)
+  set_target_properties(TestSharedLib2
+    PROPERTIES NO_SONAME 1
+  )
+  target_link_options(TestSharedLib2
+    PRIVATE "SHELL: -s WASM_BIGINT"
+    PRIVATE "SHELL: -s SIDE_MODULE=1"
+  )
+endif()
+
+set_target_properties(TestSharedLib2 PROPERTIES FOLDER "Tests")

--- a/unittests/CppInterOp/TestSharedLib2/TestSharedLib.cpp
+++ b/unittests/CppInterOp/TestSharedLib2/TestSharedLib.cpp
@@ -1,0 +1,3 @@
+#include "TestSharedLib.h"
+
+int ret_one() { return 1; }

--- a/unittests/CppInterOp/TestSharedLib2/TestSharedLib.h
+++ b/unittests/CppInterOp/TestSharedLib2/TestSharedLib.h
@@ -1,0 +1,11 @@
+#ifndef UNITTESTS_CPPINTEROP_TESTSHAREDLIB_TESTSHAREDLIB2_H
+#define UNITTESTS_CPPINTEROP_TESTSHAREDLIB_TESTSHAREDLIB2_H
+
+// Avoid having to mangle/demangle the symbol name in tests
+#ifdef _WIN32
+extern "C" __declspec(dllexport) int ret_one();
+#else
+extern "C" int __attribute__((visibility("default"))) ret_one();
+#endif
+
+#endif // UNITTESTS_CPPINTEROP_TESTSHAREDLIB_TESTSHAREDLIB2_H

--- a/unittests/CppInterOp/VariableReflectionTest.cpp
+++ b/unittests/CppInterOp/VariableReflectionTest.cpp
@@ -287,6 +287,8 @@ TEST(VariableReflectionTest, GetVariableOffset) {
   std::vector<Cpp::TCppScope_t> datamembers;
   Cpp::GetDatamembers(Decls[4], datamembers);
 
+  EXPECT_FALSE((bool)Cpp::GetVariableOffset(nullptr));
+
   EXPECT_TRUE((bool) Cpp::GetVariableOffset(Decls[0])); // a
   EXPECT_TRUE((bool) Cpp::GetVariableOffset(Decls[1])); // N
   EXPECT_TRUE((bool)Cpp::GetVariableOffset(Decls[2]));  // S


### PR DESCRIPTION
Big changes in this PR. Some parts of the explanation might be like a conversation.

## Mutex lock per interpreter.

**Question:** Do we need a per-interpreter lock?
**Answer:** Yes. Ideally, that would improve the performance in multi-threaded cases.

**Question:** Does the InterOp API fully support dispatching queries (some kind of lookup) or compiling code across multiple interpreters at the same time?
**Answer:** Actually, (I guess) No. Our API only supports stack-like access of multiple interpreters.
_Example code that will not work:_
```c++
auto interpreter_1 = Cpp::CreateInterpreter();
Cpp::Compile(R"(
void f() {}
)");
auto f = Cpp::GetNamed("f");

auto interpreter_2 = Cpp::CreateInterpreter();
Cpp::Compile(R"(
void ff() {}
)");

auto ff = Cpp::GetNamed("ff");

auto f_callable = Cpp::MakeFunctionCallable(f); // This fails because:
// MakeFunctionCallable uses the interpreter instance 2 at line
// https://github.com/compiler-research/CppInterOp/blob/dba60ff3d829551b1c86128593ca817af78d67dc/lib/CppInterOp/CppInterOp.cpp#L3148-L3150
```
But you can make the above example work, if the user rotates the [`sInterpreters`](https://github.com/compiler-research/CppInterOp/blob/dba60ff3d829551b1c86128593ca817af78d67dc/lib/CppInterOp/CppInterOp.cpp#L127).
_Example:_
```c++
auto interpreter_1 = Cpp::CreateInterpreter();
Cpp::Compile(R"(
void f() {}
)");
auto f = Cpp::GetNamed("f");

auto interpreter_2 = Cpp::CreateInterpreter();
Cpp::Compile(R"(
void ff() {}
)");

auto ff = Cpp::GetNamed("ff");

Cpp::ActivateInterpreter(interpreter_1); // look at https://github.com/compiler-research/CppInterOp/blob/dba60ff3d829551b1c86128593ca817af78d67dc/lib/CppInterOp/CppInterOp.cpp#L3273-L3287
auto f_callable = Cpp::MakeFunctionCallable(f);
```

**Question:** Ok. So is there a way for InterOp is maintain the rotation thing?
**Answer:** Would not be a easy thing to achieve. From my initial view on the matter, it might be possible. But a more important question; Should we support such usecases?

**Question:** Ok. So given the limitation of using multiple interpreter but only as a stack-access. Do we need a mutex lock per interpreter?
**Answer:** No, the user can only access the top most interpreter at a time. We don't need a mutex per interpreter. (Let me know if my reasoning is wrong somewhere)

## Testing this by running in parallel

gtest does not support running in parallel (I could not find anything with my google search). But there is this project, [gtest-parallel](https://github.com/google/gtest-parallel), that can split the tasks into separate isolated processes. But that is not what we want. We want to split the tests to run in parallel threads that share the same interpreter instance.

## Code recovery RAII

@vgvassilev, I need some pointers on incorporating the codegen error recovery RAII. I don't think we should combine the two into the same class, but let me know your opinion. And how should I go about doing it?