### PR TITLE
[ci] Remove llvm 19 Emscripten jobs

### DIFF
--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -21,34 +21,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: ubu24-arm-clang-repl-19-emscripten
-            os: ubuntu-24.04-arm
-            clang-runtime: '19'
-            cling: Off
-            llvm_enable_projects: "clang;lld"
-            llvm_targets_to_build: "WebAssembly"
-            emsdk_ver: "3.1.73"
-          - name: osx15-arm-clang-repl-19-emscripten
-            os: macos-15
-            clang-runtime: '19'
-            cling: Off
-            llvm_enable_projects: "clang;lld"
-            llvm_targets_to_build: "WebAssembly"
-            emsdk_ver: "3.1.73"
-          - name: ubu24-x86-clang-repl-19-emscripten
-            os: ubuntu-24.04
-            clang-runtime: '19'
-            cling: Off
-            llvm_enable_projects: "clang;lld"
-            llvm_targets_to_build: "WebAssembly"
-            emsdk_ver: "3.1.73"
-          - name: win2025-x86-clang-repl-19-emscripten
-            os: windows-2025
-            clang-runtime: '19'
-            cling: Off
-            llvm_enable_projects: "clang;lld"
-            llvm_targets_to_build: "WebAssembly"
-            emsdk_ver: "3.1.73"
           - name: ubu24-arm-clang-repl-20-emscripten
             os: ubuntu-24.04-arm
             clang-runtime: '20'
@@ -389,30 +361,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: ubu24-x86-clang-repl-19-emscripten_wasm
-            os: ubuntu-24.04
-            clang-runtime: '19'
-            cling: Off
-            micromamba_shell_init: bash
-            emsdk_ver: "3.1.73"
-          - name: osx15-arm-clang-repl-19-emscripten_wasm
-            os: macos-15
-            clang-runtime: '19'
-            cling: Off
-            micromamba_shell_init: bash
-            emsdk_ver: "3.1.73"
-          - name: ubu24-arm-clang-repl-19-emscripten_wasm
-            os: ubuntu-24.04-arm
-            clang-runtime: '19'
-            cling: Off
-            micromamba_shell_init: bash
-            emsdk_ver: "3.1.73"
-          - name: win2025-x86-clang-repl-19-emscripten
-            os: windows-2025
-            clang-runtime: '19'
-            cling: Off
-            micromamba_shell_init: powershell
-            emsdk_ver: "3.1.73"
           - name: ubu24-x86-clang-repl-20-emscripten_wasm
             os: ubuntu-24.04
             clang-runtime: '20'


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.

I will move these jobs over to the ci in the cppyy repos. This will free up a large amount of space with CppInterOps cache. In the unlikely event something is added which works for llvm 20 (and hopefully soon llvm 21), but not not llvm 19, we should still know quite soon due to the nightly builds in the other repos. 

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [x] I have read the contribution guide recently
