### PR TITLE
[ci] Lock numba to version 0.61.2

### DIFF
--- a/.github/actions/Build_and_Test_cppyy/action.yml
+++ b/.github/actions/Build_and_Test_cppyy/action.yml
@@ -78,7 +78,7 @@ runs:
         python -m pip install --upgrade pip
         python -m pip install pytest
         python -m pip install pytest-xdist
-        python -m pip install numba
+        python -m pip install numba==0.61.2
         echo ::endgroup::
         echo ::group::Run complete test suite
         set -o pipefail


### PR DESCRIPTION
The recent release of numba 0.62 on September 18th broke our CI with a crash in some tests. As part of supporting lates numba, we require new suppressions due to leaks in llvm::ScalarEvolution in a pass by numba through llvmlite We should hence lock the version to 0.61 until we can fully support latest numba.