### PR TITLE
Fix missing semicolon for CLANG_VERSION_MAJOR > 21 branch

### DIFF
--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -104,7 +104,7 @@ struct __clang_Interpreter_NewTag {
 } __ci_newtag;
 #if CLANG_VERSION_MAJOR > 21
 extern "C" void* __clang_Interpreter_SetValueWithAlloc(void* This, void* OutVal,
-                                                       void* OpaqueType)
+                                                       void* OpaqueType);
 #else
 void* __clang_Interpreter_SetValueWithAlloc(void* This, void* OutVal,
                                             void* OpaqueType);


### PR DESCRIPTION
# Description

Was trying to build against latest llvm when I noticed this !

## Type of change

Please tick all options which are relevant.

- [x] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [x ] I have read the contribution guide recently
