### PR TITLE
Drop smallpt notebook reference from Emscripten build instructions

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -228,7 +228,6 @@ jobs:
           micromamba activate xeus-lite-host
           jupyter lite build --XeusAddon.prefix=${{ env.PREFIX }} \
                              --contents notebooks/xeus-cpp-lite-demo.ipynb \
-                             --contents notebooks/smallpt.ipynb \
                              --contents notebooks/images/marie.png \
                              --contents notebooks/audio/audio.wav \
                              --XeusAddon.mounts="${{ env.PREFIX }}/share/xeus-cpp/tagfiles:/share/xeus-cpp/tagfiles" \

--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -1037,7 +1037,7 @@ jobs:
           cd ./xeus-cpp/
           micromamba create -n xeus-lite-host jupyterlite-core=0.6 jupyterlite-xeus jupyter_server jupyterlab notebook python-libarchive-c -c conda-forge
           micromamba activate xeus-lite-host
-          jupyter lite build --XeusAddon.prefix=${{ env.PREFIX }} --contents notebooks/xeus-cpp-lite-demo.ipynb --contents notebooks/smallpt.ipynb --contents notebooks/images/marie.png --contents notebooks/audio/audio.wav --output-dir dist
+          jupyter lite build --XeusAddon.prefix=${{ env.PREFIX }} --contents notebooks/xeus-cpp-lite-demo.ipynb --contents notebooks/images/marie.png --contents notebooks/audio/audio.wav --output-dir dist
 
     - name: Jupyter Lite integration
       if: ${{ runner.os == 'windows' }}
@@ -1046,4 +1046,4 @@ jobs:
           cd .\xeus-cpp\
           micromamba create -n xeus-lite-host jupyterlite-core=0.6 jupyterlite-xeus jupyter_server jupyterlab notebook python-libarchive-c -c conda-forge
           micromamba activate xeus-lite-host
-          jupyter lite build --XeusAddon.prefix=${{ env.PREFIX }} --contents notebooks/xeus-cpp-lite-demo.ipynb --contents notebooks/smallpt.ipynb --contents notebooks/images/marie.png --contents notebooks/audio/audio.wav --output-dir dist
+          jupyter lite build --XeusAddon.prefix=${{ env.PREFIX }} --contents notebooks/xeus-cpp-lite-demo.ipynb --contents notebooks/images/marie.png --contents notebooks/audio/audio.wav --output-dir dist

--- a/Emscripten-build-instructions.md
+++ b/Emscripten-build-instructions.md
@@ -388,7 +388,6 @@ micromamba create -n xeus-lite-host jupyterlite-core=0.6 jupyterlite-xeus jupyte
 micromamba activate xeus-lite-host
 jupyter lite serve --XeusAddon.prefix=$PREFIX \
                    --contents xeus-cpp/notebooks/xeus-cpp-lite-demo.ipynb \
-                   --contents xeus-cpp/notebooks/smallpt.ipynb \
                    --contents xeus-cpp/notebooks/images/marie.png \
                    --contents xeus-cpp/notebooks/audio/audio.wav \
                    --XeusAddon.mounts="$PREFIX/share/xeus-cpp/tagfiles:/share/xeus-cpp/tagfiles" \
@@ -403,7 +402,6 @@ micromamba create -n xeus-lite-host jupyterlite-core=0.6 jupyterlite-xeus jupyte
 micromamba activate xeus-lite-host
 jupyter lite serve --XeusAddon.prefix="$env:PREFIX" `
                    --contents xeus-cpp/notebooks/xeus-cpp-lite-demo.ipynb `
-                   --contents xeus-cpp/notebooks/smallpt.ipynb `
                    --contents xeus-cpp/notebooks/images/marie.png `
                    --contents xeus-cpp/notebooks/audio/audio.wav `
                    --XeusAddon.mounts="$env:PREFIX/share/xeus-cpp/tagfiles:/share/xeus-cpp/tagfiles" `

--- a/docs/Emscripten-build-instructions.rst
+++ b/docs/Emscripten-build-instructions.rst
@@ -410,7 +410,6 @@ To build and test Jupyter Lite with this kernel locally on Linux/MacOS you can e
    micromamba activate xeus-lite-host
    jupyter lite serve --XeusAddon.prefix=$PREFIX \
                       --contents xeus-cpp/notebooks/xeus-cpp-lite-demo.ipynb \
-                      --contents xeus-cpp/notebooks/smallpt.ipynb \
                       --contents xeus-cpp/notebooks/images/marie.png \ 
                       --contents xeus-cpp/notebooks/audio/audio.wav \
                       --XeusAddon.mounts="$PREFIX/share/xeus-cpp/tagfiles:/share/xeus-cpp/tagfiles" \
@@ -425,7 +424,6 @@ and on Windows execute
    micromamba activate xeus-lite-host
    jupyter lite serve --XeusAddon.prefix="$env:PREFIX" `
                       --contents xeus-cpp/notebooks/xeus-cpp-lite-demo.ipynb `
-                      --contents xeus-cpp/notebooks/smallpt.ipynb `
                       --contents xeus-cpp/notebooks/images/marie.png ` 
                       --contents xeus-cpp/notebooks/audio/audio.wav `
                       --XeusAddon.mounts="$env:PREFIX/share/xeus-cpp/tagfiles:/share/xeus-cpp/tagfiles" `


### PR DESCRIPTION
Now that the smallpt example notebook has been dropped from xeus-cpp, references to it need to be dropped from CppInterOps Emscripten ci and documentation.