### PR TITLE
Build Emscripten static library of CppInterOp with all Github runner cores on linux

### DIFF
--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -651,7 +651,12 @@ jobs:
                 -DSYSROOT_PATH=$SYSROOT_PATH                     \
                 ../
         fi
-        emmake make -j ${{ env.ncpus }} check-cppinterop
+        os="${{ matrix.os }}"
+        if [[ "${os}" != macos* ]] ; then
+          EMCC_CORES=2 emmake make -j 2 check-cppinterop
+        else
+          emmake make -j ${{ env.ncpus }} check-cppinterop
+        fi
         cd ./unittests/CppInterOp/
         # Explaination of options for emrun
         # --browser (name of browser on path)


### PR DESCRIPTION
If this works, then the Linux Emscripten job should be significantly faster, thereby speeding up development, since the Linux runner will be freed up much sooner than previously. If this doesn't work I will try `EMCC_CORES=2 emmake make -j 2 check-cppinterop` for the Linux job, and see if that works, because any improvement in the number of cores we can use will be worth the change.