### PR TITLE
fix common namespaces for public API and internals

### DIFF
--- a/lib/CppInterOp/CXCppInterOp.cpp
+++ b/lib/CppInterOp/CXCppInterOp.cpp
@@ -543,7 +543,7 @@ bool clang_existsFunctionTemplate(const char* name, CXScope parent) {
   const auto* Within = llvm::dyn_cast<clang::DeclContext>(getDecl(parent));
 
   auto& S = getInterpreter(parent)->getSema();
-  auto* ND = Cpp::Cpp_utils::Lookup::Named(&S, name, Within);
+  auto* ND = CppInternal::utils::Lookup::Named(&S, name, Within);
 
   if (!ND)
     return false;

--- a/lib/CppInterOp/Compatibility.h
+++ b/lib/CppInterOp/Compatibility.h
@@ -92,8 +92,8 @@ static inline char* GetEnv(const char* Var_Name) {
 #include <regex>
 #include <vector>
 
-namespace Cpp {
-namespace Cpp_utils = cling::utils;
+namespace CppInternal {
+namespace utils = cling::utils;
 }
 
 namespace compat {
@@ -434,12 +434,8 @@ inline void codeComplete(std::vector<std::string>& Results,
 
 #include "CppInterOpInterpreter.h"
 
-namespace Cpp {
-namespace Cpp_utils = Cpp::utils;
-}
-
 namespace compat {
-using Interpreter = Cpp::Interpreter;
+using Interpreter = CppInternal::Interpreter;
 
 class SynthesizingCodeRAII {
 private:

--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -769,7 +769,7 @@ TCppScope_t GetNamed(const std::string& name,
     Within = llvm::dyn_cast<clang::DeclContext>(D);
   }
 
-  auto* ND = Cpp_utils::Lookup::Named(&getSema(), name, Within);
+  auto* ND = CppInternal::utils::Lookup::Named(&getSema(), name, Within);
   if (ND && ND != (clang::NamedDecl*)-1) {
     return (TCppScope_t)(ND->getCanonicalDecl());
   }
@@ -1025,7 +1025,7 @@ std::vector<TCppFunction_t> GetFunctionsUsingName(TCppScope_t scope,
   clang::LookupResult R(S, DName, SourceLocation(), Sema::LookupOrdinaryName,
                         For_Visible_Redeclaration);
 
-  Cpp_utils::Lookup::Named(&S, R, Decl::castToDeclContext(D));
+  CppInternal::utils::Lookup::Named(&S, R, Decl::castToDeclContext(D));
 
   if (R.empty())
     return funcs;
@@ -1169,7 +1169,7 @@ bool ExistsFunctionTemplate(const std::string& name, TCppScope_t parent) {
     Within = llvm::dyn_cast<DeclContext>(D);
   }
 
-  auto* ND = Cpp_utils::Lookup::Named(&getSema(), name, Within);
+  auto* ND = CppInternal::utils::Lookup::Named(&getSema(), name, Within);
 
   if ((intptr_t)ND == (intptr_t)0)
     return false;
@@ -1214,7 +1214,7 @@ bool GetClassTemplatedMethods(const std::string& name, TCppScope_t parent,
   clang::LookupResult R(S, DName, SourceLocation(), Sema::LookupOrdinaryName,
                         For_Visible_Redeclaration);
   auto* DC = clang::Decl::castToDeclContext(D);
-  Cpp_utils::Lookup::Named(&S, R, DC);
+  CppInternal::utils::Lookup::Named(&S, R, DC);
 
   if (R.getResultKind() == clang::LookupResult::NotFound && funcs.empty())
     return false;
@@ -1508,7 +1508,7 @@ TCppScope_t LookupDatamember(const std::string& name, TCppScope_t parent) {
     Within = llvm::dyn_cast<clang::DeclContext>(D);
   }
 
-  auto* ND = Cpp_utils::Lookup::Named(&getSema(), name, Within);
+  auto* ND = CppInternal::utils::Lookup::Named(&getSema(), name, Within);
   if (ND && ND != (clang::NamedDecl*)-1) {
     if (llvm::isa_and_nonnull<clang::FieldDecl>(ND)) {
       return (TCppScope_t)ND;

--- a/lib/CppInterOp/CppInterOpInterpreter.h
+++ b/lib/CppInterOp/CppInterOpInterpreter.h
@@ -67,7 +67,7 @@ template <typename D> static D* LookupResult2Decl(clang::LookupResult& R) {
 }
 } // namespace
 
-namespace Cpp {
+namespace CppInternal {
 namespace utils {
 namespace Lookup {
 
@@ -141,9 +141,9 @@ inline clang::NamedDecl* Named(clang::Sema* S, const char* Name,
 
 } // namespace Lookup
 } // namespace utils
-} // namespace Cpp
+} // namespace CppInternal
 
-namespace Cpp {
+namespace CppInternal {
 
 /// CppInterOp Interpreter
 ///
@@ -494,7 +494,7 @@ public:
 
     // Save the current number of entries
     size_t Idx = HOpts.UserEntries.size();
-    Cpp::utils::AddIncludePaths(PathsStr, HOpts, Delim);
+    CppInternal::utils::AddIncludePaths(PathsStr, HOpts, Delim);
 
     clang::Preprocessor& PP = CI->getPreprocessor();
     clang::SourceManager& SM = PP.getSourceManager();
@@ -532,8 +532,8 @@ public:
   ///
   void GetIncludePaths(llvm::SmallVectorImpl<std::string>& incpaths,
                        bool withSystem, bool withFlags) const {
-    utils::CopyIncludePaths(getCI()->getHeaderSearchOpts(), incpaths,
-                            withSystem, withFlags);
+    CppInternal::utils::CopyIncludePaths(getCI()->getHeaderSearchOpts(),
+                                         incpaths, withSystem, withFlags);
   }
 
   CompilationResult loadLibrary(const std::string& filename, bool lookup) {
@@ -587,6 +587,6 @@ public:
   }
 
 }; // Interpreter
-} // namespace Cpp
+} // namespace CppInternal
 
 #endif // CPPINTEROP_INTERPRETER_H

--- a/lib/CppInterOp/DynamicLibraryManager.cpp
+++ b/lib/CppInterOp/DynamicLibraryManager.cpp
@@ -27,10 +27,9 @@
 #include <sys/stat.h>
 #include <system_error>
 
-namespace Cpp {
+namespace CppInternal {
 
-using namespace Cpp::utils::platform;
-using namespace Cpp::utils;
+using namespace utils;
 using namespace llvm;
 
 DynamicLibraryManager::DynamicLibraryManager() {
@@ -55,8 +54,8 @@ DynamicLibraryManager::DynamicLibraryManager() {
   for (const char* Var : kSysLibraryEnv) {
     if (const char* Env = GetEnv(Var)) {
       SmallVector<StringRef, 10> CurPaths;
-      SplitPaths(Env, CurPaths, utils::kPruneNonExistent,
-                 Cpp::utils::platform::kEnvDelim);
+      SplitPaths(Env, CurPaths, SplitMode::kPruneNonExistent,
+                 platform::kEnvDelim);
       for (const auto& Path : CurPaths)
         addSearchPath(Path);
     }
@@ -66,7 +65,7 @@ DynamicLibraryManager::DynamicLibraryManager() {
   addSearchPath(".");
 
   SmallVector<std::string, 64> SysPaths;
-  Cpp::utils::platform::GetSystemLibraryPaths(SysPaths);
+  platform::GetSystemLibraryPaths(SysPaths);
 
   for (const std::string& P : SysPaths)
     addSearchPath(P, /*IsUser*/ false);
@@ -506,4 +505,4 @@ bool DynamicLibraryManager::isSharedLibrary(StringRef libFullPath,
   return result;
 }
 
-} // end namespace Cpp
+} // end namespace CppInternal

--- a/lib/CppInterOp/DynamicLibraryManager.h
+++ b/lib/CppInterOp/DynamicLibraryManager.h
@@ -17,7 +17,7 @@
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/Path.h"
 
-namespace Cpp {
+namespace CppInternal {
 class Dyld;
 class InterpreterCallbacks;
 
@@ -219,6 +219,6 @@ public:
   static bool isSharedLibrary(llvm::StringRef libFullPath,
                               bool* exists = nullptr);
 };
-} // end namespace Cpp
+} // end namespace CppInternal
 
 #endif // CPPINTEROP_DYNAMIC_LIBRARY_MANAGER_H

--- a/lib/CppInterOp/Paths.cpp
+++ b/lib/CppInterOp/Paths.cpp
@@ -23,7 +23,7 @@
 #include <dlfcn.h>
 #endif
 
-namespace Cpp {
+namespace CppInternal {
 namespace utils {
 
 namespace platform {
@@ -361,7 +361,7 @@ bool SplitPaths(llvm::StringRef PathStr,
 
 void AddIncludePaths(
     llvm::StringRef PathStr, clang::HeaderSearchOptions& HOpts,
-    const char* Delim /* = Cpp::utils::platform::kEnvDelim */) {
+    const char* Delim /* = CppInternal::utils::platform::kEnvDelim */) {
 #define DEBUG_TYPE "AddIncludePaths"
 
   llvm::SmallVector<llvm::StringRef, 10> Paths;
@@ -399,4 +399,4 @@ void AddIncludePaths(
 }
 
 } // namespace utils
-} // namespace Cpp
+} // namespace CppInternal

--- a/lib/CppInterOp/Paths.h
+++ b/lib/CppInterOp/Paths.h
@@ -24,7 +24,7 @@ class HeaderSearchOptions;
 class FileManager;
 } // namespace clang
 
-namespace Cpp {
+namespace CppInternal {
 namespace utils {
 
 namespace platform {
@@ -80,7 +80,7 @@ enum SplitMode {
 bool SplitPaths(llvm::StringRef PathStr,
                 llvm::SmallVectorImpl<llvm::StringRef>& Paths,
                 SplitMode Mode = kPruneNonExistent,
-                llvm::StringRef Delim = Cpp::utils::platform::kEnvDelim,
+                llvm::StringRef Delim = CppInternal::utils::platform::kEnvDelim,
                 bool Verbose = false);
 
 ///\brief Adds multiple include paths separated by a delimiter into the
@@ -92,8 +92,9 @@ bool SplitPaths(llvm::StringRef PathStr,
 ///\param[in] Opts - HeaderSearchOptions to add paths into
 ///\param[in] Delim - Delimiter to separate paths or NULL if a single path
 ///
-void AddIncludePaths(llvm::StringRef PathStr, clang::HeaderSearchOptions& HOpts,
-                     const char* Delim = Cpp::utils::platform::kEnvDelim);
+void AddIncludePaths(
+    llvm::StringRef PathStr, clang::HeaderSearchOptions& HOpts,
+    const char* Delim = CppInternal::utils::platform::kEnvDelim);
 
 ///\brief Write to cling::errs that directory does not exist in a format
 /// matching what 'clang -v' would do
@@ -117,6 +118,6 @@ void CopyIncludePaths(const clang::HeaderSearchOptions& Opts,
                       bool WithSystem, bool WithFlags);
 
 } // namespace utils
-} // namespace Cpp
+} // namespace CppInternal
 
 #endif // CPPINTEROP_UTILS_PATHS_H


### PR DESCRIPTION
Drops common `Cpp` namespace used for both public API, and internal facilities.
With this patch, we introduce a `CppInternal` (open to better suggestions) namespace that contains private classes that are not meant to be exposed
```
-- Cpp
     - Public API
     - JitCall
-- CppInternal
     - Interpreter
     - DynamicLibraryManager
     - utils
        - platform
        - SplitMode
        - Lookup
        + everything in cling::utils if Cling
```

As a result we no longer perform the following unintuitive remap:

```cpp
namespace Cpp {
namespace Cpp_utils = Cpp::utils;
}
```

and the distinction between public API (everything in `include/CppInterOp.h`) and other implementation facilities are clear
   

