### PR TITLE
Remove unneeded MakeResourceDir

### DIFF
--- a/lib/CppInterOp/Compatibility.h
+++ b/lib/CppInterOp/Compatibility.h
@@ -398,13 +398,6 @@ inline std::string FixTypeName(const std::string type_name) {
   return type_name;
 }
 
-inline std::string MakeResourceDir(llvm::StringRef Dir) {
-  llvm::SmallString<128> P(Dir);
-  llvm::sys::path::append(P, CLANG_INSTALL_LIBDIR_BASENAME, "clang",
-                          CLANG_VERSION_MAJOR_STRING);
-  return std::string(P.str());
-}
-
 // Clang >= 16 (=16 with Value patch) change castAs to convertTo
 #ifdef CPPINTEROP_USE_CLING
 template <typename T> inline T convertTo(cling::Value V) {

--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -43,7 +43,7 @@
 #endif
 #include "clang/Sema/TemplateDeduction.h"
 
-#include <llvm/ADT/SmallString.h>
+#include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Demangle/Demangle.h"
@@ -52,7 +52,7 @@
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/ManagedStatic.h"
-#include <llvm/Support/Path.h>
+#include "llvm/Support/Path.h"
 #include "llvm/Support/raw_os_ostream.h"
 
 #include <algorithm>

--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -43,6 +43,7 @@
 #endif
 #include "clang/Sema/TemplateDeduction.h"
 
+#include <llvm/ADT/SmallString.h>
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Demangle/Demangle.h"
@@ -51,6 +52,7 @@
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/ManagedStatic.h"
+#include <llvm/Support/Path.h>
 #include "llvm/Support/raw_os_ostream.h"
 
 #include <algorithm>
@@ -3168,7 +3170,10 @@ static std::string MakeResourcesPath() {
   Dir = sys::path::parent_path(Dir);
   // Dir = sys::path::parent_path(Dir);
 #endif // LLVM_BINARY_DIR
-  return compat::MakeResourceDir(Dir);
+  llvm::SmallString<128> P(Dir);
+  llvm::sys::path::append(P, CLANG_INSTALL_LIBDIR_BASENAME, "clang",
+                          CLANG_VERSION_MAJOR_STRING);
+  return std::string(P.str());
 }
 } // namespace
 

--- a/unittests/CppInterOp/InterpreterTest.cpp
+++ b/unittests/CppInterOp/InterpreterTest.cpp
@@ -334,7 +334,10 @@ if (llvm::sys::RunningOnValgrind())
 
 #ifdef CPPINTEROP_USE_CLING
     std::string MainExecutableName = sys::fs::getMainExecutable(nullptr, nullptr);
-    std::string ResourceDir = compat::MakeResourceDir(LLVM_BINARY_DIR);
+    llvm::SmallString<128> P(LLVM_BINARY_DIR);
+    llvm::sys::path::append(P, CLANG_INSTALL_LIBDIR_BASENAME, "clang",
+                            CLANG_VERSION_MAJOR_STRING);
+    std::string ResourceDir = std::string(P.str());
     std::vector<const char *> ClingArgv = {"-resource-dir", ResourceDir.c_str(),
                                            "-std=c++14"};
     ClingArgv.insert(ClingArgv.begin(), MainExecutableName.c_str());


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

MakeResourceDir is in the compatibility header file despite the fact it is not dependent on what llvm version you are using, or whether you are using cling or clang-repl. Therefore this PR removes is, and just replaces the function in the code.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [x] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [x] I have read the contribution guide recently
