### PR TITLE
Try `find_package(gtest)` when configuring testing

### DIFF
--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -4,7 +4,15 @@ enable_testing()
 
 # LLVM builds (not installed llvm) provides gtest.
 if (NOT TARGET GTest::gtest AND NOT TARGET gtest)
-  include(GoogleTest)
+  find_package(GTest)
+  if (NOT GTest_FOUND)
+    if (CPPINTEROP_BUILT_STANDALONE)
+      include(GoogleTest)
+    else()
+      message(WARNING "CppInterOp could not find GTest. Provide the package or set CPPINTEROP_ENABLE_TESTING=OFF to disable this warning.")
+      return()
+    endif()
+  endif()
 endif()
 
 if(EMSCRIPTEN)


### PR DESCRIPTION
From https://github.com/root-project/root/pull/20011/commits/72b979a1646b4c758b0cc2393087a132af9816fc Prevents failures in offline builds that cannot fetch gtest. We now first look for gtest and suggest disabling testing if it is not found

To be fixed to work in general in our testing env