### PR TITLE
add library path based on resource directory

### DIFF
--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -65,6 +65,7 @@
 #include "llvm/Support/ManagedStatic.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/raw_ostream.h"
+#include "llvm/TargetParser/Host.h"
 
 #include <algorithm>
 #include <cassert>
@@ -3316,11 +3317,12 @@ TInterp_t CreateInterpreter(const std::vector<const char*>& Args /*={}*/,
                             const std::vector<const char*>& GpuArgs /*={}*/) {
   std::string MainExecutableName = sys::fs::getMainExecutable(nullptr, nullptr);
   std::string ResourceDir = MakeResourcesPath();
-#if defined(__linux__) || defined(__APPLE__)
+  std::string processTargetTriple = llvm::sys::getProcessTriple();
   namespace fs = std::filesystem;
-  if (!fs::is_directory(ResourceDir))
+  if ((!fs::is_directory(ResourceDir)) &&
+      ((processTargetTriple.find("linux") != std::string::npos) ||
+       (processTargetTriple.find("apple") != std::string::npos)))
     ResourceDir = DetectResourceDir();
-#endif
 
   std::vector<const char*> ClingArgv = {"-resource-dir", ResourceDir.c_str(),
                                         "-std=c++14"};

--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -3383,7 +3383,9 @@ TInterp_t CreateInterpreter(const std::vector<const char*>& Args /*={}*/,
     llvm::cl::ParseCommandLineOptions(NumArgs + 1, Args.get());
   }
 
+#ifndef EMSCRIPTEN
   AddLibrarySearchPaths(ResourceDir, I);
+#endif
 
   I->declare(R"(
     namespace __internal_CppInterOp {

--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -3288,7 +3288,6 @@ static std::string MakeResourcesPath() {
   return std::string(P.str());
 }
 
-#ifndef EMSCRIPTEN
 void AddLibrarySearchPaths(const std::string& ResourceDir,
                            compat::Interpreter* I) {
   // the resource-dir can be of the form
@@ -3311,7 +3310,6 @@ void AddLibrarySearchPaths(const std::string& ResourceDir,
                                                  false, false);
   }
 }
-#endif
 } // namespace
 
 TInterp_t CreateInterpreter(const std::vector<const char*>& Args /*={}*/,
@@ -3386,9 +3384,8 @@ TInterp_t CreateInterpreter(const std::vector<const char*>& Args /*={}*/,
     llvm::cl::ParseCommandLineOptions(NumArgs + 1, Args.get());
   }
 
-#ifndef EMSCRIPTEN
-  AddLibrarySearchPaths(ResourceDir, I);
-#endif
+  if (!T.isWasm())
+    AddLibrarySearchPaths(ResourceDir, I);
 
   I->declare(R"(
     namespace __internal_CppInterOp {

--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -66,6 +66,7 @@
 #include "llvm/Support/Path.h"
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/TargetParser/Host.h"
+#include "llvm/TargetParser/Triple.h"
 
 #include <algorithm>
 #include <cassert>
@@ -3317,11 +3318,9 @@ TInterp_t CreateInterpreter(const std::vector<const char*>& Args /*={}*/,
                             const std::vector<const char*>& GpuArgs /*={}*/) {
   std::string MainExecutableName = sys::fs::getMainExecutable(nullptr, nullptr);
   std::string ResourceDir = MakeResourcesPath();
-  std::string processTargetTriple = llvm::sys::getProcessTriple();
+  llvm::Triple T(llvm::sys::getProcessTriple());
   namespace fs = std::filesystem;
-  if ((!fs::is_directory(ResourceDir)) &&
-      ((processTargetTriple.find("linux") != std::string::npos) ||
-       (processTargetTriple.find("apple") != std::string::npos)))
+  if ((!fs::is_directory(ResourceDir)) && (T.isOSDarwin() || T.isOSLinux()))
     ResourceDir = DetectResourceDir();
 
   std::vector<const char*> ClingArgv = {"-resource-dir", ResourceDir.c_str(),

--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -3286,6 +3286,7 @@ static std::string MakeResourcesPath() {
   return std::string(P.str());
 }
 
+#ifndef EMSCRIPTEN
 void AddLibrarySearchPaths(const std::string& ResourceDir,
                            compat::Interpreter* I) {
   // the resource-dir can be of the form
@@ -3308,6 +3309,7 @@ void AddLibrarySearchPaths(const std::string& ResourceDir,
                                                  false, false);
   }
 }
+#endif
 } // namespace
 
 TInterp_t CreateInterpreter(const std::vector<const char*>& Args /*={}*/,
@@ -3578,7 +3580,7 @@ std::string DetectResourceDir(const char* ClangBinaryName /* = clang */) {
   std::string version = CLANG_VERSION_MAJOR_STRING;
   // We need to check if the detected resource directory is compatible.
   if (llvm::sys::path::filename(detected_resource_dir) != version)
-    std::cerr << "detected resource directory is incompatible\n";
+    return "";
 
   return detected_resource_dir;
 }

--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -3312,11 +3312,13 @@ void AddLibrarySearchPaths(const std::string& ResourceDir,
 
 TInterp_t CreateInterpreter(const std::vector<const char*>& Args /*={}*/,
                             const std::vector<const char*>& GpuArgs /*={}*/) {
-  namespace fs = std::filesystem;
   std::string MainExecutableName = sys::fs::getMainExecutable(nullptr, nullptr);
   std::string ResourceDir = MakeResourcesPath();
+#if defined(__linux__) || defined(__APPLE__)
+  namespace fs = std::filesystem;
   if (!fs::is_directory(ResourceDir))
     ResourceDir = DetectResourceDir();
+#endif
 
   std::vector<const char*> ClingArgv = {"-resource-dir", ResourceDir.c_str(),
                                         "-std=c++14"};


### PR DESCRIPTION
# Description

And
Removing `MakeResourcesPath` because it depends on the build system's configuration (at build time) and not on host system/configuration.
Or in the other case where it computes relative to executable is wrong because CppInterOp is a dynamic library and the final executable can be located anywhere on the system.

## Fixes # (issue)

xeus-cpp `LD_LIBRARY_PATH` thing for OpenMP.

Please tick all options which are relevant.

- [x] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [x] I have read the contribution guide recently
