### PR TITLE
Simplify getenv call using cstdlib

### DIFF
--- a/lib/CppInterOp/Compatibility.h
+++ b/lib/CppInterOp/Compatibility.h
@@ -20,17 +20,6 @@
 #define fileno _fileno
 #endif
 
-static inline char* GetEnv(const char* Var_Name) {
-#ifdef _MSC_VER
-  char* Env = nullptr;
-  size_t sz = 0;
-  getenv_s(&sz, Env, sz, Var_Name);
-  return Env;
-#else
-  return getenv(Var_Name);
-#endif
-}
-
 #if CLANG_VERSION_MAJOR < 19
 #define Template_Deduction_Result Sema::TemplateDeductionResult
 #define Template_Deduction_Result_Success                                      \

--- a/lib/CppInterOp/DynamicLibraryManager.cpp
+++ b/lib/CppInterOp/DynamicLibraryManager.cpp
@@ -8,7 +8,6 @@
 //------------------------------------------------------------------------------
 
 #include "DynamicLibraryManager.h"
-#include "Compatibility.h"
 #include "Paths.h"
 
 #include "llvm/ADT/StringSet.h"
@@ -23,6 +22,7 @@
 #include "llvm/Support/Endian.h"
 #endif
 
+#include <cstdlib>
 #include <fstream>
 #include <sys/stat.h>
 #include <system_error>
@@ -53,7 +53,7 @@ DynamicLibraryManager::DynamicLibraryManager() {
   // Behaviour is to not add paths that don't exist...In an interpreted env
   // does this make sense? Path could pop into existence at any time.
   for (const char* Var : kSysLibraryEnv) {
-    if (const char* Env = GetEnv(Var)) {
+    if (const char* Env = std::getenv(Var)) {
       SmallVector<StringRef, 10> CurPaths;
       SplitPaths(Env, CurPaths, utils::kPruneNonExistent,
                  Cpp::utils::platform::kEnvDelim);

--- a/lib/CppInterOp/Paths.cpp
+++ b/lib/CppInterOp/Paths.cpp
@@ -8,7 +8,6 @@
 //------------------------------------------------------------------------------
 
 #include "Paths.h"
-#include "Compatibility.h"
 
 #include "clang/Basic/FileManager.h"
 #include "clang/Lex/HeaderSearchOptions.h"


### PR DESCRIPTION
# Description

Partially reverts https://github.com/compiler-research/CppInterOp/commit/c0a4dfe7746b252f08296eec9db2a895eef3fcb9#diff-9e2485d191b0ee5c98436db2e99b854b71c96f67cb1d8b42870744ffbbe31acc

Is motivated by https://github.com/root-project/root/pull/19864

## Type of change

Simplification

## Testing

see ROOT CI PR

## Checklist

- [ ] I have read the contribution guide recently
