### PR TITLE
Remove unused getCallbacks and setCallbacks from DynamicLibraryManager.h

### DIFF
--- a/lib/CppInterOp/DynamicLibraryManager.h
+++ b/lib/CppInterOp/DynamicLibraryManager.h
@@ -116,10 +116,6 @@ public:
   DynamicLibraryManager(const DynamicLibraryManager&) = delete;
   DynamicLibraryManager& operator=(const DynamicLibraryManager&) = delete;
 
-  InterpreterCallbacks* getCallbacks() { return m_Callbacks; }
-  const InterpreterCallbacks* getCallbacks() const { return m_Callbacks; }
-  void setCallbacks(InterpreterCallbacks* C) { m_Callbacks = C; }
-
   ///\brief Returns the system include paths.
   ///
   ///\returns System include paths.


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

As far as I can tell getCallbacks and setCallbacks are not being used anywhere in CppInterOp, or any of the downstream project, so this PR removes them as unused code.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [x] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [x] I have read the contribution guide recently
