### PR TITLE
Mutex lock (implementation base on `ASTContext::getAllocator::identifyObject`)

### DIFF
--- a/unittests/CppInterOp/InterpreterTest.cpp
+++ b/unittests/CppInterOp/InterpreterTest.cpp
@@ -361,3 +361,22 @@ if (llvm::sys::RunningOnValgrind())
   delete ExtInterp;
 #endif
 }
+
+TEST(InterpreterTest, MultipleInterpreter) {
+  EXPECT_TRUE(Cpp::CreateInterpreter());
+  Cpp::Declare(R"(
+  void f() {}
+  )");
+  auto f = Cpp::GetNamed("f");
+
+  EXPECT_TRUE(Cpp::CreateInterpreter());
+  Cpp::Declare(R"(
+  void ff() {}
+  )");
+  auto ff = Cpp::GetNamed("ff");
+
+  auto f_callable = Cpp::MakeFunctionCallable(f);
+  EXPECT_EQ(f_callable.getKind(), Cpp::JitCall::Kind::kGenericCall);
+  auto ff_callable = Cpp::MakeFunctionCallable(ff);
+  EXPECT_EQ(ff_callable.getKind(), Cpp::JitCall::Kind::kGenericCall);
+}


### PR DESCRIPTION
Same as https://github.com/compiler-research/CppInterOp/pull/698
But using `ASTContext::getAllocator::identifyObject`.

This implementation is terribly slow.