### PR TITLE
Move MacOS x86 runners to MacOS 15

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -134,32 +134,32 @@ jobs:
             llvm_enable_projects: "clang"
             llvm_targets_to_build: "host;NVPTX"
           # MacOS X86 Jobs
-          - name: osx13-x86-clang-clang-repl-20
-            os: macos-13
+          - name: osx15-x86-clang-clang-repl-20
+            os: macos-15-intel
             compiler: clang
             clang-runtime: '20'
             cling: Off
             cppyy: Off
             llvm_enable_projects: "clang"
             llvm_targets_to_build: "host"
-          - name: osx13-x86-clang-clang-repl-19-cppyy
-            os: macos-13
+          - name: osx15-x86-clang-clang-repl-19-cppyy
+            os: macos-15-intel
             compiler: clang
             clang-runtime: '19'
             cling: Off
             cppyy: On
             llvm_enable_projects: "clang"
             llvm_targets_to_build: "host"
-          - name: osx13-x86-clang-clang-repl-18-cppyy
-            os: macos-13
+          - name: osx15-x86-clang-clang-repl-18-cppyy
+            os: macos-15-intel
             compiler: clang
             clang-runtime: '18'
             cling: Off
             cppyy: On
             llvm_enable_projects: "clang"
             llvm_targets_to_build: "host"
-          - name: osx13-x86-clang-clang18-cling-cppyy
-            os: macos-13
+          - name: osx15-x86-clang-clang18-cling-cppyy
+            os: macos-15-intel
             compiler: clang
             clang-runtime: '18'
             cling: On
@@ -289,3 +289,4 @@ jobs:
       uses: mxschmitt/action-tmate@v3
       # When debugging increase to a suitable value!
       timeout-minutes: 30
+


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

Fixes # (issue)

The MacOS 13 x86 runners have just been deprecated (see https://github.com/actions/runner-images/issues/13046) and a MacOS 15 x86 runner has been created as a replacement (see https://github.com/actions/runner-images/issues/13045). This will be the final MacOS x86 Github runner.

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [x] I have read the contribution guide recently
