### PR TITLE
Add Cling transactions preventing ROOT crashes in GetNamed/GetAllCppNames

### DIFF
--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -768,7 +768,11 @@ TCppScope_t GetNamed(const std::string& name,
     D = GetUnderlyingScope(D);
     Within = llvm::dyn_cast<clang::DeclContext>(D);
   }
-
+#ifdef CPPINTEROP_USE_CLING
+  if (Within)
+    Within->getPrimaryContext()->buildLookup();
+  cling::Interpreter::PushTransactionRAII RAII(&getInterp());
+#endif
   auto* ND = CppInternal::utils::Lookup::Named(&getSema(), name, Within);
   if (ND && ND != (clang::NamedDecl*)-1) {
     return (TCppScope_t)(ND->getCanonicalDecl());
@@ -3849,6 +3853,10 @@ void GetAllCppNames(TCppScope_t scope, std::set<std::string>& names) {
   auto* D = (clang::Decl*)scope;
   clang::DeclContext* DC;
   clang::DeclContext::decl_iterator decl;
+
+#ifdef CPPINTEROP_USE_CLING
+  cling::Interpreter::PushTransactionRAII RAII(&getInterp());
+#endif
 
   if (auto* TD = dyn_cast_or_null<TagDecl>(D)) {
     DC = clang::TagDecl::castToDeclContext(TD);


### PR DESCRIPTION
These appeared when building our cppyy forks inside ROOT: https://github.com/aaronj0/root/commits/cppyy-migration/