### PR TITLE
Fix incorrect build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Now CppInterOp can be built. This can be done by executing
 ```bash
 mkdir CppInterOp/build/
 cd CppInterOp/build/
-cmake -DBUILD_SHARED_LIBS=ON -DCPPINTEROP_USE_CLING=ON -DCPPINTEROP_USE_REPL=Off -DCling_DIR=$LLVM_DIR/build/tools/cling -DLLVM_DIR=$LLVM_DIR/build/lib/cmake/llvm -DClang_DIR=$LLVM_DIR/build/lib/cmake/clang -DCMAKE_INSTALL_PREFIX=$CPPINTEROP_DIR ..
+cmake -DBUILD_SHARED_LIBS=ON -DCling_DIR=$LLVM_DIR/build/tools/cling -DLLVM_DIR=$LLVM_DIR/build/lib/cmake/llvm -DClang_DIR=$LLVM_DIR/build/lib/cmake/clang -DCMAKE_INSTALL_PREFIX=$CPPINTEROP_DIR ..
 cmake --build . --target install --parallel $(nproc --all)
 ```
 


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

`-DCPPINTEROP_USE_CLING=ON -DCPPINTEROP_USE_REPL=Off ` tells CppInterOp to use Cling in the clang-repl based instructions. Found this while working on the llvm 21 PR.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [ ] New feature
- [x] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [x] I have read the contribution guide recently
