### PR TITLE
Set default c++ standard to 20 to match cppyy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -230,10 +230,11 @@ endif()
   message(STATUS "Found supported version: Clang ${CLANG_PACKAGE_VERSION}")
   message(STATUS "Using ClangConfig.cmake in: ${Clang_DIR}")
 
-  ## Clang 18 require c++17 or later.
+
   if (NOT CMAKE_CXX_STANDARD)
-    set (CMAKE_CXX_STANDARD 17)
+    set (CMAKE_CXX_STANDARD 20)
   endif()
+  ## Clang 18 require c++17 or later.
   if (CMAKE_CXX_STANDARD LESS 17)
     message(fatal "LLVM/CppInterOp requires c++17 or later")
   endif()


### PR DESCRIPTION
This may not be something we want, but I thought I would check. The default C++ standard set in CppInterOp is C++17 which I believe matches llvms default c++ standard. On the other hand the default for CPyCppyy is C++20 (see link below). 

https://github.com/compiler-research/CPyCppyy/blob/6223fda01aee4bfab771bfe8adccc79811134fe1/CMakeLists.txt#L4

This updates just updates the default C++ standard to meets CPyCppyy, while still keeping the check which sees whether any standard given via the cmake option is > 17.