### PR TITLE
Remove gtest_skip on Valgrind for FunctionReflectionTest.DestructArray

### DIFF
--- a/unittests/CppInterOp/FunctionReflectionTest.cpp
+++ b/unittests/CppInterOp/FunctionReflectionTest.cpp
@@ -2623,8 +2623,6 @@ TEST(FunctionReflectionTest, DestructArray) {
 #ifdef EMSCRIPTEN
   GTEST_SKIP() << "Test fails for Emscipten builds";
 #endif
-  if (llvm::sys::RunningOnValgrind())
-    GTEST_SKIP() << "XFAIL due to Valgrind report";
 
 #ifdef _WIN32
   GTEST_SKIP() << "Disabled on Windows. Needs fixing.";


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

If https://github.com/compiler-research/CppInterOp/pull/710 made Valgrind happy, then the gtest skip when running on Valgrind should be able to be removed.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [ ] I have read the contribution guide recently
