### PR TITLE
Create empty patch file for ci key to use

### DIFF
--- a/.github/actions/Miscellaneous/Save_PR_Info/action.yml
+++ b/.github/actions/Miscellaneous/Save_PR_Info/action.yml
@@ -55,4 +55,3 @@ runs:
 
         echo "CLING_HASH=$env:CLING_HASH" >> $GITHUB_ENV
         echo "LLVM_HASH=$env:LLVM_HASH" >> $GITHUB_ENV
-


### PR DESCRIPTION
The MacOS jobs started failing recently (see https://github.com/compiler-research/CppInterOp/actions/runs/19616954086 ). Going by the error message

```
The template is not valid. .github/workflows/main.yml (Line: 242, Col: 14): hashFiles('patches/llvm/clang19-*.patch') failed. Fail to hash files under directory '/Users/runner/work/CppInterOp/CppInterOp'
```

it appears to be suddenly failing as there is no patch files for llvm 18 and 19. This PR is a workaround where we make an empty patch file in the ci, so there is something to hash.