### PR TITLE
Move runtime template code to CPPInterOpRuntime.h for issue #697

### DIFF
--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -9,6 +9,8 @@
 
 #include "CppInterOp/CppInterOp.h"
 
+#include "CppInterOpRuntime.h"
+
 #include "Compatibility.h"
 
 #include "clang/AST/Attrs.inc"
@@ -3268,14 +3270,7 @@ TInterp_t CreateInterpreter(const std::vector<const char*>& Args /*={}*/,
   }
 
   I->declare(R"(
-    namespace __internal_CppInterOp {
-    template <typename Signature>
-    struct function;
-    template <typename Res, typename... ArgTypes>
-    struct function<Res(ArgTypes...)> {
-      typedef Res result_type;
-    };
-    }  // namespace __internal_CppInterOp
+    #include "CppInterOpRuntime.h"
   )");
 
   sInterpreters->emplace_back(I, /*Owned=*/true);

--- a/lib/CppInterOp/CppInterOpRuntime.h
+++ b/lib/CppInterOp/CppInterOpRuntime.h
@@ -1,0 +1,19 @@
+#ifndef CPPINTEROP_RUNTIME_H
+#define CPPINTEROP_RUNTIME_H
+
+// This header contains runtime utilities previously injected into the
+// interpreter using I->declare(). It is now provided as a real header so that
+// the interpreter can load it on startup.
+
+namespace __internal_CppInterOp {
+
+template <typename Signature>
+struct function;
+template <typename Res, typename... ArgTypes>
+struct function<Res(ArgTypes...)> {
+    using result_type = Res;
+};
+
+} // namespace __internal_CppInterOp
+
+#endif // CPPINTEROP_RUNTIME_H


### PR DESCRIPTION
# Description

## Summary

Moved the runtime-only `__internal_CppInterOp::function` template from the interpreter-injected string in `CppInterOp.cpp` into its own header file `CppInterOpRuntime.h`. 

This makes the code cleaner, easier to maintain, and aligns with the reviewer suggestion from https://github.com/compiler-research/CppInterOp/pull/678/files#r2242837167 .

## Changes

- Added `lib/CppInterOp/CppInterOpRuntime.h` with the template definition.
- Removed the `I->declare(...)` runtime template block from `CppInterOp.cpp`.
- Included the new header in `CppInterOp.cpp`.

## Motivation

Previously, the template code was injected into the interpreter at startup using a string. Moving it to a proper header:

- Improves readability and maintainability.
- Avoids duplication of template logic.

Fixes issue #697 


## Type of change

Please tick all options which are relevant.

- [x] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Checklist

- [x] I have read the contribution guide recently
