### PR TITLE
Add CppInterOp API Dispatch mechanism 

### DIFF
--- a/include/CppInterOp/CppInterOp.h
+++ b/include/CppInterOp/CppInterOp.h
@@ -33,7 +33,7 @@
 #endif
 #endif
 
-namespace Cpp {
+namespace CppImpl {
 using TCppIndex_t = size_t;
 using TCppScope_t = void*;
 using TCppConstScope_t = const void*;
@@ -953,6 +953,10 @@ CPPINTEROP_API int Undo(unsigned N = 1);
 CPPINTEROP_API pid_t GetExecutorPID();
 #endif
 
-} // end namespace Cpp
+} // namespace CppImpl
 
+#ifndef CPPINTEROP_DISPATCH_H
+// NOLINTNEXTLINE(misc-unused-alias-decls)
+namespace Cpp = CppImpl;
+#endif
 #endif // CPPINTEROP_CPPINTEROP_H

--- a/include/CppInterOp/Dispatch.h
+++ b/include/CppInterOp/Dispatch.h
@@ -1,0 +1,292 @@
+//===--- Dispatch.h - CppInterOp's API Dispatch Mechanism ---*- C++ -*-===//
+//
+// Part of the compiler-research project, under the Apache License v2.0 with
+// LLVM Exceptions.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Defines the mechanism which enables dispatching of the CppInterOp API
+// without linking, preventing any LLVM or Clang symbols from being leaked
+// into the client application. This is achieved using a symbol-address table
+// and an address lookup through a C symbol allowing clients to dlopen
+// CppInterOp with RTLD_LOCAL, and automatically assign the API during runtime.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CPPINTEROP_DISPATCH_H
+#define CPPINTEROP_DISPATCH_H
+
+#ifdef CPPINTEROP_CPPINTEROP_H
+#error "To use the Dispatch mechanism, do not include CppInterOp.h directly."
+#endif
+
+#include <CppInterOp/CppInterOp.h>
+
+#include <cstdlib>
+#include <iostream>
+#include <mutex>
+
+#ifdef _WIN32
+#include <windows.h>
+#undef LoadLibrary
+#else
+#include <dlfcn.h>
+#endif
+
+using CppFnPtrTy = void (*)();
+///\param[in] procname - the name of the FunctionEntry in the symbol lookup
+/// table.
+///
+///\returns the function address of the requested API, or nullptr if not found
+extern "C" CPPINTEROP_API CppFnPtrTy CppGetProcAddress(const char* procname);
+
+// macro that allows declaration and loading of all CppInterOp API functions in
+// a consistent way. This is used as our dispatched API list, along with the
+// name-address pair table
+#define CPPINTEROP_API_TABLE                                                   \
+  DISPATCH_API(CreateInterpreter, decltype(&CppImpl::CreateInterpreter))       \
+  DISPATCH_API(GetInterpreter, decltype(&CppImpl::GetInterpreter))             \
+  DISPATCH_API(Process, decltype(&CppImpl::Process))                           \
+  DISPATCH_API(GetResourceDir, decltype(&CppImpl::GetResourceDir))             \
+  DISPATCH_API(AddIncludePath, decltype(&CppImpl::AddIncludePath))             \
+  DISPATCH_API(LoadLibrary, decltype(&CppImpl::LoadLibrary))                   \
+  DISPATCH_API(Declare, decltype(&CppImpl::Declare))                           \
+  DISPATCH_API(DeleteInterpreter, decltype(&CppImpl::DeleteInterpreter))       \
+  DISPATCH_API(IsNamespace, decltype(&CppImpl::IsNamespace))                   \
+  DISPATCH_API(ObjToString, decltype(&CppImpl::ObjToString))                   \
+  DISPATCH_API(GetQualifiedCompleteName,                                       \
+               decltype(&CppImpl::GetQualifiedCompleteName))                   \
+  DISPATCH_API(GetValueKind, decltype(&CppImpl::GetValueKind))                 \
+  DISPATCH_API(GetNonReferenceType, decltype(&CppImpl::GetNonReferenceType))   \
+  DISPATCH_API(IsEnumType, decltype(&CppImpl::IsEnumType))                     \
+  DISPATCH_API(GetIntegerTypeFromEnumType,                                     \
+               decltype(&CppImpl::GetIntegerTypeFromEnumType))                 \
+  DISPATCH_API(GetReferencedType, decltype(&CppImpl::GetReferencedType))       \
+  DISPATCH_API(IsPointerType, decltype(&CppImpl::IsPointerType))               \
+  DISPATCH_API(GetPointeeType, decltype(&CppImpl::GetPointeeType))             \
+  DISPATCH_API(GetPointerType, decltype(&CppImpl::GetPointerType))             \
+  DISPATCH_API(IsReferenceType, decltype(&CppImpl::IsReferenceType))           \
+  DISPATCH_API(GetTypeAsString, decltype(&CppImpl::GetTypeAsString))           \
+  DISPATCH_API(GetCanonicalType, decltype(&CppImpl::GetCanonicalType))         \
+  DISPATCH_API(HasTypeQualifier, decltype(&CppImpl::HasTypeQualifier))         \
+  DISPATCH_API(RemoveTypeQualifier, decltype(&CppImpl::RemoveTypeQualifier))   \
+  DISPATCH_API(GetUnderlyingType, decltype(&CppImpl::GetUnderlyingType))       \
+  DISPATCH_API(IsRecordType, decltype(&CppImpl::IsRecordType))                 \
+  DISPATCH_API(IsFunctionPointerType,                                          \
+               decltype(&CppImpl::IsFunctionPointerType))                      \
+  DISPATCH_API(GetVariableType, decltype(&CppImpl::GetVariableType))           \
+  DISPATCH_API(GetNamed, decltype(&CppImpl::GetNamed))                         \
+  DISPATCH_API(GetScopeFromType, decltype(&CppImpl::GetScopeFromType))         \
+  DISPATCH_API(GetClassTemplateInstantiationArgs,                              \
+               decltype(&CppImpl::GetClassTemplateInstantiationArgs))          \
+  DISPATCH_API(IsClass, decltype(&CppImpl::IsClass))                           \
+  DISPATCH_API(GetType, decltype(&CppImpl::GetType))                           \
+  DISPATCH_API(GetTypeFromScope, decltype(&CppImpl::GetTypeFromScope))         \
+  DISPATCH_API(GetComplexType, decltype(&CppImpl::GetComplexType))             \
+  DISPATCH_API(GetIntegerTypeFromEnumScope,                                    \
+               decltype(&CppImpl::GetIntegerTypeFromEnumScope))                \
+  DISPATCH_API(GetUnderlyingScope, decltype(&CppImpl::GetUnderlyingScope))     \
+  DISPATCH_API(GetScope, decltype(&CppImpl::GetScope))                         \
+  DISPATCH_API(GetGlobalScope, decltype(&CppImpl::GetGlobalScope))             \
+  DISPATCH_API(GetScopeFromCompleteName,                                       \
+               decltype(&CppImpl::GetScopeFromCompleteName))                   \
+  DISPATCH_API(InstantiateTemplate, decltype(&CppImpl::InstantiateTemplate))   \
+  DISPATCH_API(GetParentScope, decltype(&CppImpl::GetParentScope))             \
+  DISPATCH_API(IsTemplate, decltype(&CppImpl::IsTemplate))                     \
+  DISPATCH_API(IsTemplateSpecialization,                                       \
+               decltype(&CppImpl::IsTemplateSpecialization))                   \
+  DISPATCH_API(IsTypedefed, decltype(&CppImpl::IsTypedefed))                   \
+  DISPATCH_API(IsClassPolymorphic, decltype(&CppImpl::IsClassPolymorphic))     \
+  DISPATCH_API(Demangle, decltype(&CppImpl::Demangle))                         \
+  DISPATCH_API(SizeOf, decltype(&CppImpl::SizeOf))                             \
+  DISPATCH_API(GetSizeOfType, decltype(&CppImpl::GetSizeOfType))               \
+  DISPATCH_API(IsBuiltin, decltype(&CppImpl::IsBuiltin))                       \
+  DISPATCH_API(IsComplete, decltype(&CppImpl::IsComplete))                     \
+  DISPATCH_API(Allocate, decltype(&CppImpl::Allocate))                         \
+  DISPATCH_API(Deallocate, decltype(&CppImpl::Deallocate))                     \
+  DISPATCH_API(Construct, decltype(&CppImpl::Construct))                       \
+  DISPATCH_API(Destruct, decltype(&CppImpl::Destruct))                         \
+  DISPATCH_API(IsAbstract, decltype(&CppImpl::IsAbstract))                     \
+  DISPATCH_API(IsEnumScope, decltype(&CppImpl::IsEnumScope))                   \
+  DISPATCH_API(IsEnumConstant, decltype(&CppImpl::IsEnumConstant))             \
+  DISPATCH_API(IsAggregate, decltype(&CppImpl::IsAggregate))                   \
+  DISPATCH_API(HasDefaultConstructor,                                          \
+               decltype(&CppImpl::HasDefaultConstructor))                      \
+  DISPATCH_API(IsVariable, decltype(&CppImpl::IsVariable))                     \
+  DISPATCH_API(GetAllCppNames, decltype(&CppImpl::GetAllCppNames))             \
+  DISPATCH_API(GetUsingNamespaces, decltype(&CppImpl::GetUsingNamespaces))     \
+  DISPATCH_API(GetCompleteName, decltype(&CppImpl::GetCompleteName))           \
+  DISPATCH_API(GetDestructor, decltype(&CppImpl::GetDestructor))               \
+  DISPATCH_API(IsVirtualMethod, decltype(&CppImpl::IsVirtualMethod))           \
+  DISPATCH_API(GetNumBases, decltype(&CppImpl::GetNumBases))                   \
+  DISPATCH_API(GetName, decltype(&CppImpl::GetName))                           \
+  DISPATCH_API(GetBaseClass, decltype(&CppImpl::GetBaseClass))                 \
+  DISPATCH_API(IsSubclass, decltype(&CppImpl::IsSubclass))                     \
+  DISPATCH_API(GetOperator, decltype(&CppImpl::GetOperator))                   \
+  DISPATCH_API(GetFunctionReturnType,                                          \
+               decltype(&CppImpl::GetFunctionReturnType))                      \
+  DISPATCH_API(GetBaseClassOffset, decltype(&CppImpl::GetBaseClassOffset))     \
+  DISPATCH_API(GetClassMethods, decltype(&CppImpl::GetClassMethods))           \
+  DISPATCH_API(GetFunctionsUsingName,                                          \
+               decltype(&CppImpl::GetFunctionsUsingName))                      \
+  DISPATCH_API(GetFunctionNumArgs, decltype(&CppImpl::GetFunctionNumArgs))     \
+  DISPATCH_API(GetFunctionRequiredArgs,                                        \
+               decltype(&CppImpl::GetFunctionRequiredArgs))                    \
+  DISPATCH_API(GetFunctionArgName, decltype(&CppImpl::GetFunctionArgName))     \
+  DISPATCH_API(GetFunctionArgType, decltype(&CppImpl::GetFunctionArgType))     \
+  DISPATCH_API(GetFunctionArgDefault,                                          \
+               decltype(&CppImpl::GetFunctionArgDefault))                      \
+  DISPATCH_API(IsConstMethod, decltype(&CppImpl::IsConstMethod))               \
+  DISPATCH_API(GetFunctionTemplatedDecls,                                      \
+               decltype(&CppImpl::GetFunctionTemplatedDecls))                  \
+  DISPATCH_API(ExistsFunctionTemplate,                                         \
+               decltype(&CppImpl::ExistsFunctionTemplate))                     \
+  DISPATCH_API(IsTemplatedFunction, decltype(&CppImpl::IsTemplatedFunction))   \
+  DISPATCH_API(IsStaticMethod, decltype(&CppImpl::IsStaticMethod))             \
+  DISPATCH_API(GetClassTemplatedMethods,                                       \
+               decltype(&CppImpl::GetClassTemplatedMethods))                   \
+  DISPATCH_API(BestOverloadFunctionMatch,                                      \
+               decltype(&CppImpl::BestOverloadFunctionMatch))                  \
+  DISPATCH_API(GetOperatorFromSpelling,                                        \
+               decltype(&CppImpl::GetOperatorFromSpelling))                    \
+  DISPATCH_API(IsFunctionDeleted, decltype(&CppImpl::IsFunctionDeleted))       \
+  DISPATCH_API(IsPublicMethod, decltype(&CppImpl::IsPublicMethod))             \
+  DISPATCH_API(IsProtectedMethod, decltype(&CppImpl::IsProtectedMethod))       \
+  DISPATCH_API(IsPrivateMethod, decltype(&CppImpl::IsPrivateMethod))           \
+  DISPATCH_API(IsConstructor, decltype(&CppImpl::IsConstructor))               \
+  DISPATCH_API(IsDestructor, decltype(&CppImpl::IsDestructor))                 \
+  DISPATCH_API(GetDatamembers, decltype(&CppImpl::GetDatamembers))             \
+  DISPATCH_API(GetStaticDatamembers, decltype(&CppImpl::GetStaticDatamembers)) \
+  DISPATCH_API(GetEnumConstantDatamembers,                                     \
+               decltype(&CppImpl::GetEnumConstantDatamembers))                 \
+  DISPATCH_API(LookupDatamember, decltype(&CppImpl::LookupDatamember))         \
+  DISPATCH_API(IsLambdaClass, decltype(&CppImpl::IsLambdaClass))               \
+  DISPATCH_API(GetQualifiedName, decltype(&CppImpl::GetQualifiedName))         \
+  DISPATCH_API(GetVariableOffset, decltype(&CppImpl::GetVariableOffset))       \
+  DISPATCH_API(IsPublicVariable, decltype(&CppImpl::IsPublicVariable))         \
+  DISPATCH_API(IsProtectedVariable, decltype(&CppImpl::IsProtectedVariable))   \
+  DISPATCH_API(IsPrivateVariable, decltype(&CppImpl::IsPrivateVariable))       \
+  DISPATCH_API(IsStaticVariable, decltype(&CppImpl::IsStaticVariable))         \
+  DISPATCH_API(IsConstVariable, decltype(&CppImpl::IsConstVariable))           \
+  DISPATCH_API(GetDimensions, decltype(&CppImpl::GetDimensions))               \
+  DISPATCH_API(GetEnumConstants, decltype(&CppImpl::GetEnumConstants))         \
+  DISPATCH_API(GetEnumConstantType, decltype(&CppImpl::GetEnumConstantType))   \
+  DISPATCH_API(GetEnumConstantValue, decltype(&CppImpl::GetEnumConstantValue)) \
+  DISPATCH_API(DumpScope, decltype(&CppImpl::DumpScope))                       \
+  DISPATCH_API(AddSearchPath, decltype(&CppImpl::AddSearchPath))               \
+  DISPATCH_API(Evaluate, decltype(&CppImpl::Evaluate))                         \
+  DISPATCH_API(IsDebugOutputEnabled, decltype(&CppImpl::IsDebugOutputEnabled)) \
+  DISPATCH_API(EnableDebugOutput, decltype(&CppImpl::EnableDebugOutput))       \
+  DISPATCH_API(BeginStdStreamCapture,                                          \
+               decltype(&CppImpl::BeginStdStreamCapture))                      \
+  DISPATCH_API(MakeFunctionCallable,                                           \
+               CppImpl::JitCall (*)(CppImpl::TCppConstFunction_t))             \
+  DISPATCH_API(GetFunctionAddress,                                             \
+               CppImpl::TCppFuncAddr_t (*)(CppImpl::TCppFunction_t))           \
+  /*DISPATCH_API(API_name, fnptr_ty)*/
+
+// TODO: implement overload that takes an existing opened DL handle
+inline void* dlGetProcAddress(const char* name,
+                              const char* customLibPath = nullptr) {
+  if (!name)
+    return nullptr;
+
+  static std::once_flag init;
+  static void* (*getProc)(const char*) = nullptr;
+
+  // this is currently not tested in a multiple thread/process setup
+  std::call_once(init, [customLibPath]() {
+    const char* path =
+        customLibPath ? customLibPath : std::getenv("CPPINTEROP_LIBRARY_PATH");
+    if (!path)
+      return;
+
+#ifdef _WIN32
+    HMODULE h = LoadLibraryA(path);
+    if (h) {
+      getProc = reinterpret_cast<void* (*)(const char*)>(
+          GetProcAddress(h, "CppGetProcAddress"));
+      if (!getProc)
+        FreeLibrary(h);
+    }
+#else
+    void* handle = dlopen(path, RTLD_LOCAL | RTLD_NOW);
+    if (handle) {
+      // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+      getProc = reinterpret_cast<void* (*)(const char*)>(
+          dlsym(handle, "CppGetProcAddress"));
+      if (!getProc) dlclose(handle);
+    }
+#endif
+  });
+
+  return getProc ? getProc(name) : nullptr;
+}
+
+// CppAPIType is used for the extern clauses below
+// FIXME: drop the using clauses
+namespace CppAPIType {
+// NOLINTBEGIN(bugprone-macro-parentheses)
+#define DISPATCH_API(name, type) using name = type;
+CPPINTEROP_API_TABLE
+#undef DISPATCH_API
+// NOLINTEND(bugprone-macro-parentheses)
+} // end namespace CppAPIType
+
+namespace CppInternal::Dispatch {
+
+// FIXME: This is required for the types, but we should move the types
+// into a separate namespace and only use that scope (CppImpl::Types)
+using namespace CppImpl;
+
+// NOLINTBEGIN(cppcoreguidelines-avoid-non-const-global-variables)
+#define DISPATCH_API(name, type) extern CppAPIType::name name;
+CPPINTEROP_API_TABLE
+#undef DISPATCH_API
+// NOLINTEND(cppcoreguidelines-avoid-non-const-global-variables)
+
+/// Initialize all CppInterOp API from the dynamically loaded library
+/// (RTLD_LOCAL)
+/// \param[in] customLibPath Optional custom path to libclangCppInterOp
+/// \returns true if initialization succeeded, false otherwise
+inline bool LoadDispatchAPI(const char* customLibPath = nullptr) {
+  std::cout << "[CppInterOp Dispatch] Loading CppInterOp API from "
+            << (customLibPath ? customLibPath : "default library path") << '\n';
+  if (customLibPath) {
+    void* test = dlGetProcAddress("GetInterpreter", customLibPath);
+    if (!test) {
+      std::cerr << "[CppInterOp Dispatch] Failed to load API from: "
+                << customLibPath << '\n';
+      return false;
+    }
+  }
+
+// NOLINTBEGIN(cppcoreguidelines-pro-type-reinterpret-cast)
+#define DISPATCH_API(name, type)                                               \
+  name = reinterpret_cast<type>(dlGetProcAddress(#name));
+  CPPINTEROP_API_TABLE
+#undef DISPATCH_API
+  // NOLINTEND(cppcoreguidelines-pro-type-reinterpret-cast)
+
+  // Sanity check to verify that critical (and consequently all) functions are
+  // loaded
+  if (!GetInterpreter || !CreateInterpreter) {
+    std::cerr << "[CppInterOp Dispatch] Failed to load critical functions\n";
+    return false;
+  }
+
+  return true;
+}
+
+// Unload all CppInterOp API functions
+inline void UnloadDispatchAPI() {
+#define DISPATCH_API(name, type) name = nullptr;
+  CPPINTEROP_API_TABLE
+#undef DISPATCH_API
+}
+} // namespace CppInternal::Dispatch
+
+// NOLINTNEXTLINE(misc-unused-alias-decls)
+namespace Cpp = CppInternal::Dispatch;
+#endif // CPPINTEROP_DISPATCH_H

--- a/lib/CppInterOp/CMakeLists.txt
+++ b/lib/CppInterOp/CMakeLists.txt
@@ -107,6 +107,7 @@ endif(LLVM_LINK_LLVM_DYLIB)
 add_llvm_library(clangCppInterOp
   DISABLE_LLVM_LINK_LLVM_DYLIB
   CppInterOp.cpp
+  Dispatch.cpp
   CXCppInterOp.cpp
   ${DLM}
   LINK_LIBS

--- a/lib/CppInterOp/CXCppInterOp.cpp
+++ b/lib/CppInterOp/CXCppInterOp.cpp
@@ -323,9 +323,9 @@ void clang_Interpreter_addIncludePath(CXInterpreter I, const char* dir) {
   getInterpreter(I)->AddIncludePath(dir);
 }
 
-namespace Cpp {
+namespace CppImpl {
 int Declare(compat::Interpreter& interp, const char* code, bool silent);
-} // namespace Cpp
+} // namespace CppImpl
 
 enum CXErrorCode clang_Interpreter_declare(CXInterpreter I, const char* code,
                                            bool silent) {
@@ -406,11 +406,11 @@ CXString clang_Interpreter_searchLibrariesForSymbol(CXInterpreter I,
           mangled_name, search_system));
 }
 
-namespace Cpp {
+namespace CppImpl {
 bool InsertOrReplaceJitSymbol(compat::Interpreter& I,
                               const char* linker_mangled_name,
                               uint64_t address);
-} // namespace Cpp
+} // namespace CppImpl
 
 bool clang_Interpreter_insertOrReplaceJitSymbol(CXInterpreter I,
                                                 const char* linker_mangled_name,
@@ -565,12 +565,12 @@ bool clang_existsFunctionTemplate(const char* name, CXScope parent) {
   return true;
 }
 
-namespace Cpp {
+namespace CppImpl {
 TCppScope_t InstantiateTemplate(compat::Interpreter& I, TCppScope_t tmpl,
                                 const TemplateArgInfo* template_args,
                                 size_t template_args_size,
                                 bool instantiate_body = false);
-} // namespace Cpp
+} // namespace CppImpl
 
 CXScope clang_instantiateTemplate(CXScope tmpl,
                                   CXTemplateArgInfo* template_args,
@@ -593,10 +593,10 @@ CXObject clang_allocate(unsigned int n) { return ::operator new(n); }
 
 void clang_deallocate(CXObject address) { ::operator delete(address); }
 
-namespace Cpp {
+namespace CppImpl {
 void* Construct(compat::Interpreter& interp, TCppScope_t scope,
                 void* arena /*=nullptr*/, TCppIndex_t count);
-} // namespace Cpp
+} // namespace CppImpl
 
 CXObject clang_construct(CXScope scope, void* arena, size_t count) {
   return Cpp::Construct(*getInterpreter(scope),
@@ -609,10 +609,10 @@ void clang_invoke(CXScope func, void* result, void** args, size_t n,
       .Invoke(result, {args, n}, self);
 }
 
-namespace Cpp {
+namespace CppImpl {
 bool Destruct(compat::Interpreter& interp, TCppObject_t This,
               const clang::Decl* Class, bool withFree, size_t nary);
-} // namespace Cpp
+} // namespace CppImpl
 
 bool clang_destruct(CXObject This, CXScope S, bool withFree, size_t nary) {
   return Cpp::Destruct(*getInterpreter(S), This, getDecl(S), withFree, nary);

--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -104,8 +104,8 @@
 #include <unistd.h>
 #endif // WIN32
 
-//  Runtime symbols required if the library using JIT (Cpp::Evaluate) does not
-//  link to llvm
+//  Runtime symbols required if the library using JIT (Cpp::Evaluate) does
+//  not link to llvm
 #if !defined(CPPINTEROP_USE_CLING) && !defined(EMSCRIPTEN)
 struct __clang_Interpreter_NewTag {
 } __ci_newtag;
@@ -131,7 +131,7 @@ void __clang_Interpreter_SetValueNoAlloc(void*, void*, void*,
 #endif
 #endif // CPPINTEROP_USE_CLING
 
-namespace Cpp {
+namespace CppImpl {
 
 using namespace clang;
 using namespace llvm;
@@ -4349,4 +4349,4 @@ pid_t GetExecutorPID() {
 
 #endif
 
-} // end namespace Cpp
+} // namespace CppImpl

--- a/lib/CppInterOp/Dispatch.cpp
+++ b/lib/CppInterOp/Dispatch.cpp
@@ -1,0 +1,26 @@
+#include <CppInterOp/Dispatch.h>
+
+#include <iostream> // for std::cerr
+#include <string_view>
+#include <unordered_map>
+
+// NOLINTBEGIN(cppcoreguidelines-pro-type-cstyle-cast)
+static const std::unordered_map<std::string_view, CppFnPtrTy> DispatchMap = {
+#define DISPATCH_API(name, type)                                               \
+  {#name, (CppFnPtrTy) static_cast<type>(&CppImpl::name)},
+    CPPINTEROP_API_TABLE
+#undef DISPATCH_API
+};
+// NOLINTEND(cppcoreguidelines-pro-type-cstyle-cast)
+
+CppFnPtrTy CppGetProcAddress(const char* funcName) {
+  auto it = DispatchMap.find(funcName);
+  if (it == DispatchMap.end()) {
+    std::cerr
+        << "[CppInterOp Dispatch] Failed to find API: " << funcName
+        << " May need to be ported to the symbol-address table in Dispatch.h\n";
+    return nullptr;
+  }
+  // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
+  return reinterpret_cast<CppFnPtrTy>(it->second);
+}

--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -30,11 +30,18 @@ add_dependencies(CppInterOpUnitTests clangCppInterOp)
 
 set (TIMEOUT_VALUE 2400)
 function(add_cppinterop_unittest name)
-  add_executable(${name} EXCLUDE_FROM_ALL ${ARGN})
+  cmake_parse_arguments(ARG
+    "ENABLE_DISPATCH"
+    ""
+    ""
+    ${ARGN}
+  )
+  add_executable(${name} EXCLUDE_FROM_ALL ${ARG_UNPARSED_ARGUMENTS})
   add_dependencies(CppInterOpUnitTests ${name})
   target_include_directories(${name} PUBLIC ${CMAKE_CURRENT_BINARY_DIR} ${GTEST_INCLUDE_DIR})
   set_property(TARGET ${name} PROPERTY RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
   export_executable_symbols(${name})
+
   if(WIN32)
     target_link_libraries(${name} PUBLIC ${ARG_LIBRARIES} ${gtest_libs})
     set_property(TARGET ${name} APPEND_STRING PROPERTY LINK_FLAGS "${MSVC_EXPORTS}")
@@ -65,8 +72,16 @@ function(add_cppinterop_unittest name)
                         ENVIRONMENT "CPLUS_INCLUDE_PATH=${CMAKE_BINARY_DIR}/etc"
                         LABELS
                         DEPENDS)
-  # FIXME: Just call gtest_add_tests this function is available.
-  #gtest_add_tests(${name} "${Arguments}" AUTO)
+  # Auto-generate the dispatch version if shared libs are built by recursively calling
+  # add_cppinterop_unittest with the necessary compile definitions
+  # FIXME: Enable for WASM builds
+  if (NOT EMSCRIPTEN AND ARG_ENABLE_DISPATCH AND BUILD_SHARED_LIBS)
+    add_cppinterop_unittest(${name}Dispatch ${ARG_UNPARSED_ARGUMENTS} DispatchTest.cpp)
+    target_compile_definitions(${name}Dispatch PRIVATE 
+      ENABLE_DISPATCH_TESTS
+      CPPINTEROP_LIB_PATH="${CMAKE_BINARY_DIR}/lib/libclangCppInterOp${CMAKE_SHARED_LIBRARY_SUFFIX}"
+    )
+  endif()
 endfunction()
 
 add_subdirectory(CppInterOp)

--- a/unittests/CppInterOp/CMakeLists.txt
+++ b/unittests/CppInterOp/CMakeLists.txt
@@ -11,6 +11,7 @@ else()
 endif()
 
 add_cppinterop_unittest(CppInterOpTests
+  ENABLE_DISPATCH
   CommentReflectionTest.cpp
   EnumReflectionTest.cpp
   FunctionReflectionTest.cpp

--- a/unittests/CppInterOp/CUDATest.cpp
+++ b/unittests/CppInterOp/CUDATest.cpp
@@ -6,6 +6,8 @@
 
 #include "gtest/gtest.h"
 
+#include <cstdint>
+
 using namespace TestUtils;
 
 static bool HasCudaSDK() {
@@ -17,7 +19,7 @@ static bool HasCudaSDK() {
     if (!Cpp::CreateInterpreter({}, {"--cuda"}))
       return false;
     return Cpp::Declare("__global__ void test_func() {}"
-                        "test_func<<<1,1>>>();") == 0;
+                        "test_func<<<1,1>>>();" DFLT_FALSE) == 0;
   };
   static bool hasCuda = supportsCudaSDK();
   return hasCuda;
@@ -35,9 +37,9 @@ static bool HasCudaRuntime() {
     if (!Cpp::CreateInterpreter({}, {"--cuda"}))
       return false;
     if (Cpp::Declare("__global__ void test_func() {}"
-                     "test_func<<<1,1>>>();"))
+                     "test_func<<<1,1>>>();" DFLT_FALSE))
       return false;
-    intptr_t result = Cpp::Evaluate("(bool)cudaGetLastError()");
+    intptr_t result = Cpp::Evaluate("(bool)cudaGetLastError()" DFLT_NULLPTR);
     return !(bool)result;
   };
   static bool hasCuda = supportsCuda();
@@ -65,7 +67,7 @@ TEST(CUDATest, CUDAH) {
     GTEST_SKIP() << "Skipping CUDA tests as CUDA SDK not found";
 
   Cpp::CreateInterpreter({}, {"--cuda"});
-  bool success = !Cpp::Declare("#include <cuda.h>");
+  bool success = !Cpp::Declare("#include <cuda.h>" DFLT_FALSE);
   EXPECT_TRUE(success);
 }
 

--- a/unittests/CppInterOp/CommentReflectionTest.cpp
+++ b/unittests/CppInterOp/CommentReflectionTest.cpp
@@ -12,7 +12,7 @@ using namespace TestUtils;
 using namespace llvm;
 using namespace clang;
 
-TYPED_TEST(CppInterOpTest, CommentReflectionDoxygenBlockAndLine) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, CommentReflection_DoxygenBlockAndLine) {
   std::vector<Decl*> Decls;
   std::string code = R"(
     /** Adds two integers.
@@ -49,18 +49,18 @@ TYPED_TEST(CppInterOpTest, CommentReflectionDoxygenBlockAndLine) {
   clang_Interpreter_dispose(I);
 }
 
-TYPED_TEST(CppInterOpTest, CommentReflectionDoxygenNullScope) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, CommentReflection_DoxygenNullScope) {
   CXScope NullS{};
   CXString Doc = clang_getDoxygenComment(NullS, /*strip_comment_markers=*/true);
   EXPECT_STREQ(get_c_string(Doc), "");
   dispose_string(Doc);
 }
 
-TYPED_TEST(CppInterOpTest, CommentReflectionDoxygenNullPtr) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, CommentReflection_DoxygenNullPtr) {
   EXPECT_EQ(Cpp::GetDoxygenComment(nullptr, /*strip=*/true), "");
 }
 
-TYPED_TEST(CppInterOpTest, CommentReflectionDoxygenNoComment) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, CommentReflection_DoxygenNoComment) {
   std::vector<Decl*> Decls;
   std::string code = R"(
     int foo() { return 42; }
@@ -71,7 +71,7 @@ TYPED_TEST(CppInterOpTest, CommentReflectionDoxygenNoComment) {
   EXPECT_EQ(Cpp::GetDoxygenComment(Decls[0], /*strip=*/true), "");
 }
 
-TYPED_TEST(CppInterOpTest, CommentReflectionDoxygenNonDoxygenComment) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, CommentReflection_DoxygenNonDoxygenComment) {
   std::vector<Decl*> Decls;
   std::string code = R"(
     // A regular non-doxygen comment.
@@ -82,4 +82,3 @@ TYPED_TEST(CppInterOpTest, CommentReflectionDoxygenNonDoxygenComment) {
   ASSERT_GE(Decls.size(), 1U);
   EXPECT_EQ(Cpp::GetDoxygenComment(Decls[0], /*strip=*/true), "");
 }
-

--- a/unittests/CppInterOp/DispatchTest.cpp
+++ b/unittests/CppInterOp/DispatchTest.cpp
@@ -1,0 +1,71 @@
+#include "Utils.h"
+
+#include "CppInterOp/Dispatch.h"
+
+#include "clang/AST/Decl.h"
+#include "clang/AST/GlobalDecl.h"
+
+#include "gtest/gtest.h"
+
+#include <vector>
+
+using namespace TestUtils;
+using namespace llvm;
+using namespace clang;
+
+// NOLINTBEGIN(cppcoreguidelines-pro-type-reinterpret-cast)
+
+TEST(CPPINTEROP_TEST_MODE, DispatchAPI_CppGetProcAddress_Basic) {
+  auto IsClassFn =
+      reinterpret_cast<CppAPIType::IsClass>(CppGetProcAddress("IsClass"));
+  EXPECT_NE(IsClassFn, nullptr) << "Failed to obtain API function pointer";
+  std::vector<Decl*> Decls;
+  GetAllTopLevelDecls("namespace N {} class C{}; int I;", Decls);
+  EXPECT_FALSE(IsClassFn(Decls[0]));
+  EXPECT_TRUE(IsClassFn(Decls[1]));
+  EXPECT_FALSE(IsClassFn(Decls[2]));
+}
+
+TEST(CPPINTEROP_TEST_MODE, DispatchAPI_CppGetProcAddress_Unimplemented) {
+  testing::internal::CaptureStderr();
+  void (*func_ptr)() = CppGetProcAddress("NonExistentFunction");
+  std::string output = testing::internal::GetCapturedStderr();
+  EXPECT_EQ(output,
+            "[CppInterOp Dispatch] Failed to find API: NonExistentFunction May "
+            "need to be ported to the symbol-address table in Dispatch.h\n");
+  EXPECT_EQ(func_ptr, nullptr);
+}
+
+TEST(CPPINTEROP_TEST_MODE, DispatchAPI_CppGetProcAddress_Advanced) {
+  std::string code = R"(
+    int add(int x, int y) { return x + y; }
+    int add(double x, double y) { return x + y; }
+  )";
+
+  std::vector<Decl*> Decls;
+  GetAllTopLevelDecls(code, Decls);
+  EXPECT_EQ(Decls.size(), 2);
+
+  auto Add_int = clang::GlobalDecl(static_cast<clang::NamedDecl*>(Decls[0]));
+  auto Add_double = clang::GlobalDecl(static_cast<clang::NamedDecl*>(Decls[1]));
+
+  std::string mangled_add_int;
+  std::string mangled_add_double;
+  compat::maybeMangleDeclName(Add_int, mangled_add_int);
+  compat::maybeMangleDeclName(Add_double, mangled_add_double);
+
+  auto DemangleFn =
+      reinterpret_cast<CppAPIType::Demangle>(CppGetProcAddress("Demangle"));
+  auto GetQualifiedCompleteNameFn =
+      reinterpret_cast<CppAPIType::GetQualifiedCompleteName>(
+          CppGetProcAddress("GetQualifiedCompleteName"));
+
+  std::string demangled_add_int = DemangleFn(mangled_add_int);
+  std::string demangled_add_double = DemangleFn(mangled_add_double);
+
+  EXPECT_NE(demangled_add_int.find(GetQualifiedCompleteNameFn(Decls[0])),
+            std::string::npos);
+  EXPECT_NE(demangled_add_double.find(GetQualifiedCompleteNameFn(Decls[1])),
+            std::string::npos);
+}
+// NOLINTEND(cppcoreguidelines-pro-type-reinterpret-cast)

--- a/unittests/CppInterOp/DynamicLibraryManagerTest.cpp
+++ b/unittests/CppInterOp/DynamicLibraryManagerTest.cpp
@@ -20,7 +20,7 @@ std::string GetExecutablePath(const char* Argv0) {
   return llvm::sys::fs::getMainExecutable(Argv0, MainAddr);
 }
 
-TYPED_TEST(CppInterOpTest, DynamicLibraryManagerTestSanity) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, DynamicLibraryManager_Sanity) {
 #ifdef EMSCRIPTEN
   GTEST_SKIP() << "Test fails for Emscipten builds";
 #endif
@@ -69,7 +69,7 @@ TYPED_TEST(CppInterOpTest, DynamicLibraryManagerTestSanity) {
   // EXPECT_FALSE(Cpp::GetFunctionAddress("ret_zero"));
 }
 
-TYPED_TEST(CppInterOpTest, DynamicLibraryManagerTestBasicSymbolLookup) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, DynamicLibraryManager_BasicSymbolLookup) {
 #ifndef EMSCRIPTEN
   GTEST_SKIP() << "This test is only intended for Emscripten builds.";
 #else

--- a/unittests/CppInterOp/EnumReflectionTest.cpp
+++ b/unittests/CppInterOp/EnumReflectionTest.cpp
@@ -12,7 +12,7 @@ using namespace TestUtils;
 using namespace llvm;
 using namespace clang;
 
-TYPED_TEST(CppInterOpTest, EnumReflectionTestIsEnumType) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, EnumReflection_IsEnumType) {
   std::vector<Decl *> Decls;
   std::string code =  R"(
     enum class E {
@@ -40,7 +40,7 @@ TYPED_TEST(CppInterOpTest, EnumReflectionTestIsEnumType) {
   EXPECT_TRUE(Cpp::IsEnumType(Cpp::GetVariableType(Decls[5])));
 }
 
-TYPED_TEST(CppInterOpTest, EnumReflectionTestGetIntegerTypeFromEnumScope) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, EnumReflection_GetIntegerTypeFromEnumScope) {
   std::vector<Decl *> Decls;
   std::string code = R"(
     enum Switch : bool {
@@ -90,7 +90,7 @@ TYPED_TEST(CppInterOpTest, EnumReflectionTestGetIntegerTypeFromEnumScope) {
   EXPECT_EQ(Cpp::GetTypeAsString(Cpp::GetIntegerTypeFromEnumScope(Decls[5])),"NULL TYPE");
 }
 
-TYPED_TEST(CppInterOpTest, EnumReflectionTestGetIntegerTypeFromEnumType) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, EnumReflection_GetIntegerTypeFromEnumType) {
   std::vector<Decl *> Decls;
   std::string code = R"(
     enum Switch : bool {
@@ -150,7 +150,7 @@ TYPED_TEST(CppInterOpTest, EnumReflectionTestGetIntegerTypeFromEnumType) {
   EXPECT_EQ(get_int_type_from_enum_var(Decls[11]), "NULL TYPE"); // When a non Enum Type variable is used
 }
 
-TYPED_TEST(CppInterOpTest, EnumReflectionTestGetEnumConstants) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, EnumReflection_GetEnumConstants) {
   std::vector<Decl *> Decls;
   std::string code = R"(
     enum ZeroEnum {
@@ -194,7 +194,7 @@ TYPED_TEST(CppInterOpTest, EnumReflectionTestGetEnumConstants) {
   EXPECT_EQ(Cpp::GetEnumConstants(Decls[5]).size(), 0);
 }
 
-TYPED_TEST(CppInterOpTest, EnumReflectionTestGetEnumConstantType) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, EnumReflection_GetEnumConstantType) {
   std::vector<Decl *> Decls;
   std::string code = R"(
     enum Enum0 {
@@ -225,7 +225,7 @@ TYPED_TEST(CppInterOpTest, EnumReflectionTestGetEnumConstantType) {
   EXPECT_EQ(get_enum_constant_type_as_str(nullptr), "NULL TYPE");
 }
 
-TYPED_TEST(CppInterOpTest, EnumReflectionTestGetEnumConstantValue) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, EnumReflection_GetEnumConstantValue) {
   std::vector<Decl *> Decls;
   std::string code = R"(
     enum Counter {
@@ -253,7 +253,7 @@ TYPED_TEST(CppInterOpTest, EnumReflectionTestGetEnumConstantValue) {
   EXPECT_EQ(Cpp::GetEnumConstantValue(Decls[1]), 0); // Checking value of non enum constant
 }
 
-TYPED_TEST(CppInterOpTest, EnumReflectionTestGetEnums) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, EnumReflection_GetEnums) {
   std::string code = R"(
     enum Color {
       Red,
@@ -302,8 +302,8 @@ TYPED_TEST(CppInterOpTest, EnumReflectionTestGetEnums) {
   Cpp::TCppScope_t myClass_scope = Cpp::GetScope("myClass", 0);
   Cpp::TCppScope_t unsupported_scope = Cpp::GetScope("myVariable", 0);
 
-  Cpp::GetEnums(globalscope,enumNames1);
-  Cpp::GetEnums(Animals_scope,enumNames2);
+  Cpp::GetEnums(globalscope, enumNames1);
+  Cpp::GetEnums(Animals_scope, enumNames2);
   Cpp::GetEnums(myClass_scope, enumNames3);
   Cpp::GetEnums(unsupported_scope, enumNames4);
 

--- a/unittests/CppInterOp/FunctionReflectionTest.cpp
+++ b/unittests/CppInterOp/FunctionReflectionTest.cpp
@@ -14,12 +14,18 @@
 #include "gtest/gtest.h"
 
 #include <string>
+#include <vector>
 
 using namespace TestUtils;
 using namespace llvm;
 using namespace clang;
 
-TYPED_TEST(CppInterOpTest, FunctionReflectionTestGetClassMethods) {
+// Reusable empty template args vector. In the dispatch mode, passing an empty
+// initializer list {} does not work since the compiler cannot deduce the type
+// for a function pointer
+static const std::vector<Cpp::TemplateArgInfo> empty_templ_args = {};
+
+TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_GetClassMethods) {
   std::vector<Decl*> Decls;
   std::string code = R"(
     class A;
@@ -171,7 +177,8 @@ TYPED_TEST(CppInterOpTest, FunctionReflectionTestGetClassMethods) {
   clang_Interpreter_dispose(I);
 }
 
-TYPED_TEST(CppInterOpTest, FunctionReflectionTestConstructorInGetClassMethods) {
+TYPED_TEST(CPPINTEROP_TEST_MODE,
+           FunctionReflection_ConstructorInGetClassMethods) {
   std::vector<Decl*> Decls;
   std::string code = R"(
     struct S {
@@ -195,7 +202,7 @@ TYPED_TEST(CppInterOpTest, FunctionReflectionTestConstructorInGetClassMethods) {
   EXPECT_TRUE(has_constructor(Decls[0]));
 }
 
-TYPED_TEST(CppInterOpTest, FunctionReflectionTestHasDefaultConstructor) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_HasDefaultConstructor) {
   std::vector<Decl*> Decls;
   std::string code = R"(
     class A {
@@ -236,7 +243,7 @@ TYPED_TEST(CppInterOpTest, FunctionReflectionTestHasDefaultConstructor) {
   clang_Interpreter_dispose(I);
 }
 
-TYPED_TEST(CppInterOpTest, FunctionReflectionTestGetDestructor) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_GetDestructor) {
   std::vector<Decl*> Decls;
   std::string code = R"(
     class A {
@@ -272,7 +279,7 @@ TYPED_TEST(CppInterOpTest, FunctionReflectionTestGetDestructor) {
   clang_Interpreter_dispose(I);
 }
 
-TYPED_TEST(CppInterOpTest, FunctionReflectionTestGetFunctionsUsingName) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_GetFunctionsUsingName) {
   std::vector<Decl*> Decls;
   std::string code = R"(
     class A {
@@ -316,7 +323,7 @@ TYPED_TEST(CppInterOpTest, FunctionReflectionTestGetFunctionsUsingName) {
   EXPECT_EQ(get_number_of_funcs_using_name(Decls[2], ""), 0);
 }
 
-TYPED_TEST(CppInterOpTest, FunctionReflectionTestGetClassDecls) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_GetClassDecls) {
   std::vector<Decl*> Decls, SubDecls;
   std::string code = R"(
     class MyTemplatedMethodClass {
@@ -353,7 +360,7 @@ TYPED_TEST(CppInterOpTest, FunctionReflectionTestGetClassDecls) {
   EXPECT_EQ(Cpp::GetName(methods[3]), Cpp::GetName(SubDecls[8]));
 }
 
-TYPED_TEST(CppInterOpTest, FunctionReflectionTestGetFunctionTemplatedDecls) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_GetFunctionTemplatedDecls) {
   std::vector<Decl*> Decls, SubDecls;
   std::string code = R"(
     class MyTemplatedMethodClass {
@@ -390,7 +397,7 @@ TYPED_TEST(CppInterOpTest, FunctionReflectionTestGetFunctionTemplatedDecls) {
   EXPECT_EQ(Cpp::GetName(template_methods[3]), Cpp::GetName(SubDecls[6]));
 }
 
-TYPED_TEST(CppInterOpTest, FunctionReflectionTestGetFunctionReturnType) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_GetFunctionReturnType) {
   std::vector<Decl*> Decls, SubDecls, TemplateSubDecls;
   std::string code = R"(
     namespace N { class C {}; }
@@ -483,11 +490,12 @@ TYPED_TEST(CppInterOpTest, FunctionReflectionTestGetFunctionReturnType) {
 
   std::vector<Cpp::TemplateArgInfo> args2 = {C.DoubleTy.getAsOpaquePtr()};
   EXPECT_EQ(Cpp::GetTypeAsString(Cpp::GetFunctionReturnType(Cpp::GetNamed(
-                "func", Cpp::InstantiateTemplate(Decls[15], args2.data(), 1)))),
+                "func", Cpp::InstantiateTemplate(Decls[15], args2.data(),
+                                                 1 DFLT_FALSE)))),
             "double");
 }
 
-TYPED_TEST(CppInterOpTest, FunctionReflectionTestGetFunctionNumArgs) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_GetFunctionNumArgs) {
   std::vector<Decl*> Decls, TemplateSubDecls;
   std::string code = R"(
     void f1() {}
@@ -526,7 +534,7 @@ TYPED_TEST(CppInterOpTest, FunctionReflectionTestGetFunctionNumArgs) {
   EXPECT_EQ(Cpp::GetFunctionNumArgs(TemplateSubDecls[3]), 3);
 }
 
-TYPED_TEST(CppInterOpTest, FunctionReflectionTestGetFunctionRequiredArgs) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_GetFunctionRequiredArgs) {
   std::vector<Decl*> Decls, TemplateSubDecls;
   std::string code = R"(
     void f1() {}
@@ -561,7 +569,7 @@ TYPED_TEST(CppInterOpTest, FunctionReflectionTestGetFunctionRequiredArgs) {
   EXPECT_EQ(Cpp::GetFunctionRequiredArgs(TemplateSubDecls[3]), 2);
 }
 
-TYPED_TEST(CppInterOpTest, FunctionReflectionTestGetFunctionArgType) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_GetFunctionArgType) {
   std::vector<Decl*> Decls;
   std::string code = R"(
     void f1(int i, double d, long l, char ch) {}
@@ -581,7 +589,7 @@ TYPED_TEST(CppInterOpTest, FunctionReflectionTestGetFunctionArgType) {
   EXPECT_EQ(Cpp::GetTypeAsString(Cpp::GetFunctionArgType(Decls[2], 0)), "NULL TYPE");
 }
 
-TYPED_TEST(CppInterOpTest, FunctionReflectionTestGetFunctionSignature) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_GetFunctionSignature) {
   std::vector<Decl*> Decls;
   std::string code = R"(
     class C {
@@ -625,7 +633,7 @@ TYPED_TEST(CppInterOpTest, FunctionReflectionTestGetFunctionSignature) {
   EXPECT_EQ(Cpp::GetFunctionSignature(nullptr), "<unknown>");
 }
 
-TYPED_TEST(CppInterOpTest, FunctionReflectionTestIsTemplatedFunction) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_IsTemplatedFunction) {
   std::vector<Decl*> Decls;
   std::vector<Decl*> SubDeclsC1;
   std::string code = R"(
@@ -665,7 +673,7 @@ TYPED_TEST(CppInterOpTest, FunctionReflectionTestIsTemplatedFunction) {
   clang_Interpreter_dispose(I);
 }
 
-TYPED_TEST(CppInterOpTest, FunctionReflectionTestExistsFunctionTemplate) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_ExistsFunctionTemplate) {
   std::vector<Decl*> Decls;
   std::string code = R"(
     template<typename T>
@@ -693,7 +701,8 @@ TYPED_TEST(CppInterOpTest, FunctionReflectionTestExistsFunctionTemplate) {
   clang_Interpreter_dispose(I);
 }
 
-TYPED_TEST(CppInterOpTest, FunctionReflectionTestInstantiateTemplateFunctionFromString) {
+TYPED_TEST(CPPINTEROP_TEST_MODE,
+           FunctionReflection_InstantiateTemplateFunctionFromString) {
 #if CLANG_VERSION_MAJOR == 18 && defined(CPPINTEROP_USE_CLING) &&              \
     defined(_WIN32) && (defined(_M_ARM) || defined(_M_ARM64))
   GTEST_SKIP() << "Test fails with Cling on Windows on ARM";
@@ -709,7 +718,8 @@ TYPED_TEST(CppInterOpTest, FunctionReflectionTestInstantiateTemplateFunctionFrom
   EXPECT_TRUE(Instance1);
 }
 
-TYPED_TEST(CppInterOpTest, FunctionReflectionTestInstantiateFunctionTemplate) {
+TYPED_TEST(CPPINTEROP_TEST_MODE,
+           FunctionReflection_InstantiateFunctionTemplate) {
   std::vector<Decl*> Decls;
   std::string code = R"(
 template<typename T> T TrivialFnTemplate() { return T(); }
@@ -719,8 +729,9 @@ template<typename T> T TrivialFnTemplate() { return T(); }
   ASTContext& C = Interp->getCI()->getASTContext();
 
   std::vector<Cpp::TemplateArgInfo> args1 = {C.IntTy.getAsOpaquePtr()};
-  auto Instance1 = Cpp::InstantiateTemplate(Decls[0], args1.data(),
-                                            /*type_size*/ args1.size());
+  auto Instance1 =
+      Cpp::InstantiateTemplate(Decls[0], args1.data(),
+                               /*type_size*/ args1.size() DFLT_FALSE);
   EXPECT_TRUE(isa<FunctionDecl>((Decl*)Instance1));
   FunctionDecl* FD = cast<FunctionDecl>((Decl*)Instance1);
   FunctionDecl* FnTD1 = FD->getTemplateInstantiationPattern();
@@ -729,7 +740,7 @@ template<typename T> T TrivialFnTemplate() { return T(); }
   EXPECT_TRUE(TA1.getAsType()->isIntegerType());
 }
 
-TYPED_TEST(CppInterOpTest, FunctionReflectionTestInstantiateTemplateMethod) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_InstantiateTemplateMethod) {
   std::vector<Decl*> Decls;
   std::string code = R"(
     class MyTemplatedMethodClass {
@@ -747,8 +758,9 @@ TYPED_TEST(CppInterOpTest, FunctionReflectionTestInstantiateTemplateMethod) {
   ASTContext& C = Interp->getCI()->getASTContext();
 
   std::vector<Cpp::TemplateArgInfo> args1 = {C.IntTy.getAsOpaquePtr()};
-  auto Instance1 = Cpp::InstantiateTemplate(Decls[1], args1.data(),
-                                            /*type_size*/ args1.size());
+  auto Instance1 =
+      Cpp::InstantiateTemplate(Decls[1], args1.data(),
+                               /*type_size*/ args1.size() DFLT_FALSE);
   EXPECT_TRUE(isa<FunctionDecl>((Decl*)Instance1));
   FunctionDecl* FD = cast<FunctionDecl>((Decl*)Instance1);
   FunctionDecl* FnTD1 = FD->getTemplateInstantiationPattern();
@@ -757,7 +769,7 @@ TYPED_TEST(CppInterOpTest, FunctionReflectionTestInstantiateTemplateMethod) {
   EXPECT_TRUE(TA1.getAsType()->isIntegerType());
 }
 
-TYPED_TEST(CppInterOpTest, FunctionReflectionTestLookupConstructors) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_LookupConstructors) {
   if (llvm::sys::RunningOnValgrind())
     GTEST_SKIP() << "XFAIL due to Valgrind report";
 
@@ -798,7 +810,7 @@ TYPED_TEST(CppInterOpTest, FunctionReflectionTestLookupConstructors) {
   EXPECT_EQ(Cpp::GetFunctionSignature(ctors[3]), "MyClass::MyClass(T t)");
 }
 
-TYPED_TEST(CppInterOpTest, FunctionReflectionTestGetClassTemplatedMethods) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_GetClassTemplatedMethods) {
   if (llvm::sys::RunningOnValgrind())
     GTEST_SKIP() << "XFAIL due to Valgrind report";
 
@@ -856,7 +868,8 @@ TYPED_TEST(CppInterOpTest, FunctionReflectionTestGetClassTemplatedMethods) {
             "void MyClass::templatedStaticMethod(T param)");
 }
 
-TYPED_TEST(CppInterOpTest, FunctionReflectionTestGetClassTemplatedMethods_VariadicsAndOthers) {
+TYPED_TEST(CPPINTEROP_TEST_MODE,
+           FunctionReflection_GetClassTemplatedMethods_VariadicsAndOthers) {
   std::vector<Decl*> Decls;
   std::string code = R"(
     class MyClass {
@@ -910,7 +923,8 @@ TYPED_TEST(CppInterOpTest, FunctionReflectionTestGetClassTemplatedMethods_Variad
             "void MyClass::staticVariadic(T t, Args ...args)");
 }
 
-TYPED_TEST(CppInterOpTest, FunctionReflectionTestInstantiateVariadicFunction) {
+TYPED_TEST(CPPINTEROP_TEST_MODE,
+           FunctionReflection_InstantiateVariadicFunction) {
   std::vector<Decl*> Decls;
   std::string code = R"(
     class MyClass {};
@@ -927,8 +941,9 @@ TYPED_TEST(CppInterOpTest, FunctionReflectionTestInstantiateVariadicFunction) {
 
   std::vector<Cpp::TemplateArgInfo> args1 = {C.DoubleTy.getAsOpaquePtr(),
                                              C.IntTy.getAsOpaquePtr()};
-  auto Instance1 = Cpp::InstantiateTemplate(Decls[1], args1.data(),
-                                            /*type_size*/ args1.size());
+  auto Instance1 =
+      Cpp::InstantiateTemplate(Decls[1], args1.data(),
+                               /*type_size*/ args1.size() DFLT_FALSE);
   EXPECT_TRUE(Cpp::IsTemplatedFunction(Instance1));
   EXPECT_EQ(Cpp::GetFunctionSignature(Instance1),
             "template<> void VariadicFn<<double, int>>(double args, int args)");
@@ -973,7 +988,8 @@ TYPED_TEST(CppInterOpTest, FunctionReflectionTestInstantiateVariadicFunction) {
             "fixedParam, MyClass args, double args)");
 }
 
-TYPED_TEST(CppInterOpTest, FunctionReflectionTestBestOverloadFunctionMatch0) {
+TYPED_TEST(CPPINTEROP_TEST_MODE,
+           FunctionReflection_BestOverloadFunctionMatch0) {
   // make sure templates are not instantiated multiple times
   std::vector<Decl*> Decls;
   std::string code = R"(
@@ -1015,15 +1031,16 @@ TYPED_TEST(CppInterOpTest, FunctionReflectionTestBestOverloadFunctionMatch0) {
   EXPECT_EQ(fn, fn0);
 
   fn = Cpp::InstantiateTemplate(Decls[0], explicit_args1.data(),
-                                explicit_args1.size());
+                                explicit_args1.size() DFLT_FALSE);
   EXPECT_EQ(fn, fn0);
 
   fn = Cpp::InstantiateTemplate(Decls[0], explicit_args2.data(),
-                                explicit_args2.size());
+                                explicit_args2.size() DFLT_FALSE);
   EXPECT_EQ(fn, fn0);
 }
 
-TYPED_TEST(CppInterOpTest, FunctionReflectionTestBestOverloadFunctionMatch1) {
+TYPED_TEST(CPPINTEROP_TEST_MODE,
+           FunctionReflection_BestOverloadFunctionMatch1) {
   std::vector<Decl*> Decls;
   std::string code = R"(
     class MyTemplatedMethodClass {
@@ -1103,7 +1120,8 @@ TYPED_TEST(CppInterOpTest, FunctionReflectionTestBestOverloadFunctionMatch1) {
             "template<> long MyTemplatedMethodClass::get_size<1, int>(int a)");
 }
 
-TYPED_TEST(CppInterOpTest, FunctionReflectionTestBestOverloadFunctionMatch2) {
+TYPED_TEST(CPPINTEROP_TEST_MODE,
+           FunctionReflection_BestOverloadFunctionMatch2) {
   std::vector<Decl*> Decls;
   std::string code = R"(
     template<typename T>
@@ -1139,12 +1157,12 @@ TYPED_TEST(CppInterOpTest, FunctionReflectionTestBestOverloadFunctionMatch2) {
 
   std::vector<Cpp::TemplateArgInfo> args1 = {C.IntTy.getAsOpaquePtr()};
   std::vector<Cpp::TemplateArgInfo> args2 = {
-      Cpp::GetVariableType(Cpp::GetNamed("a"))};
+      Cpp::GetVariableType(Cpp::GetNamed("a" DFLT_NULLPTR))};
   std::vector<Cpp::TemplateArgInfo> args3 = {C.IntTy.getAsOpaquePtr(),
                                              C.IntTy.getAsOpaquePtr()};
   std::vector<Cpp::TemplateArgInfo> args4 = {
-      Cpp::GetVariableType(Cpp::GetNamed("a")),
-      Cpp::GetVariableType(Cpp::GetNamed("a"))};
+      Cpp::GetVariableType(Cpp::GetNamed("a" DFLT_NULLPTR)),
+      Cpp::GetVariableType(Cpp::GetNamed("a" DFLT_NULLPTR))};
   std::vector<Cpp::TemplateArgInfo> args5 = {C.IntTy.getAsOpaquePtr(),
                                              C.DoubleTy.getAsOpaquePtr()};
 
@@ -1173,7 +1191,8 @@ TYPED_TEST(CppInterOpTest, FunctionReflectionTestBestOverloadFunctionMatch2) {
             "void somefunc(int arg1, double arg2)");
 }
 
-TYPED_TEST(CppInterOpTest, FunctionReflectionTestBestOverloadFunctionMatch3) {
+TYPED_TEST(CPPINTEROP_TEST_MODE,
+           FunctionReflection_BestOverloadFunctionMatch3) {
   std::vector<Decl*> Decls;
   std::string code = R"(
     template<typename T>
@@ -1211,13 +1230,14 @@ TYPED_TEST(CppInterOpTest, FunctionReflectionTestBestOverloadFunctionMatch3) {
   ASTContext& C = Interp->getCI()->getASTContext();
 
   std::vector<Cpp::TemplateArgInfo> args1 = {
-      Cpp::GetVariableType(Cpp::GetNamed("a")),
-      Cpp::GetVariableType(Cpp::GetNamed("a"))};
+      Cpp::GetVariableType(Cpp::GetNamed("a" DFLT_NULLPTR)),
+      Cpp::GetVariableType(Cpp::GetNamed("a" DFLT_NULLPTR))};
   std::vector<Cpp::TemplateArgInfo> args2 = {
-      Cpp::GetVariableType(Cpp::GetNamed("a")), C.IntTy.getAsOpaquePtr()};
+      Cpp::GetVariableType(Cpp::GetNamed("a" DFLT_NULLPTR)),
+      C.IntTy.getAsOpaquePtr()};
   std::vector<Cpp::TemplateArgInfo> args3 = {
-      Cpp::GetVariableType(Cpp::GetNamed("a")), C.DoubleTy.getAsOpaquePtr()};
-
+      Cpp::GetVariableType(Cpp::GetNamed("a" DFLT_NULLPTR)),
+      C.DoubleTy.getAsOpaquePtr()};
   std::vector<Cpp::TemplateArgInfo> explicit_args;
 
   Cpp::TCppFunction_t func1 =
@@ -1228,14 +1248,14 @@ TYPED_TEST(CppInterOpTest, FunctionReflectionTestBestOverloadFunctionMatch3) {
       Cpp::BestOverloadFunctionMatch(candidates, explicit_args, args3);
 
   candidates.clear();
-  Cpp::GetOperator(
-      Cpp::GetScopeFromType(Cpp::GetVariableType(Cpp::GetNamed("a"))),
-      Cpp::Operator::OP_Minus, candidates);
+  Cpp::GetOperator(Cpp::GetScopeFromType(
+                       Cpp::GetVariableType(Cpp::GetNamed("a" DFLT_NULLPTR))),
+                   Cpp::Operator::OP_Minus, candidates DFLT_OP_ARITY);
 
   EXPECT_EQ(candidates.size(), 1);
 
   std::vector<Cpp::TemplateArgInfo> args4 = {
-      Cpp::GetVariableType(Cpp::GetNamed("a"))};
+      Cpp::GetVariableType(Cpp::GetNamed("a" DFLT_NULLPTR))};
 
   Cpp::TCppFunction_t func4 =
       Cpp::BestOverloadFunctionMatch(candidates, explicit_args, args4);
@@ -1251,7 +1271,8 @@ TYPED_TEST(CppInterOpTest, FunctionReflectionTestBestOverloadFunctionMatch3) {
             "template<> A<int> A<int>::operator-<int>(A<int> rhs)");
 }
 
-TYPED_TEST(CppInterOpTest, FunctionReflectionTestBestOverloadFunctionMatch4) {
+TYPED_TEST(CPPINTEROP_TEST_MODE,
+           FunctionReflection_BestOverloadFunctionMatch4) {
   std::vector<Decl*> Decls, SubDecls;
   std::string code = R"(
     template<typename T>
@@ -1288,13 +1309,13 @@ TYPED_TEST(CppInterOpTest, FunctionReflectionTestBestOverloadFunctionMatch4) {
   std::vector<Cpp::TemplateArgInfo> args1 = {};
   std::vector<Cpp::TemplateArgInfo> args2 = {C.IntTy.getAsOpaquePtr()};
   std::vector<Cpp::TemplateArgInfo> args3 = {
-      Cpp::GetVariableType(Cpp::GetNamed("a"))};
+      Cpp::GetVariableType(Cpp::GetNamed("a" DFLT_NULLPTR))};
   std::vector<Cpp::TemplateArgInfo> args4 = {
-      Cpp::GetVariableType(Cpp::GetNamed("a")),
-      Cpp::GetVariableType(Cpp::GetNamed("b"))};
+      Cpp::GetVariableType(Cpp::GetNamed("a" DFLT_NULLPTR)),
+      Cpp::GetVariableType(Cpp::GetNamed("b" DFLT_NULLPTR))};
   std::vector<Cpp::TemplateArgInfo> args5 = {
-      Cpp::GetVariableType(Cpp::GetNamed("a")),
-      Cpp::GetVariableType(Cpp::GetNamed("a"))};
+      Cpp::GetVariableType(Cpp::GetNamed("a" DFLT_NULLPTR)),
+      Cpp::GetVariableType(Cpp::GetNamed("a" DFLT_NULLPTR))};
 
   std::vector<Cpp::TemplateArgInfo> explicit_args1;
   std::vector<Cpp::TemplateArgInfo> explicit_args2 = {C.IntTy.getAsOpaquePtr(),
@@ -1322,7 +1343,8 @@ TYPED_TEST(CppInterOpTest, FunctionReflectionTestBestOverloadFunctionMatch4) {
             "template<> void B::fn<int, int>(A<int> x, A<int> y)");
 }
 
-TYPED_TEST(CppInterOpTest, FunctionReflectionTestBestOverloadFunctionMatch5) {
+TYPED_TEST(CPPINTEROP_TEST_MODE,
+           FunctionReflection_BestOverloadFunctionMatch5) {
   std::vector<Decl*> Decls;
   std::string code = R"(
     template<typename T1, typename T2>
@@ -1346,7 +1368,7 @@ TYPED_TEST(CppInterOpTest, FunctionReflectionTestBestOverloadFunctionMatch5) {
   };
 
   Cpp::TCppScope_t callme = Cpp::InstantiateTemplate(
-      Decls[0], explicit_params.data(), explicit_params.size());
+      Decls[0], explicit_params.data(), explicit_params.size() DFLT_FALSE);
   EXPECT_TRUE(callme);
 
   std::vector<Cpp::TemplateArgInfo> arg_types = {
@@ -1356,7 +1378,7 @@ TYPED_TEST(CppInterOpTest, FunctionReflectionTestBestOverloadFunctionMatch5) {
   };
 
   Cpp::TCppScope_t callback =
-      Cpp::BestOverloadFunctionMatch(candidates, {}, arg_types);
+      Cpp::BestOverloadFunctionMatch(candidates, empty_templ_args, arg_types);
   EXPECT_TRUE(callback);
 
   EXPECT_EQ(Cpp::GetFunctionSignature(callback),
@@ -1364,7 +1386,7 @@ TYPED_TEST(CppInterOpTest, FunctionReflectionTestBestOverloadFunctionMatch5) {
             "&>>(void (*callable)(double, int), double &args, int &args)");
 }
 
-TYPED_TEST(CppInterOpTest, FunctionReflectionTestIsPublicMethod) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_IsPublicMethod) {
   std::vector<Decl *> Decls, SubDecls;
   std::string code = R"(
     class C {
@@ -1391,7 +1413,7 @@ TYPED_TEST(CppInterOpTest, FunctionReflectionTestIsPublicMethod) {
   EXPECT_FALSE(Cpp::IsPublicMethod(SubDecls[9]));
 }
 
-TYPED_TEST(CppInterOpTest, FunctionReflectionTestIsProtectedMethod) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_IsProtectedMethod) {
   std::vector<Decl *> Decls, SubDecls;
   std::string code = R"(
     class C {
@@ -1416,7 +1438,7 @@ TYPED_TEST(CppInterOpTest, FunctionReflectionTestIsProtectedMethod) {
   EXPECT_TRUE(Cpp::IsProtectedMethod(SubDecls[8]));
 }
 
-TYPED_TEST(CppInterOpTest, FunctionReflectionTestIsPrivateMethod) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_IsPrivateMethod) {
   std::vector<Decl *> Decls, SubDecls;
   std::string code = R"(
     class C {
@@ -1441,7 +1463,7 @@ TYPED_TEST(CppInterOpTest, FunctionReflectionTestIsPrivateMethod) {
   EXPECT_FALSE(Cpp::IsPrivateMethod(SubDecls[8]));
 }
 
-TYPED_TEST(CppInterOpTest, FunctionReflectionTestIsConstructor) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_IsConstructor) {
   std::vector<Decl *> Decls, SubDecls;
   std::string code = R"(
     class C {
@@ -1488,7 +1510,7 @@ TYPED_TEST(CppInterOpTest, FunctionReflectionTestIsConstructor) {
   EXPECT_EQ(templCtorCount, 1);
 }
 
-TYPED_TEST(CppInterOpTest, FunctionReflectionTestIsDestructor) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_IsDestructor) {
   std::vector<Decl *> Decls, SubDecls;
   std::string code = R"(
     class C {
@@ -1513,7 +1535,7 @@ TYPED_TEST(CppInterOpTest, FunctionReflectionTestIsDestructor) {
   EXPECT_FALSE(Cpp::IsDestructor(SubDecls[8]));
 }
 
-TYPED_TEST(CppInterOpTest, FunctionReflectionTestIsStaticMethod) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_IsStaticMethod) {
   std::vector<Decl *> Decls, SubDecls;
   std::string code = R"(
     class C {
@@ -1530,7 +1552,7 @@ TYPED_TEST(CppInterOpTest, FunctionReflectionTestIsStaticMethod) {
   EXPECT_TRUE(Cpp::IsStaticMethod(SubDecls[2]));
 }
 
-TYPED_TEST(CppInterOpTest, FunctionReflectionTestGetFunctionAddress) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_GetFunctionAddress) {
 #ifdef EMSCRIPTEN
 #if CLANG_VERSION_MAJOR < 20
   GTEST_SKIP() << "Test fails for Emscipten builds";
@@ -1577,14 +1599,14 @@ TYPED_TEST(CppInterOpTest, FunctionReflectionTestGetFunctionAddress) {
 
   ASTContext& C = Interp->getCI()->getASTContext();
   std::vector<Cpp::TemplateArgInfo> argument = {C.DoubleTy.getAsOpaquePtr()};
-  Cpp::TCppScope_t add1_double =
-      Cpp::InstantiateTemplate(funcs[0], argument.data(), argument.size());
+  Cpp::TCppScope_t add1_double = Cpp::InstantiateTemplate(
+      funcs[0], argument.data(), argument.size() DFLT_FALSE);
   EXPECT_TRUE(add1_double);
 
   EXPECT_TRUE(Cpp::GetFunctionAddress(add1_double));
 }
 
-TYPED_TEST(CppInterOpTest, FunctionReflectionTestIsVirtualMethod) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_IsVirtualMethod) {
   std::vector<Decl*> Decls, SubDecls;
   std::string code = R"(
     class A {
@@ -1604,7 +1626,7 @@ TYPED_TEST(CppInterOpTest, FunctionReflectionTestIsVirtualMethod) {
   EXPECT_FALSE(Cpp::IsVirtualMethod(Decls[0]));
 }
 
-TYPED_TEST(CppInterOpTest, FunctionReflectionTestJitCallAdvanced) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_JitCallAdvanced) {
 #ifdef EMSCRIPTEN
 #if CLANG_VERSION_MAJOR < 20
   GTEST_SKIP() << "Test fails for Emscipten builds";
@@ -1639,7 +1661,7 @@ TYPED_TEST(CppInterOpTest, FunctionReflectionTestJitCallAdvanced) {
   Ctor.Invoke(&object);
   EXPECT_TRUE(object) << "Failed to call the ctor.";
   // Building a wrapper with a typedef decl must be possible.
-  EXPECT_TRUE(Cpp::Destruct(object, Decls[1]));
+  EXPECT_TRUE(Cpp::Destruct(object, Decls[1] DFLT_TRUE DFLT_0));
 
   // C API
   auto* I = clang_createInterpreterFromRawPtr(Cpp::GetInterpreter());
@@ -1655,7 +1677,7 @@ TYPED_TEST(CppInterOpTest, FunctionReflectionTestJitCallAdvanced) {
 
 #if !defined(NDEBUG) && GTEST_HAS_DEATH_TEST
 #ifndef _WIN32 // Death tests do not work on Windows
-TYPED_TEST(CppInterOpTest, FunctionReflectionTestJitCallDebug) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_JitCallDebug) {
 #ifdef EMSCRIPTEN
 #if CLANG_VERSION_MAJOR < 20
   GTEST_SKIP() << "Test fails for Emscipten builds";
@@ -1689,7 +1711,7 @@ TYPED_TEST(CppInterOpTest, FunctionReflectionTestJitCallDebug) {
       { JC.InvokeConstructor(/*result=*/nullptr); },
       "Must pass the location of the created object!");
 
-  void* result = Cpp::Allocate(Decls[0]);
+  void* result = Cpp::Allocate(Decls[0] DFLT_1);
   EXPECT_DEATH(
       { JC.InvokeConstructor(&result, 0UL); },
       "Number of objects to construct should be atleast 1");
@@ -1729,8 +1751,8 @@ TYPED_TEST(CppInterOpTest, FunctionReflectionTestJitCallDebug) {
   EXPECT_TRUE(*obj == 42);
 
   // Destructors
-  Cpp::TCppScope_t scope_C = Cpp::GetNamed("C");
-  Cpp::TCppObject_t object_C = Cpp::Construct(scope_C);
+  Cpp::TCppScope_t scope_C = Cpp::GetNamed("C" DFLT_0);
+  Cpp::TCppObject_t object_C = Cpp::Construct(scope_C DFLT_NULLPTR DFLT_1);
 
   // Make destructor callable and pass arguments
   JC = Cpp::MakeFunctionCallable(SubDecls[4]);
@@ -1751,7 +1773,7 @@ instantiation_in_host<int>();
 template int instantiation_in_host<int>();
 #endif
 
-TYPED_TEST(CppInterOpTest, FunctionReflectionTestGetFunctionCallWrapper) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_GetFunctionCallWrapper) {
 #ifdef EMSCRIPTEN
   GTEST_SKIP() << "Test fails for Emscipten builds";
 #endif
@@ -1792,13 +1814,13 @@ TYPED_TEST(CppInterOpTest, FunctionReflectionTestGetFunctionCallWrapper) {
       Cpp::MakeFunctionCallable(Decls[0]);
   EXPECT_TRUE(FCI1.getKind() == Cpp::JitCall::kGenericCall);
   Cpp::JitCall FCI2 =
-      Cpp::MakeFunctionCallable(Cpp::GetNamed("f2"));
+      Cpp::MakeFunctionCallable(Cpp::GetNamed("f2" DFLT_NULLPTR));
   EXPECT_TRUE(FCI2.getKind() == Cpp::JitCall::kGenericCall);
-  Cpp::JitCall FCI3 =
-    Cpp::MakeFunctionCallable(Cpp::GetNamed("f3", Cpp::GetNamed("NS")));
+  Cpp::JitCall FCI3 = Cpp::MakeFunctionCallable(
+      Cpp::GetNamed("f3", Cpp::GetNamed("NS" DFLT_NULLPTR)));
   EXPECT_TRUE(FCI3.getKind() == Cpp::JitCall::kGenericCall);
-  Cpp::JitCall FCI4 =
-      Cpp::MakeFunctionCallable(Cpp::GetNamed("f4", Cpp::GetNamed("NS")));
+  Cpp::JitCall FCI4 = Cpp::MakeFunctionCallable(
+      Cpp::GetNamed("f4", Cpp::GetNamed("NS" DFLT_NULLPTR)));
   EXPECT_TRUE(FCI4.getKind() == Cpp::JitCall::kGenericCall);
 
   int i = 9, ret1, ret3, ret4;
@@ -1820,8 +1842,8 @@ TYPED_TEST(CppInterOpTest, FunctionReflectionTestGetFunctionCallWrapper) {
   FCI4.Invoke(&ret4);
   EXPECT_EQ(ret4, 4);
 
-  Cpp::JitCall FCI5 =
-      Cpp::MakeFunctionCallable(Cpp::GetNamed("f5", Cpp::GetNamed("NS")));
+  Cpp::JitCall FCI5 = Cpp::MakeFunctionCallable(
+      Cpp::GetNamed("f5", Cpp::GetNamed("NS" DFLT_NULLPTR)));
   EXPECT_TRUE(FCI5.getKind() == Cpp::JitCall::kGenericCall);
 
   typedef int (*int_func)();
@@ -1839,7 +1861,7 @@ TYPED_TEST(CppInterOpTest, FunctionReflectionTestGetFunctionCallWrapper) {
     };
   )");
 
-  clang::NamedDecl *ClassC = (clang::NamedDecl*)Cpp::GetNamed("C");
+  clang::NamedDecl* ClassC = (clang::NamedDecl*)Cpp::GetNamed("C" DFLT_NULLPTR);
   auto *CtorD = (clang::CXXConstructorDecl*)Cpp::GetDefaultConstructor(ClassC);
   auto FCI_Ctor =
     Cpp::MakeFunctionCallable(CtorD);
@@ -1873,11 +1895,12 @@ TYPED_TEST(CppInterOpTest, FunctionReflectionTestGetFunctionCallWrapper) {
   ASTContext& C = Interp->getCI()->getASTContext();
 
   std::vector<Cpp::TemplateArgInfo> argument = {C.IntTy.getAsOpaquePtr()};
-  auto Instance1 = Cpp::InstantiateTemplate(Decls1[0], argument.data(),
-                                            /*type_size*/ argument.size());
+  auto Instance1 =
+      Cpp::InstantiateTemplate(Decls1[0], argument.data(),
+                               /*type_size*/ argument.size() DFLT_FALSE);
   EXPECT_TRUE(isa<ClassTemplateSpecializationDecl>((Decl*)Instance1));
   auto* CTSD1 = static_cast<ClassTemplateSpecializationDecl*>(Instance1);
-  auto* Add_D = Cpp::GetNamed("Add",CTSD1);
+  auto* Add_D = Cpp::GetNamed("Add", CTSD1);
   Cpp::JitCall FCI_Add = Cpp::MakeFunctionCallable(Add_D);
   EXPECT_TRUE(FCI_Add.getKind() == Cpp::JitCall::kGenericCall);
 
@@ -1894,7 +1917,7 @@ TYPED_TEST(CppInterOpTest, FunctionReflectionTestGetFunctionCallWrapper) {
   }
   )");
 
-  Cpp::TCppScope_t set_5 = Cpp::GetNamed("set_5");
+  Cpp::TCppScope_t set_5 = Cpp::GetNamed("set_5" DFLT_NULLPTR);
   EXPECT_TRUE(set_5);
 
   Cpp::JitCall set_5_f = Cpp::MakeFunctionCallable(set_5);
@@ -1920,7 +1943,7 @@ TYPED_TEST(CppInterOpTest, FunctionReflectionTestGetFunctionCallWrapper) {
   )");
 
   Cpp::TCppScope_t TypedefToPrivateClass =
-      Cpp::GetNamed("TypedefToPrivateClass");
+      Cpp::GetNamed("TypedefToPrivateClass" DFLT_NULLPTR);
   EXPECT_TRUE(TypedefToPrivateClass);
 
   Cpp::TCppScope_t f = Cpp::GetNamed("f", TypedefToPrivateClass);
@@ -1941,7 +1964,7 @@ TYPED_TEST(CppInterOpTest, FunctionReflectionTestGetFunctionCallWrapper) {
       bool operator<(T t) { return true; }
     };
   )");
-  Cpp::TCppScope_t TOperator = Cpp::GetNamed("TOperator");
+  Cpp::TCppScope_t TOperator = Cpp::GetNamed("TOperator" DFLT_NULLPTR);
 
   auto* TOperatorCtor = Cpp::GetDefaultConstructor(TOperator);
   auto FCI_TOperatorCtor = Cpp::MakeFunctionCallable(TOperatorCtor);
@@ -1950,12 +1973,13 @@ TYPED_TEST(CppInterOpTest, FunctionReflectionTestGetFunctionCallWrapper) {
 
   EXPECT_TRUE(toperator);
   std::vector<Cpp::TCppScope_t> operators;
-  Cpp::GetOperator(TOperator, Cpp::OP_Less, operators);
+  Cpp::GetOperator(TOperator, Cpp::Operator::OP_Less, operators DFLT_OP_ARITY);
   EXPECT_EQ(operators.size(), 1);
 
   Cpp::TCppScope_t op_templated = operators[0];
   auto TAI = Cpp::TemplateArgInfo(Cpp::GetType("int"));
-  Cpp::TCppScope_t op = Cpp::InstantiateTemplate(op_templated, &TAI, 1);
+  Cpp::TCppScope_t op =
+      Cpp::InstantiateTemplate(op_templated, &TAI, 1 DFLT_FALSE);
   auto FCI_op = Cpp::MakeFunctionCallable(op);
   bool boolean = false;
   FCI_op.Invoke((void*)&boolean, {args, /*args_size=*/1}, toperator);
@@ -1990,14 +2014,14 @@ TYPED_TEST(CppInterOpTest, FunctionReflectionTestGetFunctionCallWrapper) {
     N1::N2::Klass1<char, float> K2;
   )");
 
-  Cpp::TCppType_t K1 = Cpp::GetTypeFromScope(Cpp::GetNamed("K1"));
-  Cpp::TCppType_t K2 = Cpp::GetTypeFromScope(Cpp::GetNamed("K2"));
+  Cpp::TCppType_t K1 = Cpp::GetTypeFromScope(Cpp::GetNamed("K1" DFLT_NULLPTR));
+  Cpp::TCppType_t K2 = Cpp::GetTypeFromScope(Cpp::GetNamed("K2" DFLT_NULLPTR));
   operators.clear();
-  Cpp::GetOperator(Cpp::GetScope("N2", Cpp::GetScope("N1")), Cpp::OP_Plus,
-                   operators);
+  Cpp::GetOperator(Cpp::GetScope("N2", Cpp::GetScope("N1" DFLT_NULLPTR)),
+                   Cpp::Operator::OP_Plus, operators DFLT_OP_ARITY);
   EXPECT_EQ(operators.size(), 1);
   Cpp::TCppFunction_t kop =
-      Cpp::BestOverloadFunctionMatch(operators, {}, {K1, K2});
+      Cpp::BestOverloadFunctionMatch(operators, empty_templ_args, {K1, K2});
   auto chrono_op_fn_callable = Cpp::MakeFunctionCallable(kop);
   EXPECT_EQ(chrono_op_fn_callable.getKind(), Cpp::JitCall::kGenericCall);
 
@@ -2070,9 +2094,9 @@ TYPED_TEST(CppInterOpTest, FunctionReflectionTestGetFunctionCallWrapper) {
   )");
 
   std::vector<Cpp::TCppFunction_t> unresolved_candidate_methods;
-  Cpp::GetClassTemplatedMethods("get", Cpp::GetScope("my_std"),
+  Cpp::GetClassTemplatedMethods("get", Cpp::GetScope("my_std" DFLT_NULLPTR),
                                 unresolved_candidate_methods);
-  Cpp::TCppType_t p = Cpp::GetTypeFromScope(Cpp::GetNamed("p"));
+  Cpp::TCppType_t p = Cpp::GetTypeFromScope(Cpp::GetNamed("p" DFLT_NULLPTR));
   EXPECT_TRUE(p);
 
   Cpp::TCppScope_t fn = Cpp::BestOverloadFunctionMatch(
@@ -2149,8 +2173,8 @@ TYPED_TEST(CppInterOpTest, FunctionReflectionTestGetFunctionCallWrapper) {
 
   Cpp::TCppScope_t tuple_tuple = Cpp::BestOverloadFunctionMatch(
       unresolved_candidate_methods, {},
-      {Cpp::GetVariableType(Cpp::GetNamed("tuple_one")),
-       Cpp::GetVariableType(Cpp::GetNamed("tuple_two"))});
+      {Cpp::GetVariableType(Cpp::GetNamed("tuple_one" DFLT_NULLPTR)),
+       Cpp::GetVariableType(Cpp::GetNamed("tuple_two" DFLT_NULLPTR))});
   EXPECT_TRUE(tuple_tuple);
 
   auto tuple_tuple_callable = Cpp::MakeFunctionCallable(tuple_tuple);
@@ -2165,7 +2189,7 @@ TYPED_TEST(CppInterOpTest, FunctionReflectionTestGetFunctionCallWrapper) {
   )");
 
   Cpp::TCppScope_t bar =
-      Cpp::GetNamed("bar", Cpp::GetScope("EnumFunctionSameName"));
+      Cpp::GetNamed("bar", Cpp::GetScope("EnumFunctionSameName" DFLT_NULLPTR));
   EXPECT_TRUE(bar);
 
   auto bar_callable = Cpp::MakeFunctionCallable(bar);
@@ -2181,7 +2205,7 @@ TYPED_TEST(CppInterOpTest, FunctionReflectionTestGetFunctionCallWrapper) {
 
   template<typename T>
   void consume(T t) {}
-  )");
+  )" DFLT_FALSE);
 
   unresolved_candidate_methods.clear();
   Cpp::GetClassTemplatedMethods("consume", Cpp::GetGlobalScope(),
@@ -2190,7 +2214,7 @@ TYPED_TEST(CppInterOpTest, FunctionReflectionTestGetFunctionCallWrapper) {
 
   Cpp::TCppScope_t consume = Cpp::BestOverloadFunctionMatch(
       unresolved_candidate_methods, {},
-      {Cpp::GetVariableType(Cpp::GetNamed("consumable"))});
+      {Cpp::GetVariableType(Cpp::GetNamed("consumable" DFLT_NULLPTR))});
   EXPECT_TRUE(consume);
 
   auto consume_callable = Cpp::MakeFunctionCallable(consume);
@@ -2210,21 +2234,22 @@ TYPED_TEST(CppInterOpTest, FunctionReflectionTestGetFunctionCallWrapper) {
     const Product<TT, O>
     operator*(const KlassProduct<O> &other) const { return Product<TT, O>(); }
   };
-  )");
+  )" DFLT_FALSE);
 
-  Cpp::TCppScope_t KlassProduct = Cpp::GetNamed("KlassProduct");
+  Cpp::TCppScope_t KlassProduct = Cpp::GetNamed("KlassProduct" DFLT_NULLPTR);
   EXPECT_TRUE(KlassProduct);
 
   Cpp::TCppScope_t KlassProduct_int =
-      Cpp::InstantiateTemplate(KlassProduct, &TAI, 1);
+      Cpp::InstantiateTemplate(KlassProduct, &TAI, 1 DFLT_FALSE);
   EXPECT_TRUE(KlassProduct_int);
   TAI = Cpp::TemplateArgInfo(Cpp::GetType("float"));
   Cpp::TCppScope_t KlassProduct_float =
-      Cpp::InstantiateTemplate(KlassProduct, &TAI, 1);
+      Cpp::InstantiateTemplate(KlassProduct, &TAI, 1 DFLT_FALSE);
   EXPECT_TRUE(KlassProduct_float);
 
   operators.clear();
-  Cpp::GetOperator(KlassProduct_int, Cpp::OP_Star, operators);
+  Cpp::GetOperator(KlassProduct_int, Cpp::Operator::OP_Star,
+                   operators DFLT_OP_ARITY);
   EXPECT_EQ(operators.size(), 2);
 
   op = Cpp::BestOverloadFunctionMatch(
@@ -2244,43 +2269,47 @@ TYPED_TEST(CppInterOpTest, FunctionReflectionTestGetFunctionCallWrapper) {
     template <MyEnum E>
     class TemplatedEnum {};
     }
-  )");
+  )" DFLT_FALSE);
 
-  Cpp::TCppScope_t TemplatedEnum = Cpp::GetScope("TemplatedEnum");
+  Cpp::TCppScope_t TemplatedEnum = Cpp::GetScope("TemplatedEnum" DFLT_NULLPTR);
   EXPECT_TRUE(TemplatedEnum);
 
-  auto TAI_enum =
-      Cpp::TemplateArgInfo(Cpp::GetTypeFromScope(Cpp::GetNamed("MyEnum")), "1");
+  auto TAI_enum = Cpp::TemplateArgInfo(
+      Cpp::GetTypeFromScope(Cpp::GetNamed("MyEnum" DFLT_NULLPTR)), "1");
   Cpp::TCppScope_t TemplatedEnum_instantiated =
-      Cpp::InstantiateTemplate(TemplatedEnum, &TAI_enum, 1);
+      Cpp::InstantiateTemplate(TemplatedEnum, &TAI_enum, 1 DFLT_FALSE);
   EXPECT_TRUE(TemplatedEnum_instantiated);
 
-  Cpp::TCppObject_t obj = Cpp::Construct(TemplatedEnum_instantiated);
+  Cpp::TCppObject_t obj =
+      Cpp::Construct(TemplatedEnum_instantiated DFLT_NULLPTR DFLT_1);
   EXPECT_TRUE(obj);
-  Cpp::Destruct(obj, TemplatedEnum_instantiated);
+  Cpp::Destruct(obj, TemplatedEnum_instantiated DFLT_TRUE DFLT_0);
   obj = nullptr;
 
   Cpp::TCppScope_t MyNameSpace_TemplatedEnum =
-      Cpp::GetScope("TemplatedEnum", Cpp::GetScope("MyNameSpace"));
+      Cpp::GetScope("TemplatedEnum", Cpp::GetScope("MyNameSpace" DFLT_NULLPTR));
   EXPECT_TRUE(TemplatedEnum);
 
-  TAI_enum = Cpp::TemplateArgInfo(Cpp::GetTypeFromScope(Cpp::GetNamed(
-                                      "MyEnum", Cpp::GetScope("MyNameSpace"))),
-                                  "1");
+  TAI_enum = Cpp::TemplateArgInfo(
+      Cpp::GetTypeFromScope(
+          Cpp::GetNamed("MyEnum", Cpp::GetScope("MyNameSpace" DFLT_NULLPTR))),
+      "1");
   Cpp::TCppScope_t MyNameSpace_TemplatedEnum_instantiated =
-      Cpp::InstantiateTemplate(MyNameSpace_TemplatedEnum, &TAI_enum, 1);
+      Cpp::InstantiateTemplate(MyNameSpace_TemplatedEnum, &TAI_enum,
+                               1 DFLT_FALSE);
   EXPECT_TRUE(TemplatedEnum_instantiated);
 
-  obj = Cpp::Construct(MyNameSpace_TemplatedEnum_instantiated);
+  obj = Cpp::Construct(
+      MyNameSpace_TemplatedEnum_instantiated DFLT_NULLPTR DFLT_1);
   EXPECT_TRUE(obj);
-  Cpp::Destruct(obj, MyNameSpace_TemplatedEnum_instantiated);
+  Cpp::Destruct(obj, MyNameSpace_TemplatedEnum_instantiated DFLT_TRUE DFLT_0);
   obj = nullptr;
 
   Cpp::Declare(R"(
     auto get_fn(int x) { return [x](int y){ return x + y; }; }
-  )");
+  )" DFLT_FALSE);
 
-  Cpp::TCppScope_t get_fn = Cpp::GetNamed("get_fn");
+  Cpp::TCppScope_t get_fn = Cpp::GetNamed("get_fn" DFLT_NULLPTR);
   EXPECT_TRUE(get_fn);
 
   auto get_fn_callable = Cpp::MakeFunctionCallable(get_fn);
@@ -2290,7 +2319,7 @@ TYPED_TEST(CppInterOpTest, FunctionReflectionTestGetFunctionCallWrapper) {
   EXPECT_FALSE(Cpp::IsLambdaClass(Cpp::GetFunctionReturnType(bar)));
 }
 
-TYPED_TEST(CppInterOpTest, FunctionReflectionTestIsConstMethod) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_IsConstMethod) {
   std::vector<Decl*> Decls, SubDecls;
   std::string code = R"(
     class C {
@@ -2308,7 +2337,7 @@ TYPED_TEST(CppInterOpTest, FunctionReflectionTestIsConstMethod) {
   EXPECT_FALSE(Cpp::IsConstMethod(method));
 }
 
-TYPED_TEST(CppInterOpTest, FunctionReflectionTestGetFunctionArgName) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_GetFunctionArgName) {
   std::vector<Decl*> Decls;
   std::string code = R"(
     void f1(int i, double d, long l, char ch) {}
@@ -2348,7 +2377,7 @@ TYPED_TEST(CppInterOpTest, FunctionReflectionTestGetFunctionArgName) {
   EXPECT_EQ(Cpp::GetFunctionArgName(Decls[4], 3), "l");
 }
 
-TYPED_TEST(CppInterOpTest, FunctionReflectionTestGetFunctionArgDefault) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_GetFunctionArgDefault) {
   std::vector<Decl*> Decls;
   std::string code = R"(
     void f1(int i, double d = 4.0, const char *s = "default", char ch = 'c') {}
@@ -2400,7 +2429,7 @@ TYPED_TEST(CppInterOpTest, FunctionReflectionTestGetFunctionArgDefault) {
   ASTContext& C = Interp->getCI()->getASTContext();
   Cpp::TemplateArgInfo template_args[1] = {C.IntTy.getAsOpaquePtr()};
   Cpp::TCppScope_t my_struct =
-      Cpp::InstantiateTemplate(Decls[6], template_args, 1);
+      Cpp::InstantiateTemplate(Decls[6], template_args, 1 DFLT_FALSE);
   EXPECT_TRUE(my_struct);
 
   std::vector<Cpp::TCppFunction_t> fns =
@@ -2412,7 +2441,7 @@ TYPED_TEST(CppInterOpTest, FunctionReflectionTestGetFunctionArgDefault) {
   EXPECT_EQ(Cpp::GetFunctionArgDefault(fn, 1), "S()");
 }
 
-TYPED_TEST(CppInterOpTest, FunctionReflectionTestConstruct) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_Construct) {
 #ifdef EMSCRIPTEN
 #if CLANG_VERSION_MAJOR < 20
   GTEST_SKIP() << "Test fails for Emscipten builds";
@@ -2445,8 +2474,8 @@ TYPED_TEST(CppInterOpTest, FunctionReflectionTestConstruct) {
   GetAllTopLevelDecls(code, Decls, false, interpreter_args);
   GetAllSubDecls(Decls[1], SubDecls);
   testing::internal::CaptureStdout();
-  Cpp::TCppScope_t scope = Cpp::GetNamed("C");
-  Cpp::TCppObject_t object = Cpp::Construct(scope);
+  Cpp::TCppScope_t scope = Cpp::GetNamed("C" DFLT_NULLPTR);
+  Cpp::TCppObject_t object = Cpp::Construct(scope DFLT_NULLPTR DFLT_1);
   EXPECT_TRUE(object != nullptr);
   std::string output = testing::internal::GetCapturedStdout();
   EXPECT_EQ(output, "Constructor Executed");
@@ -2454,28 +2483,28 @@ TYPED_TEST(CppInterOpTest, FunctionReflectionTestConstruct) {
 
   // Placement.
   testing::internal::CaptureStdout();
-  void* where = Cpp::Allocate(scope);
-  EXPECT_TRUE(where == Cpp::Construct(scope, where));
+  void* where = Cpp::Allocate(scope DFLT_1);
+  EXPECT_TRUE(where == Cpp::Construct(scope, where DFLT_1));
   // Check for the value of x which should be at the start of the object.
   EXPECT_TRUE(*(int *)where == 12345);
-  Cpp::Deallocate(scope, where);
+  Cpp::Deallocate(scope, where DFLT_1);
   output = testing::internal::GetCapturedStdout();
   EXPECT_EQ(output, "Constructor Executed");
   output.clear();
 
   // Pass a constructor
   testing::internal::CaptureStdout();
-  where = Cpp::Allocate(scope);
-  EXPECT_TRUE(where == Cpp::Construct(SubDecls[3], where));
+  where = Cpp::Allocate(scope DFLT_1);
+  EXPECT_TRUE(where == Cpp::Construct(SubDecls[3], where DFLT_1));
   EXPECT_TRUE(*(int*)where == 12345);
-  Cpp::Deallocate(scope, where);
+  Cpp::Deallocate(scope, where DFLT_1);
   output = testing::internal::GetCapturedStdout();
   EXPECT_EQ(output, "Constructor Executed");
   output.clear();
 
   // Pass a non-class decl, this should fail
-  where = Cpp::Allocate(scope);
-  where = Cpp::Construct(Decls[2], where);
+  where = Cpp::Allocate(scope DFLT_1);
+  where = Cpp::Construct(Decls[2], where DFLT_1);
   EXPECT_TRUE(where == nullptr);
   // C API
   testing::internal::CaptureStdout();
@@ -2495,7 +2524,7 @@ TYPED_TEST(CppInterOpTest, FunctionReflectionTestConstruct) {
 }
 
 // Test zero initialization of PODs and default initialization cases
-TYPED_TEST(CppInterOpTest, FunctionReflectionTestConstructPOD) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_ConstructPOD) {
 #ifdef EMSCRIPTEN
 #if CLANG_VERSION_MAJOR < 20
   GTEST_SKIP() << "Test fails for Emscipten builds";
@@ -2522,17 +2551,17 @@ TYPED_TEST(CppInterOpTest, FunctionReflectionTestConstructPOD) {
       };
     })");
 
-  auto *ns = Cpp::GetNamed("PODS");
+  auto* ns = Cpp::GetNamed("PODS" DFLT_NULLPTR);
   Cpp::TCppScope_t scope = Cpp::GetNamed("SomePOD_B", ns);
   EXPECT_TRUE(scope);
-  Cpp::TCppObject_t object = Cpp::Construct(scope);
+  Cpp::TCppObject_t object = Cpp::Construct(scope DFLT_NULLPTR DFLT_1);
   EXPECT_TRUE(object != nullptr);
   int* fInt = reinterpret_cast<int*>(reinterpret_cast<char*>(object));
   EXPECT_TRUE(*fInt == 0);
 
   scope = Cpp::GetNamed("SomePOD_C", ns);
   EXPECT_TRUE(scope);
-  object = Cpp::Construct(scope);
+  object = Cpp::Construct(scope DFLT_NULLPTR DFLT_1);
   EXPECT_TRUE(object);
   auto* fDouble =
       reinterpret_cast<double*>(reinterpret_cast<char*>(object) + sizeof(int));
@@ -2540,7 +2569,7 @@ TYPED_TEST(CppInterOpTest, FunctionReflectionTestConstructPOD) {
 }
 
 // Test nested constructor calls
-TYPED_TEST(CppInterOpTest, FunctionReflectionTestConstructNested) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_ConstructNested) {
 #ifdef EMSCRIPTEN
 #if CLANG_VERSION_MAJOR < 20
   GTEST_SKIP() << "Test fails for Emscipten builds";
@@ -2579,9 +2608,9 @@ TYPED_TEST(CppInterOpTest, FunctionReflectionTestConstructNested) {
     )");
 
   testing::internal::CaptureStdout();
-  Cpp::TCppScope_t scope_A = Cpp::GetNamed("A");
-  Cpp::TCppScope_t scope_B = Cpp::GetNamed("B");
-  Cpp::TCppObject_t object = Cpp::Construct(scope_B);
+  Cpp::TCppScope_t scope_A = Cpp::GetNamed("A" DFLT_NULLPTR);
+  Cpp::TCppScope_t scope_B = Cpp::GetNamed("B" DFLT_NULLPTR);
+  Cpp::TCppObject_t object = Cpp::Construct(scope_B DFLT_NULLPTR DFLT_1);
   EXPECT_TRUE(object != nullptr);
   std::string output = testing::internal::GetCapturedStdout();
   EXPECT_EQ(output, "A Constructor Called\nB Constructor Called\n");
@@ -2589,8 +2618,8 @@ TYPED_TEST(CppInterOpTest, FunctionReflectionTestConstructNested) {
 
   // In-memory construction
   testing::internal::CaptureStdout();
-  void* arena = Cpp::Allocate(scope_B);
-  EXPECT_TRUE(arena == Cpp::Construct(scope_B, arena));
+  void* arena = Cpp::Allocate(scope_B DFLT_1);
+  EXPECT_TRUE(arena == Cpp::Construct(scope_B, arena DFLT_1));
 
   // Check if both integers a_val and b_val were set.
   EXPECT_EQ(*(int*)arena, 7);
@@ -2598,13 +2627,13 @@ TYPED_TEST(CppInterOpTest, FunctionReflectionTestConstructNested) {
   int* b_val_ptr =
       reinterpret_cast<int*>(reinterpret_cast<char*>(arena) + a_size);
   EXPECT_EQ(*b_val_ptr, 99);
-  Cpp::Deallocate(scope_B, arena);
+  Cpp::Deallocate(scope_B, arena DFLT_1);
   output = testing::internal::GetCapturedStdout();
   EXPECT_EQ(output, "A Constructor Called\nB Constructor Called\n");
   output.clear();
 }
 
-TYPED_TEST(CppInterOpTest, FunctionReflectionTestConstructArray) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_ConstructArray) {
 #if defined(EMSCRIPTEN)
   GTEST_SKIP() << "Test fails for Emscripten builds";
 #endif
@@ -2630,7 +2659,7 @@ TYPED_TEST(CppInterOpTest, FunctionReflectionTestConstructArray) {
       };
       )");
 
-  Cpp::TCppScope_t scope = Cpp::GetNamed("C");
+  Cpp::TCppScope_t scope = Cpp::GetNamed("C" DFLT_NULLPTR);
   std::string output;
 
   size_t a = 5;                          // Construct an array of 5 objects
@@ -2658,7 +2687,7 @@ TYPED_TEST(CppInterOpTest, FunctionReflectionTestConstructArray) {
   output.clear();
 }
 
-TYPED_TEST(CppInterOpTest, FunctionReflectionTestDestruct) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_Destruct) {
 #ifdef EMSCRIPTEN
   GTEST_SKIP() << "Test fails for Emscipten builds";
 #endif
@@ -2686,20 +2715,20 @@ TYPED_TEST(CppInterOpTest, FunctionReflectionTestDestruct) {
     )");
 
   testing::internal::CaptureStdout();
-  Cpp::TCppScope_t scope = Cpp::GetNamed("C");
-  Cpp::TCppObject_t object = Cpp::Construct(scope);
-  EXPECT_TRUE(Cpp::Destruct(object, scope));
+  Cpp::TCppScope_t scope = Cpp::GetNamed("C" DFLT_NULLPTR);
+  Cpp::TCppObject_t object = Cpp::Construct(scope DFLT_NULLPTR DFLT_1);
+  EXPECT_TRUE(Cpp::Destruct(object, scope DFLT_TRUE DFLT_0));
   std::string output = testing::internal::GetCapturedStdout();
 
   EXPECT_EQ(output, "Destructor Executed");
 
   output.clear();
   testing::internal::CaptureStdout();
-  object = Cpp::Construct(scope);
+  object = Cpp::Construct(scope DFLT_NULLPTR DFLT_1);
   // Make sure we do not call delete by adding an explicit Deallocate. If we
   // called delete the Deallocate will cause a double deletion error.
-  EXPECT_TRUE(Cpp::Destruct(object, scope, /*withFree=*/false));
-  Cpp::Deallocate(scope, object);
+  EXPECT_TRUE(Cpp::Destruct(object, scope, /*withFree=*/false DFLT_0));
+  Cpp::Deallocate(scope, object DFLT_1);
   output = testing::internal::GetCapturedStdout();
   EXPECT_EQ(output, "Destructor Executed");
 
@@ -2716,7 +2745,7 @@ TYPED_TEST(CppInterOpTest, FunctionReflectionTestDestruct) {
   clang_Interpreter_takeInterpreterAsPtr(I);
   clang_Interpreter_dispose(I);
 
-  // Failure Test, FunctionReflectionTestthis wrapper should not compile since we explicitly delete
+  // Failure Test, this wrapper should not compile since we explicitly delete
   // the destructor
   Interp->declare(R"(
   class D {
@@ -2726,12 +2755,12 @@ TYPED_TEST(CppInterOpTest, FunctionReflectionTestDestruct) {
   };
   )");
 
-  scope = Cpp::GetNamed("D");
-  object = Cpp::Construct(scope);
-  EXPECT_FALSE(Cpp::Destruct(object, scope));
+  scope = Cpp::GetNamed("D" DFLT_NULLPTR);
+  object = Cpp::Construct(scope DFLT_NULLPTR DFLT_1);
+  EXPECT_FALSE(Cpp::Destruct(object, scope DFLT_TRUE DFLT_0));
 }
 
-TYPED_TEST(CppInterOpTest, FunctionReflectionTestDestructArray) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_DestructArray) {
 #ifdef EMSCRIPTEN
   GTEST_SKIP() << "Test fails for Emscipten builds";
 #endif
@@ -2762,7 +2791,7 @@ TYPED_TEST(CppInterOpTest, FunctionReflectionTestDestructArray) {
       };
       )");
 
-  Cpp::TCppScope_t scope = Cpp::GetNamed("C");
+  Cpp::TCppScope_t scope = Cpp::GetNamed("C" DFLT_NULLPTR);
   std::string output;
 
   size_t a = 5;                          // Construct an array of 5 objects
@@ -2810,7 +2839,7 @@ TYPED_TEST(CppInterOpTest, FunctionReflectionTestDestructArray) {
   output.clear();
 }
 
-TYPED_TEST(CppInterOpTest, FunctionReflectionTestUndoTest) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_UndoTest) {
 #ifdef _WIN32
   GTEST_SKIP() << "Disabled on Windows. Needs fixing.";
 #endif
@@ -2837,7 +2866,7 @@ TYPED_TEST(CppInterOpTest, FunctionReflectionTestUndoTest) {
 #endif
 }
 
-TYPED_TEST(CppInterOpTest, FunctionReflectionTestFailingTest1) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_FailingTest1) {
 #ifdef _WIN32
   GTEST_SKIP() << "Disabled on Windows. Needs fixing.";
 #endif
@@ -2854,20 +2883,20 @@ TYPED_TEST(CppInterOpTest, FunctionReflectionTestFailingTest1) {
 
     template<class C1, class C2>
     bool is_equal(const C1& c1, const C2& c2) { return (bool)(c1 == c2); }
-  )"));
+  )" DFLT_FALSE));
 
-  Cpp::TCppType_t o1 = Cpp::GetTypeFromScope(Cpp::GetNamed("o1"));
-  Cpp::TCppType_t o2 = Cpp::GetTypeFromScope(Cpp::GetNamed("o2"));
+  Cpp::TCppType_t o1 = Cpp::GetTypeFromScope(Cpp::GetNamed("o1" DFLT_NULLPTR));
+  Cpp::TCppType_t o2 = Cpp::GetTypeFromScope(Cpp::GetNamed("o2" DFLT_NULLPTR));
   std::vector<Cpp::TCppFunction_t> fns;
   Cpp::GetClassTemplatedMethods("is_equal", Cpp::GetGlobalScope(), fns);
   EXPECT_EQ(fns.size(), 1);
 
   Cpp::TemplateArgInfo args[2] = {{o1}, {o2}};
-  Cpp::TCppScope_t fn = Cpp::InstantiateTemplate(fns[0], args, 2);
+  Cpp::TCppScope_t fn = Cpp::InstantiateTemplate(fns[0], args, 2 DFLT_FALSE);
   EXPECT_TRUE(fn);
 
   Cpp::JitCall jit_call = Cpp::MakeFunctionCallable(fn);
   EXPECT_EQ(jit_call.getKind(), Cpp::JitCall::kUnknown); // expected to fail
-  EXPECT_FALSE(Cpp::Declare("int x = 1;"));
-  EXPECT_FALSE(Cpp::Declare("int y = x;"));
+  EXPECT_FALSE(Cpp::Declare("int x = 1;" DFLT_FALSE));
+  EXPECT_FALSE(Cpp::Declare("int y = x;" DFLT_FALSE));
 }

--- a/unittests/CppInterOp/JitTest.cpp
+++ b/unittests/CppInterOp/JitTest.cpp
@@ -11,7 +11,7 @@ static int printf_jit(const char* format, ...) {
   return 0;
 }
 
-TYPED_TEST(CppInterOpTest, JitTestInsertOrReplaceJitSymbol) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, Jit_InsertOrReplaceJitSymbol) {
 #ifdef EMSCRIPTEN
   GTEST_SKIP() << "Test fails for Emscipten builds";
 #endif
@@ -41,7 +41,7 @@ TYPED_TEST(CppInterOpTest, JitTestInsertOrReplaceJitSymbol) {
   EXPECT_TRUE(Cpp::InsertOrReplaceJitSymbol("non_existent", 0));
 }
 
-TYPED_TEST(CppInterOpTest, JitTestStreamRedirect) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, Jit_StreamRedirect) {
   if (TypeParam::isOutOfProcess)
     GTEST_SKIP() << "Test fails for OOP JIT builds";
   // printf and etc are fine here.
@@ -75,7 +75,7 @@ TYPED_TEST(CppInterOpTest, JitTestStreamRedirect) {
   // NOLINTEND(cppcoreguidelines-pro-type-vararg)
 }
 
-TYPED_TEST(CppInterOpTest, JitTestStreamRedirectJIT) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, Jit_StreamRedirectJIT) {
 #ifdef EMSCRIPTEN
   GTEST_SKIP() << "Test fails for Emscipten builds";
 #endif
@@ -109,4 +109,3 @@ TYPED_TEST(CppInterOpTest, JitTestStreamRedirectJIT) {
   EXPECT_STREQ(CapturedStringOut.c_str(), "Hello World\n");
   EXPECT_STREQ(CapturedStringErr.c_str(), "Hello Err\n");
 }
-

--- a/unittests/CppInterOp/ScopeReflectionTest.cpp
+++ b/unittests/CppInterOp/ScopeReflectionTest.cpp
@@ -25,7 +25,7 @@ using namespace TestUtils;
 using namespace llvm;
 using namespace clang;
 
-TYPED_TEST(CppInterOpTest, ScopeReflectionTestIsEnumScope) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, ScopeReflection_IsEnumScope) {
   std::vector<Decl *> Decls;
   std::vector<Decl *> SubDecls;
   std::string code = R"(
@@ -48,7 +48,7 @@ TYPED_TEST(CppInterOpTest, ScopeReflectionTestIsEnumScope) {
   EXPECT_FALSE(Cpp::IsEnumScope(SubDecls[1]));
 }
 
-TYPED_TEST(CppInterOpTest, ScopeReflectionTestIsEnumConstant) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, ScopeReflection_IsEnumConstant) {
   std::vector<Decl *> Decls;
   std::vector<Decl *> SubDecls;
   std::string code = R"(
@@ -71,7 +71,7 @@ TYPED_TEST(CppInterOpTest, ScopeReflectionTestIsEnumConstant) {
   EXPECT_TRUE(Cpp::IsEnumConstant(SubDecls[1]));
 }
 
-TYPED_TEST(CppInterOpTest, ScopeReflectionTestDemangle) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, ScopeReflection_Demangle) {
   if (llvm::sys::RunningOnValgrind())
     GTEST_SKIP() << "XFAIL due to Valgrind report";
 
@@ -101,7 +101,7 @@ TYPED_TEST(CppInterOpTest, ScopeReflectionTestDemangle) {
             std::string::npos);
 }
 
-TYPED_TEST(CppInterOpTest, ScopeReflectionTestIsAggregate) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, ScopeReflection_IsAggregate) {
   std::vector<Decl *> Decls;
   std::string code = R"(
     char cv[4] = {};
@@ -127,7 +127,7 @@ TYPED_TEST(CppInterOpTest, ScopeReflectionTestIsAggregate) {
 }
 
 // Check that the CharInfo table has been constructed reasonably.
-TYPED_TEST(CppInterOpTest, ScopeReflectionTestIsNamespace) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, ScopeReflection_IsNamespace) {
   std::vector<Decl*> Decls;
   GetAllTopLevelDecls("namespace N {} class C{}; int I;", Decls);
   EXPECT_TRUE(Cpp::IsNamespace(Decls[0]));
@@ -135,7 +135,7 @@ TYPED_TEST(CppInterOpTest, ScopeReflectionTestIsNamespace) {
   EXPECT_FALSE(Cpp::IsNamespace(Decls[2]));
 }
 
-TYPED_TEST(CppInterOpTest, ScopeReflectionTestIsClass) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, ScopeReflection_IsClass) {
   std::vector<Decl*> Decls;
   GetAllTopLevelDecls("namespace N {} class C{}; int I;", Decls);
   EXPECT_FALSE(Cpp::IsClass(Decls[0]));
@@ -143,7 +143,7 @@ TYPED_TEST(CppInterOpTest, ScopeReflectionTestIsClass) {
   EXPECT_FALSE(Cpp::IsClass(Decls[2]));
 }
 
-TYPED_TEST(CppInterOpTest, ScopeReflectionTestIsClassPolymorphic) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, ScopeReflection_IsClassPolymorphic) {
   std::vector<Decl*> Decls;
   GetAllTopLevelDecls(R"(
     namespace N {}
@@ -165,7 +165,7 @@ TYPED_TEST(CppInterOpTest, ScopeReflectionTestIsClassPolymorphic) {
   EXPECT_FALSE(Cpp::IsClassPolymorphic(Decls[3]));
 }
 
-TYPED_TEST(CppInterOpTest, ScopeReflectionTestIsComplete) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, ScopeReflection_IsComplete) {
   std::vector<Decl*> Decls;
   std::string code = R"(
     namespace N {}
@@ -190,7 +190,7 @@ TYPED_TEST(CppInterOpTest, ScopeReflectionTestIsComplete) {
   EXPECT_FALSE(Cpp::IsComplete(nullptr));
 }
 
-TYPED_TEST(CppInterOpTest, ScopeReflectionTestSizeOf) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, ScopeReflection_SizeOf) {
   std::vector<Decl*> Decls;
   std::string code = R"(namespace N {} class C{}; int I; struct S;
                         enum E : int; union U{}; class Size4{int i;};
@@ -208,8 +208,7 @@ TYPED_TEST(CppInterOpTest, ScopeReflectionTestSizeOf) {
   EXPECT_EQ(Cpp::SizeOf(Decls[7]), sizeof(B));
 }
 
-
-TYPED_TEST(CppInterOpTest, ScopeReflectionTestIsBuiltin) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, ScopeReflection_IsBuiltin) {
 #if CLANG_VERSION_MAJOR == 18 && defined(CPPINTEROP_USE_CLING) &&              \
     defined(_WIN32) && (defined(_M_ARM) || defined(_M_ARM64))
   GTEST_SKIP() << "Test fails with Cling on Windows on ARM";
@@ -245,7 +244,7 @@ TYPED_TEST(CppInterOpTest, ScopeReflectionTestIsBuiltin) {
     EXPECT_TRUE(Cpp::IsBuiltin(C.getTypeDeclType(CTSD).getAsOpaquePtr()));
 }
 
-TYPED_TEST(CppInterOpTest, ScopeReflectionTestIsTemplate) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, ScopeReflection_IsTemplate) {
   std::vector<Decl *> Decls;
   std::string code = R"(template<typename T>
                         class A{};
@@ -271,7 +270,7 @@ TYPED_TEST(CppInterOpTest, ScopeReflectionTestIsTemplate) {
   EXPECT_FALSE(Cpp::IsTemplate(Decls[3]));
 }
 
-TYPED_TEST(CppInterOpTest, ScopeReflectionTestIsTemplateSpecialization) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, ScopeReflection_IsTemplateSpecialization) {
   std::vector<Decl *> Decls;
   std::string code = R"(
     template<typename T>
@@ -287,7 +286,7 @@ TYPED_TEST(CppInterOpTest, ScopeReflectionTestIsTemplateSpecialization) {
           Cpp::GetScopeFromType(Cpp::GetVariableType(Decls[1]))));
 }
 
-TYPED_TEST(CppInterOpTest, ScopeReflectionTestIsTypedefed) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, ScopeReflection_IsTypedefed) {
   std::vector<Decl *> Decls;
   std::string code = R"(
     typedef int I;
@@ -301,7 +300,7 @@ TYPED_TEST(CppInterOpTest, ScopeReflectionTestIsTypedefed) {
   EXPECT_FALSE(Cpp::IsTypedefed(Decls[2]));
 }
 
-TYPED_TEST(CppInterOpTest, ScopeReflectionTestIsAbstract) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, ScopeReflection_IsAbstract) {
   std::vector<Decl *> Decls;
   std::string code = R"(
     class A {};
@@ -321,7 +320,7 @@ TYPED_TEST(CppInterOpTest, ScopeReflectionTestIsAbstract) {
   EXPECT_FALSE(Cpp::IsAbstract(Decls[2]));
 }
 
-TYPED_TEST(CppInterOpTest, ScopeReflectionTestIsVariable) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, ScopeReflection_IsVariable) {
   std::vector<Decl *> Decls;
   std::string code = R"(
     int i;
@@ -345,7 +344,7 @@ TYPED_TEST(CppInterOpTest, ScopeReflectionTestIsVariable) {
   EXPECT_TRUE(Cpp::IsVariable(SubDecls[3]));
 }
 
-TYPED_TEST(CppInterOpTest, ScopeReflectionTestGetName) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, ScopeReflection_GetName) {
   std::vector<Decl*> Decls;
   std::string code = R"(namespace N {} class C{}; int I; struct S;
                         enum E : int; union U{}; class Size4{int i;};
@@ -363,7 +362,7 @@ TYPED_TEST(CppInterOpTest, ScopeReflectionTestGetName) {
   EXPECT_EQ(Cpp::GetName(nullptr), "<unnamed>");
 }
 
-TYPED_TEST(CppInterOpTest, ScopeReflectionTestGetCompleteName) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, ScopeReflection_GetCompleteName) {
   std::vector<Decl *> Decls;
   std::string code = R"(namespace N {}
                         class C{};
@@ -404,12 +403,13 @@ TYPED_TEST(CppInterOpTest, ScopeReflectionTestGetCompleteName) {
   ASTContext& C = Interp->getCI()->getASTContext();
   Cpp::TemplateArgInfo template_args[2] = {C.IntTy.getAsOpaquePtr(),
                                            C.DoubleTy.getAsOpaquePtr()};
-  Cpp::TCppScope_t fn = Cpp::InstantiateTemplate(Decls[11], template_args, 2);
+  Cpp::TCppScope_t fn =
+      Cpp::InstantiateTemplate(Decls[11], template_args, 2 DFLT_FALSE);
   EXPECT_TRUE(fn);
   EXPECT_EQ(Cpp::GetCompleteName(fn), "fn<int, double>");
 }
 
-TYPED_TEST(CppInterOpTest, ScopeReflectionTestGetQualifiedName) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, ScopeReflection_GetQualifiedName) {
   std::vector<Decl*> Decls;
   std::string code = R"(namespace N {
                         class C {
@@ -429,7 +429,7 @@ TYPED_TEST(CppInterOpTest, ScopeReflectionTestGetQualifiedName) {
   EXPECT_EQ(Cpp::GetQualifiedName(Decls[4]), "N::C::E");
 }
 
-TYPED_TEST(CppInterOpTest, ScopeReflectionTestGetQualifiedCompleteName) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, ScopeReflection_GetQualifiedCompleteName) {
   std::vector<Decl*> Decls;
   std::string code = R"(namespace N {
                         class C {
@@ -454,7 +454,7 @@ TYPED_TEST(CppInterOpTest, ScopeReflectionTestGetQualifiedCompleteName) {
   EXPECT_EQ(Cpp::GetQualifiedCompleteName(Decls[6]), "N::C::E");
 }
 
-TYPED_TEST(CppInterOpTest, ScopeReflectionTestGetUsingNamespaces) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, ScopeReflection_GetUsingNamespaces) {
   std::vector<Decl *> Decls, Decls1;
   std::string code = R"(
     namespace abc {
@@ -487,12 +487,12 @@ TYPED_TEST(CppInterOpTest, ScopeReflectionTestGetUsingNamespaces) {
   EXPECT_EQ(usingNamespaces1.size(), 0);
 }
 
-TYPED_TEST(CppInterOpTest, ScopeReflectionTestGetGlobalScope) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, ScopeReflection_GetGlobalScope) {
   EXPECT_EQ(Cpp::GetQualifiedName(Cpp::GetGlobalScope()), "");
   EXPECT_EQ(Cpp::GetName(Cpp::GetGlobalScope()), "");
 }
 
-TYPED_TEST(CppInterOpTest, ScopeReflectionTestGetUnderlyingScope) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, ScopeReflection_GetUnderlyingScope) {
   std::vector<Decl *> Decls;
   std::string code = R"(
     namespace N {
@@ -511,7 +511,7 @@ TYPED_TEST(CppInterOpTest, ScopeReflectionTestGetUnderlyingScope) {
   EXPECT_EQ(Cpp::GetQualifiedName(Cpp::GetUnderlyingScope(nullptr)), "<unnamed>");
 }
 
-TYPED_TEST(CppInterOpTest, ScopeReflectionTestGetScope) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, ScopeReflection_GetScope) {
   std::string code = R"(namespace N {
                         class C {
                           int i;
@@ -537,7 +537,7 @@ TYPED_TEST(CppInterOpTest, ScopeReflectionTestGetScope) {
   EXPECT_EQ(Cpp::GetQualifiedName(non_existent), "<unnamed>");
 }
 
-TYPED_TEST(CppInterOpTest, ScopeReflectionTestGetScopefromCompleteName) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, ScopeReflection_GetScopefromCompleteName) {
   std::string code = R"(namespace N1 {
                         namespace N2 {
                           class C {
@@ -556,7 +556,7 @@ TYPED_TEST(CppInterOpTest, ScopeReflectionTestGetScopefromCompleteName) {
   EXPECT_EQ(Cpp::GetQualifiedName(Cpp::GetScopeFromCompleteName("N1::N2::C::S")), "N1::N2::C::S");
 }
 
-TYPED_TEST(CppInterOpTest, ScopeReflectionTestGetNamed) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, ScopeReflection_GetNamed) {
 #if CLANG_VERSION_MAJOR == 18 && defined(CPPINTEROP_USE_CLING) &&              \
     defined(_WIN32) && (defined(_M_ARM) || defined(_M_ARM64))
   GTEST_SKIP() << "Test fails with Cling on Windows on ARM";
@@ -601,7 +601,7 @@ TYPED_TEST(CppInterOpTest, ScopeReflectionTestGetNamed) {
   EXPECT_EQ(Cpp::GetQualifiedName(std_string_npos_var), "std::basic_string<char>::npos");
 }
 
-TYPED_TEST(CppInterOpTest, ScopeReflectionTestGetParentScope) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, ScopeReflection_GetParentScope) {
   std::string code = R"(namespace N1 {
                         namespace N2 {
                           class C {
@@ -616,7 +616,7 @@ TYPED_TEST(CppInterOpTest, ScopeReflectionTestGetParentScope) {
   TestFixture::CreateInterpreter();
 
   Interp->declare(code);
-  Cpp::TCppScope_t ns_N1 = Cpp::GetNamed("N1");
+  Cpp::TCppScope_t ns_N1 = Cpp::GetNamed("N1" DFLT_NULLPTR);
   Cpp::TCppScope_t ns_N2 = Cpp::GetNamed("N2", ns_N1);
   Cpp::TCppScope_t cl_C = Cpp::GetNamed("C", ns_N2);
   Cpp::TCppScope_t int_i = Cpp::GetNamed("i", cl_C);
@@ -633,7 +633,7 @@ TYPED_TEST(CppInterOpTest, ScopeReflectionTestGetParentScope) {
   EXPECT_EQ(Cpp::GetQualifiedName(Cpp::GetParentScope(en_B)), "N1::N2::C::E");
 }
 
-TYPED_TEST(CppInterOpTest, ScopeReflectionTestGetScopeFromType) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, ScopeReflection_GetScopeFromType) {
   std::vector<Decl *> Decls;
   std::string code = R"(
     namespace N {
@@ -677,7 +677,7 @@ TYPED_TEST(CppInterOpTest, ScopeReflectionTestGetScopeFromType) {
             "N::C");
 }
 
-TYPED_TEST(CppInterOpTest, ScopeReflectionTestGetNumBases) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, ScopeReflection_GetNumBases) {
   std::vector<Decl *> Decls;
   std::string code = R"(
     class A {};
@@ -708,7 +708,7 @@ TYPED_TEST(CppInterOpTest, ScopeReflectionTestGetNumBases) {
   EXPECT_EQ(Cpp::GetNumBases(Cpp::GetUnderlyingScope(Decls[7])), 1);
 }
 
-TYPED_TEST(CppInterOpTest, ScopeReflectionTestGetBaseClass) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, ScopeReflection_GetBaseClass) {
   std::vector<Decl *> Decls;
   std::string code = R"(
     class A {};
@@ -744,20 +744,20 @@ TYPED_TEST(CppInterOpTest, ScopeReflectionTestGetBaseClass) {
   EXPECT_EQ(get_base_class_name(Decls[4], 0), "D");
   EXPECT_EQ(get_base_class_name(Decls[10], 0), "<unnamed>");
 
-  auto *VD = Cpp::GetNamed("var");
+  auto* VD = Cpp::GetNamed("var" DFLT_NULLPTR);
   auto *VT = Cpp::GetVariableType(VD);
   auto *TC2_A_Decl = Cpp::GetScopeFromType(VT);
   auto *TC1_A_Decl = Cpp::GetBaseClass(TC2_A_Decl, 0);
   EXPECT_EQ(Cpp::GetCompleteName(TC1_A_Decl), "TC1<A>");
 
-  auto* VD1 = Cpp::GetNamed("var1");
+  auto* VD1 = Cpp::GetNamed("var1" DFLT_NULLPTR);
   auto* VT1 = Cpp::GetVariableType(VD1);
   auto* TC3_A_Decl = Cpp::GetScopeFromType(VT1);
   auto* A_class = Cpp::GetBaseClass(TC3_A_Decl, 0);
   EXPECT_EQ(Cpp::GetCompleteName(A_class), "A");
 }
 
-TYPED_TEST(CppInterOpTest, ScopeReflectionTestIsSubclass) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, ScopeReflection_IsSubclass) {
   std::vector<Decl *> Decls;
   std::string code = R"(
     class A {};
@@ -799,7 +799,7 @@ TYPED_TEST(CppInterOpTest, ScopeReflectionTestIsSubclass) {
   EXPECT_FALSE(Cpp::IsSubclass(Decls[4], nullptr));
 }
 
-TYPED_TEST(CppInterOpTest, ScopeReflectionTestGetBaseClassOffset) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, ScopeReflection_GetBaseClassOffset) {
   std::vector<Decl *> Decls;
 #define Stringify(s) Stringifyx(s)
 #define Stringifyx(...) #__VA_ARGS__
@@ -836,7 +836,7 @@ CODE;
   EXPECT_EQ(Cpp::GetBaseClassOffset(Decls[6], Decls[0]), (char *)(A*)g - (char *)g);
 }
 
-TYPED_TEST(CppInterOpTest, ScopeReflectionTestGetAllCppNames) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, ScopeReflection_GetAllCppNames) {
   std::vector<Decl *> Decls;
   std::string code = R"(
     class A { int a; };
@@ -878,7 +878,7 @@ TYPED_TEST(CppInterOpTest, ScopeReflectionTestGetAllCppNames) {
   test_get_all_cpp_names(Decls[5], {});
 }
 
-TYPED_TEST(CppInterOpTest, ScopeReflectionTestInstantiateNNTPClassTemplate) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, ScopeReflection_InstantiateNNTPClassTemplate) {
   std::vector<Decl *> Decls;
   std::string code = R"(
     template <int N>
@@ -897,7 +897,7 @@ TYPED_TEST(CppInterOpTest, ScopeReflectionTestInstantiateNNTPClassTemplate) {
   Cpp::TCppType_t IntTy = C.IntTy.getAsOpaquePtr();
   std::vector<Cpp::TemplateArgInfo> args1 = {{IntTy, "5"}};
   EXPECT_TRUE(Cpp::InstantiateTemplate(Decls[0], args1.data(),
-                                       /*type_size*/ args1.size()));
+                                       /*type_size*/ args1.size() DFLT_FALSE));
 
   // C API
   auto* I = clang_createInterpreterFromRawPtr(Cpp::GetInterpreter());
@@ -911,7 +911,7 @@ TYPED_TEST(CppInterOpTest, ScopeReflectionTestInstantiateNNTPClassTemplate) {
   clang_Interpreter_dispose(I);
 }
 
-TYPED_TEST(CppInterOpTest, ScopeReflectionTestInstantiateVarTemplate) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, ScopeReflection_InstantiateVarTemplate) {
   std::vector<Decl*> Decls;
   std::string code = R"(
 template<class T> constexpr T pi = T(3.1415926535897932385L);
@@ -921,8 +921,9 @@ template<class T> constexpr T pi = T(3.1415926535897932385L);
   ASTContext& C = Interp->getCI()->getASTContext();
 
   std::vector<Cpp::TemplateArgInfo> args1 = {C.IntTy.getAsOpaquePtr()};
-  auto Instance1 = Cpp::InstantiateTemplate(Decls[0], args1.data(),
-                                            /*type_size*/ args1.size());
+  auto* Instance1 =
+      Cpp::InstantiateTemplate(Decls[0], args1.data(),
+                               /*type_size*/ args1.size() DFLT_FALSE);
   EXPECT_TRUE(isa<VarDecl>((Decl*)Instance1));
   auto* VD = cast<VarTemplateSpecializationDecl>((Decl*)Instance1);
   VarTemplateDecl* VDTD1 = VD->getSpecializedTemplate();
@@ -935,7 +936,7 @@ template<class T> constexpr T pi = T(3.1415926535897932385L);
   EXPECT_TRUE(TA1.getAsType()->isIntegerType());
 }
 
-TYPED_TEST(CppInterOpTest, ScopeReflectionTestInstantiateFunctionTemplate) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, ScopeReflection_InstantiateFunctionTemplate) {
   std::vector<Decl*> Decls;
   std::string code = R"(
 template<typename T> T TrivialFnTemplate() { return T(); }
@@ -945,8 +946,9 @@ template<typename T> T TrivialFnTemplate() { return T(); }
   ASTContext& C = Interp->getCI()->getASTContext();
 
   std::vector<Cpp::TemplateArgInfo> args1 = {C.IntTy.getAsOpaquePtr()};
-  auto Instance1 = Cpp::InstantiateTemplate(Decls[0], args1.data(),
-                                            /*type_size*/ args1.size());
+  auto* Instance1 =
+      Cpp::InstantiateTemplate(Decls[0], args1.data(),
+                               /*type_size*/ args1.size() DFLT_FALSE);
   EXPECT_TRUE(isa<FunctionDecl>((Decl*)Instance1));
   FunctionDecl* FD = cast<FunctionDecl>((Decl*)Instance1);
   FunctionDecl* FnTD1 = FD->getTemplateInstantiationPattern();
@@ -955,7 +957,8 @@ template<typename T> T TrivialFnTemplate() { return T(); }
   EXPECT_TRUE(TA1.getAsType()->isIntegerType());
 }
 
-TYPED_TEST(CppInterOpTest, ScopeReflectionTestInstantiateTemplateFunctionFromString) {
+TYPED_TEST(CPPINTEROP_TEST_MODE,
+           ScopeReflection_InstantiateTemplateFunctionFromString) {
 #if CLANG_VERSION_MAJOR == 18 && defined(CPPINTEROP_USE_CLING) &&              \
     defined(_WIN32) && (defined(_M_ARM) || defined(_M_ARM64))
   GTEST_SKIP() << "Test fails with Cling on Windows on ARM";
@@ -971,7 +974,7 @@ TYPED_TEST(CppInterOpTest, ScopeReflectionTestInstantiateTemplateFunctionFromStr
   EXPECT_TRUE(Instance1);
 }
 
-TYPED_TEST(CppInterOpTest, ScopeReflectionTestInstantiateTemplate) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, ScopeReflection_InstantiateTemplate) {
   std::vector<Decl *> Decls;
   std::string code = R"(
     template<typename T>
@@ -1015,8 +1018,9 @@ TYPED_TEST(CppInterOpTest, ScopeReflectionTestInstantiateTemplate) {
   ASTContext &C = Interp->getCI()->getASTContext();
 
   std::vector<Cpp::TemplateArgInfo> args1 = {C.IntTy.getAsOpaquePtr()};
-  auto Instance1 = Cpp::InstantiateTemplate(Decls[0], args1.data(),
-                                            /*type_size*/ args1.size());
+  auto* Instance1 =
+      Cpp::InstantiateTemplate(Decls[0], args1.data(),
+                               /*type_size*/ args1.size() DFLT_FALSE);
   EXPECT_TRUE(isa<ClassTemplateSpecializationDecl>((Decl*)Instance1));
   auto *CTSD1 = static_cast<ClassTemplateSpecializationDecl*>(Instance1);
   EXPECT_TRUE(CTSD1->hasDefinition());
@@ -1025,7 +1029,7 @@ TYPED_TEST(CppInterOpTest, ScopeReflectionTestInstantiateTemplate) {
   EXPECT_TRUE(CTSD1->hasDefinition());
 
   auto Instance2 = Cpp::InstantiateTemplate(Decls[1], nullptr,
-                                            /*type_size*/ 0);
+                                            /*type_size*/ 0 DFLT_FALSE);
   EXPECT_TRUE(isa<ClassTemplateSpecializationDecl>((Decl*)Instance2));
   auto *CTSD2 = static_cast<ClassTemplateSpecializationDecl*>(Instance2);
   EXPECT_TRUE(CTSD2->hasDefinition());
@@ -1033,8 +1037,9 @@ TYPED_TEST(CppInterOpTest, ScopeReflectionTestInstantiateTemplate) {
   EXPECT_TRUE(TA2.getAsType()->isIntegerType());
 
   std::vector<Cpp::TemplateArgInfo> args3 = {C.IntTy.getAsOpaquePtr()};
-  auto Instance3 = Cpp::InstantiateTemplate(Decls[2], args3.data(),
-                                            /*type_size*/ args3.size());
+  auto* Instance3 =
+      Cpp::InstantiateTemplate(Decls[2], args3.data(),
+                               /*type_size*/ args3.size() DFLT_FALSE);
   EXPECT_TRUE(isa<ClassTemplateSpecializationDecl>((Decl*)Instance3));
   auto *CTSD3 = static_cast<ClassTemplateSpecializationDecl*>(Instance3);
   EXPECT_TRUE(CTSD3->hasDefinition());
@@ -1050,8 +1055,9 @@ TYPED_TEST(CppInterOpTest, ScopeReflectionTestInstantiateTemplate) {
 
   std::vector<Cpp::TemplateArgInfo> args4 = {C.IntTy.getAsOpaquePtr(),
                                                {C.IntTy.getAsOpaquePtr(), "3"}};
-  auto Instance4 = Cpp::InstantiateTemplate(Decls[3], args4.data(),
-                                            /*type_size*/ args4.size());
+  auto* Instance4 =
+      Cpp::InstantiateTemplate(Decls[3], args4.data(),
+                               /*type_size*/ args4.size() DFLT_FALSE);
 
   EXPECT_TRUE(isa<ClassTemplateSpecializationDecl>((Decl*)Instance4));
   auto *CTSD4 = static_cast<ClassTemplateSpecializationDecl*>(Instance4);
@@ -1062,7 +1068,8 @@ TYPED_TEST(CppInterOpTest, ScopeReflectionTestInstantiateTemplate) {
   EXPECT_TRUE(TA4_1.getAsIntegral() == 3);
 }
 
-TYPED_TEST(CppInterOpTest, ScopeReflectionTestGetClassTemplateInstantiationArgs) {
+TYPED_TEST(CPPINTEROP_TEST_MODE,
+           ScopeReflection_GetClassTemplateInstantiationArgs) {
   std::vector<Decl *> Decls;
   std::string code = R"(
     template<typename ...T> struct __Cppyy_AppendTypesSlow {};
@@ -1073,9 +1080,9 @@ TYPED_TEST(CppInterOpTest, ScopeReflectionTestGetClassTemplateInstantiationArgs)
 
   GetAllTopLevelDecls(code, Decls);
 
-  auto *v1 = Cpp::GetNamed("v1");
-  auto *v2 = Cpp::GetNamed("v2");
-  auto *v3 = Cpp::GetNamed("v3");
+  auto* v1 = Cpp::GetNamed("v1" DFLT_NULLPTR);
+  auto* v2 = Cpp::GetNamed("v2" DFLT_NULLPTR);
+  auto* v3 = Cpp::GetNamed("v3" DFLT_NULLPTR);
   EXPECT_TRUE(v1 && v2 && v3);
 
   auto *v1_class = Cpp::GetScopeFromType(Cpp::GetVariableType(v1));
@@ -1099,8 +1106,7 @@ TYPED_TEST(CppInterOpTest, ScopeReflectionTestGetClassTemplateInstantiationArgs)
   EXPECT_TRUE(instance_types.size() == 0);
 }
 
-
-TYPED_TEST(CppInterOpTest, ScopeReflectionTestIncludeVector) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, ScopeReflection_IncludeVector) {
 #if CLANG_VERSION_MAJOR == 18 && defined(CPPINTEROP_USE_CLING) &&              \
     defined(_WIN32) && (defined(_M_ARM) || defined(_M_ARM64))
   GTEST_SKIP() << "Test fails with Cling on Windows on ARM";
@@ -1116,7 +1122,7 @@ TYPED_TEST(CppInterOpTest, ScopeReflectionTestIncludeVector) {
   Interp->declare(code);
 }
 
-TYPED_TEST(CppInterOpTest, ScopeReflectionTestGetOperator) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, ScopeReflection_GetOperator) {
   if (llvm::sys::RunningOnValgrind())
     GTEST_SKIP() << "XFAIL due to Valgrind report";
 
@@ -1154,39 +1160,44 @@ TYPED_TEST(CppInterOpTest, ScopeReflectionTestGetOperator) {
     }
   )";
 
-  Cpp::Declare(code.c_str());
+  Cpp::Declare(code.c_str() DFLT_FALSE);
 
   std::vector<Cpp::TCppFunction_t> ops;
 
-  Cpp::GetOperator(Cpp::GetGlobalScope(), Cpp::Operator::OP_Plus, ops);
+  Cpp::GetOperator(Cpp::GetGlobalScope(), Cpp::Operator::OP_Plus,
+                   ops DFLT_OP_ARITY);
   EXPECT_EQ(ops.size(), 1);
   ops.clear();
 
-  Cpp::GetOperator(Cpp::GetGlobalScope(), Cpp::Operator::OP_Minus, ops);
+  Cpp::GetOperator(Cpp::GetGlobalScope(), Cpp::Operator::OP_Minus,
+                   ops DFLT_OP_ARITY);
   EXPECT_EQ(ops.size(), 1);
   ops.clear();
 
-  Cpp::GetOperator(Cpp::GetGlobalScope(), Cpp::Operator::OP_Star, ops);
+  Cpp::GetOperator(Cpp::GetGlobalScope(), Cpp::Operator::OP_Star,
+                   ops DFLT_OP_ARITY);
   EXPECT_EQ(ops.size(), 0);
   ops.clear();
 
   // operators defined within a namespace
-  Cpp::GetOperator(Cpp::GetScope("extra_ops"), Cpp::Operator::OP_Plus, ops);
+  Cpp::GetOperator(Cpp::GetScope("extra_ops" DFLT_0), Cpp::Operator::OP_Plus,
+                   ops DFLT_OP_ARITY);
   EXPECT_EQ(ops.size(), 2);
   ops.clear();
 
   // unary operator
-  Cpp::GetOperator(Cpp::GetScope("extra_ops"), Cpp::Operator::OP_Tilde, ops);
+  Cpp::GetOperator(Cpp::GetScope("extra_ops" DFLT_0), Cpp::Operator::OP_Tilde,
+                   ops DFLT_OP_ARITY);
   EXPECT_EQ(ops.size(), 1);
   ops.clear();
 
-  Cpp::GetOperator(Cpp::GetScope("extra_ops"), Cpp::Operator::OP_Tilde, ops,
-                   Cpp::OperatorArity::kUnary);
+  Cpp::GetOperator(Cpp::GetScope("extra_ops" DFLT_0), Cpp::Operator::OP_Tilde,
+                   ops, Cpp::OperatorArity::kUnary);
   EXPECT_EQ(ops.size(), 1);
   ops.clear();
 
-  Cpp::GetOperator(Cpp::GetScope("extra_ops"), Cpp::Operator::OP_Tilde, ops,
-                   Cpp::OperatorArity::kBinary);
+  Cpp::GetOperator(Cpp::GetScope("extra_ops" DFLT_0), Cpp::Operator::OP_Tilde,
+                   ops, Cpp::OperatorArity::kBinary);
   EXPECT_EQ(ops.size(), 0);
 
   std::string inheritance_code = R"(
@@ -1205,13 +1216,15 @@ TYPED_TEST(CppInterOpTest, ScopeReflectionTestGetOperator) {
     }
   };
   )";
-  Cpp::Declare(inheritance_code.c_str());
+  Cpp::Declare(inheritance_code.c_str() DFLT_FALSE);
 
   ops.clear();
-  Cpp::GetOperator(Cpp::GetScope("Child"), Cpp::Operator::OP_Plus, ops);
+  Cpp::GetOperator(Cpp::GetScope("Child" DFLT_0), Cpp::Operator::OP_Plus,
+                   ops DFLT_OP_ARITY);
   EXPECT_EQ(ops.size(), 1);
 
   ops.clear();
-  Cpp::GetOperator(Cpp::GetScope("Child"), Cpp::Operator::OP_Minus, ops);
+  Cpp::GetOperator(Cpp::GetScope("Child" DFLT_0), Cpp::Operator::OP_Minus,
+                   ops DFLT_OP_ARITY);
   EXPECT_EQ(ops.size(), 1);
 }

--- a/unittests/CppInterOp/TypeReflectionTest.cpp
+++ b/unittests/CppInterOp/TypeReflectionTest.cpp
@@ -17,7 +17,7 @@ using namespace TestUtils;
 using namespace llvm;
 using namespace clang;
 
-TYPED_TEST(CppInterOpTest, TypeReflectionTestGetTypeAsString) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, TypeReflection_GetTypeAsString) {
   std::vector<Decl *> Decls;
   std::string code = R"(
     namespace N {
@@ -57,7 +57,7 @@ TYPED_TEST(CppInterOpTest, TypeReflectionTestGetTypeAsString) {
   EXPECT_EQ(Cpp::GetTypeAsString(QT7.getAsOpaquePtr()), "char[4]");
 }
 
-TYPED_TEST(CppInterOpTest, TypeReflectionTestGetSizeOfType) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, TypeReflection_GetSizeOfType) {
   std::vector<Decl *> Decls;
   std::string code =  R"(
     struct S {
@@ -85,7 +85,7 @@ TYPED_TEST(CppInterOpTest, TypeReflectionTestGetSizeOfType) {
             sizeof(intptr_t));
 }
 
-TYPED_TEST(CppInterOpTest, TypeReflectionTestGetCanonicalType) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, TypeReflection_GetCanonicalType) {
   std::vector<Decl *> Decls;
   std::string code =  R"(
     typedef int I;
@@ -108,7 +108,7 @@ TYPED_TEST(CppInterOpTest, TypeReflectionTestGetCanonicalType) {
   EXPECT_EQ(Cpp::GetTypeAsString(Cpp::GetCanonicalType(D4)), "NULL TYPE");
 }
 
-TYPED_TEST(CppInterOpTest, TypeReflectionTestGetType) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, TypeReflection_GetType) {
   TestFixture::CreateInterpreter();
 
   std::string code =  R"(
@@ -133,7 +133,7 @@ TYPED_TEST(CppInterOpTest, TypeReflectionTestGetType) {
   EXPECT_EQ(Cpp::GetTypeAsString(Cpp::GetType("struct")),"NULL TYPE");
 }
 
-TYPED_TEST(CppInterOpTest, TypeReflectionTestIsRecordType) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, TypeReflection_IsRecordType) {
   std::vector<Decl *> Decls;
 
   std::string code = R"(
@@ -200,7 +200,7 @@ TYPED_TEST(CppInterOpTest, TypeReflectionTestIsRecordType) {
   EXPECT_FALSE(is_var_of_record_ty(Decls[24]));
 }
 
-TYPED_TEST(CppInterOpTest, TypeReflectionTestGetUnderlyingType) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, TypeReflection_GetUnderlyingType) {
   std::vector<Decl *> Decls;
 
   std::string code = R"(
@@ -278,7 +278,7 @@ TYPED_TEST(CppInterOpTest, TypeReflectionTestGetUnderlyingType) {
   EXPECT_EQ(get_underly_var_type_as_str(Decls[30]), "E");
 }
 
-TYPED_TEST(CppInterOpTest, TypeReflectionTestIsUnderlyingTypeRecordType) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, TypeReflection_IsUnderlyingTypeRecordType) {
   std::vector<Decl *> Decls;
 
   std::string code = R"(
@@ -345,7 +345,7 @@ TYPED_TEST(CppInterOpTest, TypeReflectionTestIsUnderlyingTypeRecordType) {
   EXPECT_TRUE(is_var_of_underly_record_ty(Decls[24]));
 }
 
-TYPED_TEST(CppInterOpTest, TypeReflectionTestGetComplexType) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, TypeReflection_GetComplexType) {
   TestFixture::CreateInterpreter();
 
   auto get_complex_type_as_string = [&](const std::string &element_type) {
@@ -379,7 +379,7 @@ TYPED_TEST(CppInterOpTest, TypeReflectionTestGetComplexType) {
   clang_Interpreter_dispose(I);
 }
 
-TYPED_TEST(CppInterOpTest, TypeReflectionTestGetTypeFromScope) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, TypeReflection_GetTypeFromScope) {
   std::vector<Decl *> Decls;
 
   std::string code =  R"(
@@ -396,7 +396,7 @@ TYPED_TEST(CppInterOpTest, TypeReflectionTestGetTypeFromScope) {
   EXPECT_EQ(Cpp::GetTypeAsString(Cpp::GetTypeFromScope(nullptr)), "NULL TYPE");
 }
 
-TYPED_TEST(CppInterOpTest, TypeReflectionTestIsTypeDerivedFrom) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, TypeReflection_IsTypeDerivedFrom) {
   std::vector<Decl *> Decls;
 
   std::string code = R"(
@@ -433,7 +433,7 @@ TYPED_TEST(CppInterOpTest, TypeReflectionTestIsTypeDerivedFrom) {
   EXPECT_FALSE(Cpp::IsTypeDerivedFrom(type_A, type_E));
 }
 
-TYPED_TEST(CppInterOpTest, TypeReflectionTestGetDimensions) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, TypeReflection_GetDimensions) {
   std::vector<Decl *> Decls, SubDecls;
 
   std::string code = R"(
@@ -528,7 +528,7 @@ TYPED_TEST(CppInterOpTest, TypeReflectionTestGetDimensions) {
   }
 }
 
-TYPED_TEST(CppInterOpTest, TypeReflectionTestIsPODType) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, TypeReflection_IsPODType) {
   std::vector<Decl *> Decls;
 
   std::string code = R"(
@@ -550,7 +550,7 @@ TYPED_TEST(CppInterOpTest, TypeReflectionTestIsPODType) {
   EXPECT_FALSE(Cpp::IsPODType(0));
 }
 
-TYPED_TEST(CppInterOpTest, TypeReflectionTestIsSmartPtrType) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, TypeReflection_IsSmartPtrType) {
 #if CLANG_VERSION_MAJOR == 18 && defined(CPPINTEROP_USE_CLING) &&              \
     defined(_WIN32) && (defined(_M_ARM) || defined(_M_ARM64))
   GTEST_SKIP() << "Test fails with Cling on Windows on ARM";
@@ -582,8 +582,8 @@ TYPED_TEST(CppInterOpTest, TypeReflectionTestIsSmartPtrType) {
     C object();
   )");
 
-  auto get_type_from_varname = [&](const std::string &varname) {
-    return Cpp::GetVariableType(Cpp::GetNamed(varname));
+  auto get_type_from_varname = [&](const std::string& varname) {
+    return Cpp::GetVariableType(Cpp::GetNamed(varname DFLT_NULLPTR));
   };
 
   //EXPECT_TRUE(Cpp::IsSmartPtrType(get_type_from_varname("smart_ptr1")));
@@ -596,7 +596,7 @@ TYPED_TEST(CppInterOpTest, TypeReflectionTestIsSmartPtrType) {
   EXPECT_FALSE(Cpp::IsSmartPtrType(get_type_from_varname("object")));
 }
 
-TYPED_TEST(CppInterOpTest, TypeReflectionTestIsFunctionPointerType) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, TypeReflection_IsFunctionPointerType) {
   std::vector<const char*> interpreter_args = {"-include", "new"};
   TestFixture::CreateInterpreter(interpreter_args);
 
@@ -607,13 +607,13 @@ TYPED_TEST(CppInterOpTest, TypeReflectionTestIsFunctionPointerType) {
     int i = 2;
   )");
 
-  EXPECT_TRUE(
-      Cpp::IsFunctionPointerType(Cpp::GetVariableType(Cpp::GetNamed("f"))));
-  EXPECT_FALSE(
-      Cpp::IsFunctionPointerType(Cpp::GetVariableType(Cpp::GetNamed("i"))));
+  EXPECT_TRUE(Cpp::IsFunctionPointerType(
+      Cpp::GetVariableType(Cpp::GetNamed("f" DFLT_NULLPTR))));
+  EXPECT_FALSE(Cpp::IsFunctionPointerType(
+      Cpp::GetVariableType(Cpp::GetNamed("i" DFLT_NULLPTR))));
 }
 
-TYPED_TEST(CppInterOpTest, TypeReflectionTestOperatorSpelling) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, TypeReflection_OperatorSpelling) {
   EXPECT_EQ(Cpp::GetSpellingFromOperator(Cpp::OP_Less), "<");
   EXPECT_EQ(Cpp::GetSpellingFromOperator(Cpp::OP_Plus), "+");
   EXPECT_EQ(Cpp::GetOperatorFromSpelling("->"), Cpp::OP_Arrow);
@@ -621,7 +621,7 @@ TYPED_TEST(CppInterOpTest, TypeReflectionTestOperatorSpelling) {
   EXPECT_EQ(Cpp::GetOperatorFromSpelling("invalid"), Cpp::OP_None);
 }
 
-TYPED_TEST(CppInterOpTest, TypeReflectionTestTypeQualifiers) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, TypeReflection_TypeQualifiers) {
   TestFixture::CreateInterpreter();
   Cpp::Declare(R"(
     int *a;
@@ -632,16 +632,16 @@ TYPED_TEST(CppInterOpTest, TypeReflectionTestTypeQualifiers) {
     int *__restrict__ const f = nullptr;
     int *__restrict__ volatile g;
     int *__restrict__ const volatile h = nullptr;
-  )");
+  )" DFLT_FALSE);
 
-  Cpp::TCppType_t a = Cpp::GetVariableType(Cpp::GetNamed("a"));
-  Cpp::TCppType_t b = Cpp::GetVariableType(Cpp::GetNamed("b"));
-  Cpp::TCppType_t c = Cpp::GetVariableType(Cpp::GetNamed("c"));
-  Cpp::TCppType_t d = Cpp::GetVariableType(Cpp::GetNamed("d"));
-  Cpp::TCppType_t e = Cpp::GetVariableType(Cpp::GetNamed("e"));
-  Cpp::TCppType_t f = Cpp::GetVariableType(Cpp::GetNamed("f"));
-  Cpp::TCppType_t g = Cpp::GetVariableType(Cpp::GetNamed("g"));
-  Cpp::TCppType_t h = Cpp::GetVariableType(Cpp::GetNamed("h"));
+  Cpp::TCppType_t a = Cpp::GetVariableType(Cpp::GetNamed("a" DFLT_NULLPTR));
+  Cpp::TCppType_t b = Cpp::GetVariableType(Cpp::GetNamed("b" DFLT_NULLPTR));
+  Cpp::TCppType_t c = Cpp::GetVariableType(Cpp::GetNamed("c" DFLT_NULLPTR));
+  Cpp::TCppType_t d = Cpp::GetVariableType(Cpp::GetNamed("d" DFLT_NULLPTR));
+  Cpp::TCppType_t e = Cpp::GetVariableType(Cpp::GetNamed("e" DFLT_NULLPTR));
+  Cpp::TCppType_t f = Cpp::GetVariableType(Cpp::GetNamed("f" DFLT_NULLPTR));
+  Cpp::TCppType_t g = Cpp::GetVariableType(Cpp::GetNamed("g" DFLT_NULLPTR));
+  Cpp::TCppType_t h = Cpp::GetVariableType(Cpp::GetNamed("h" DFLT_NULLPTR));
 
   EXPECT_FALSE(Cpp::HasTypeQualifier(nullptr, Cpp::QualKind::Const));
   EXPECT_FALSE(Cpp::RemoveTypeQualifier(nullptr, Cpp::QualKind::Const));

--- a/unittests/CppInterOp/Utils.cpp
+++ b/unittests/CppInterOp/Utils.cpp
@@ -1,7 +1,5 @@
 #include "Utils.h"
 
-#include "CppInterOp/CppInterOp.h"
-
 #include "clang/AST/Decl.h"
 #include "clang/AST/DeclCXX.h"
 #include "clang/Basic/Version.h"
@@ -13,11 +11,34 @@
 #include "llvm/TargetParser/Triple.h"
 
 #include <algorithm>
+#include <cstdlib>
 #include <string>
 #include <vector>
 
 using namespace clang;
 using namespace llvm;
+
+#if defined(ENABLE_DISPATCH_TESTS)
+#define DISPATCH_API(name, type) CppAPIType::name Cpp::name = nullptr;
+CPPINTEROP_API_TABLE
+#undef DISPATCH_API
+namespace {
+struct DispatchInitializer {
+  DispatchInitializer() {
+    if (!Cpp::LoadDispatchAPI(CPPINTEROP_LIB_PATH)) {
+      std::abort();
+    }
+  }
+  ~DispatchInitializer() { Cpp::UnloadDispatchAPI(); }
+  DispatchInitializer(const DispatchInitializer&) = delete;
+  DispatchInitializer& operator=(const DispatchInitializer&) = delete;
+  DispatchInitializer(DispatchInitializer&&) noexcept = default;
+  DispatchInitializer& operator=(DispatchInitializer&&) noexcept = default;
+};
+// FIXME: Make this threadsafe by moving it as a function static.
+DispatchInitializer g_dispatch_init;
+} // namespace
+#endif
 
 namespace TestUtils {
 TestConfig current_config;
@@ -35,7 +56,7 @@ void TestUtils::GetAllTopLevelDecls(
     const std::string& code, std::vector<Decl*>& Decls,
     bool filter_implicitGenerated /* = false */,
     const std::vector<const char*>& interpreter_args /* = {} */) {
-  Cpp::CreateInterpreter(interpreter_args);
+  Cpp::CreateInterpreter(interpreter_args, {});
 #ifdef CPPINTEROP_USE_CLING
   cling::Transaction *T = nullptr;
   Interp->declare(code, &T);

--- a/unittests/CppInterOp/Utils.h
+++ b/unittests/CppInterOp/Utils.h
@@ -5,7 +5,14 @@
 
 #include "clang-c/CXCppInterOp.h"
 #include "clang-c/CXString.h"
+
+#if defined(ENABLE_DISPATCH_TESTS)
+#include "CppInterOp/Dispatch.h"
+#define CPPINTEROP_TEST_MODE CppInterOpDispatchTest
+#else
 #include "CppInterOp/CppInterOp.h"
+#define CPPINTEROP_TEST_MODE CppInterOpTest
+#endif
 
 #include "llvm/Support/Valgrind.h"
 
@@ -71,8 +78,7 @@ struct OutOfProcessJITConfig {
 #endif
 
 // Define typed test fixture
-template <typename Config>
-class CppInterOpTest : public ::testing::Test {
+template <typename Config> class CPPINTEROP_TEST_MODE : public ::testing::Test {
 protected:
   void SetUp() override {
     TestUtils::current_config =
@@ -104,7 +110,7 @@ using CppInterOpTestTypes = ::testing::Types<InProcessJITConfig, OutOfProcessJIT
 using CppInterOpTestTypes = ::testing::Types<InProcessJITConfig>;
 #endif
 
-TYPED_TEST_SUITE(CppInterOpTest, CppInterOpTestTypes, JITConfigNameGenerator);
-
+TYPED_TEST_SUITE(CPPINTEROP_TEST_MODE, CppInterOpTestTypes,
+                 JITConfigNameGenerator);
 
 #endif // CPPINTEROP_UNITTESTS_LIBCPPINTEROP_UTILS_H

--- a/unittests/CppInterOp/Utils.h
+++ b/unittests/CppInterOp/Utils.h
@@ -9,9 +9,23 @@
 #if defined(ENABLE_DISPATCH_TESTS)
 #include "CppInterOp/Dispatch.h"
 #define CPPINTEROP_TEST_MODE CppInterOpDispatchTest
+// Helper macros that conditionally pass default arguments in dispatch mode
+// tests
+#define DFLT_OP_ARITY , Cpp::OperatorArity::kBoth
+#define DFLT_NULLPTR , nullptr
+#define DFLT_FALSE , false
+#define DFLT_TRUE , true
+#define DFLT_0 , 0
+#define DFLT_1 , 1
 #else
 #include "CppInterOp/CppInterOp.h"
 #define CPPINTEROP_TEST_MODE CppInterOpTest
+#define DFLT_OP_ARITY
+#define DFLT_NULLPTR
+#define DFLT_FALSE
+#define DFLT_TRUE
+#define DFLT_0
+#define DFLT_1
 #endif
 
 #include "llvm/Support/Valgrind.h"

--- a/unittests/CppInterOp/VariableReflectionTest.cpp
+++ b/unittests/CppInterOp/VariableReflectionTest.cpp
@@ -16,7 +16,7 @@ using namespace TestUtils;
 using namespace llvm;
 using namespace clang;
 
-TYPED_TEST(CppInterOpTest, VariableReflectionTestGetDatamembers) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, VariableReflection_GetDatamembers) {
   std::vector<Decl*> Decls;
   std::string code = R"(
     class C {
@@ -113,7 +113,7 @@ TYPED_TEST(CppInterOpTest, VariableReflectionTestGetDatamembers) {
 
 CODE
 
-TYPED_TEST(CppInterOpTest, VariableReflectionTestDatamembersWithAnonymousStructOrUnion) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, VariableReflection_DatamembersWithAnonymousStructOrUnion) {
   if (llvm::sys::RunningOnValgrind())
     GTEST_SKIP() << "XFAIL due to Valgrind report";
 
@@ -136,33 +136,35 @@ TYPED_TEST(CppInterOpTest, VariableReflectionTestDatamembersWithAnonymousStructO
   EXPECT_EQ(datamembers_klass1.size(), 3);
   EXPECT_EQ(datamembers_klass2.size(), 3);
 
-  EXPECT_EQ(Cpp::GetVariableOffset(datamembers_klass1[0]), 0);
-  EXPECT_EQ(Cpp::GetVariableOffset(datamembers_klass1[1]),
+  EXPECT_EQ(Cpp::GetVariableOffset(datamembers_klass1[0] DFLT_0), 0);
+  // NOLINTBEGIN(cppcoreguidelines-pro-type-union-access)
+  EXPECT_EQ(Cpp::GetVariableOffset(datamembers_klass1[1] DFLT_0),
             ((intptr_t) & (k1.a)) - ((intptr_t) & (k1.num)));
-  EXPECT_EQ(Cpp::GetVariableOffset(datamembers_klass1[2]),
+  EXPECT_EQ(Cpp::GetVariableOffset(datamembers_klass1[2] DFLT_0),
             ((intptr_t) & (k1.b)) - ((intptr_t) & (k1.num)));
 
-  EXPECT_EQ(Cpp::GetVariableOffset(datamembers_klass2[0]), 0);
-  EXPECT_EQ(Cpp::GetVariableOffset(datamembers_klass2[1]),
+  EXPECT_EQ(Cpp::GetVariableOffset(datamembers_klass2[0] DFLT_0), 0);
+  EXPECT_EQ(Cpp::GetVariableOffset(datamembers_klass2[1] DFLT_0),
             ((intptr_t) & (k2.a)) - ((intptr_t) & (k2.num)));
-  EXPECT_EQ(Cpp::GetVariableOffset(datamembers_klass2[2]),
+  EXPECT_EQ(Cpp::GetVariableOffset(datamembers_klass2[2] DFLT_0),
             ((intptr_t) & (k2.b)) - ((intptr_t) & (k2.num)));
 
-  EXPECT_EQ(Cpp::GetVariableOffset(datamembers_klass3[0]), 0);
-  EXPECT_EQ(Cpp::GetVariableOffset(datamembers_klass3[1]),
+  EXPECT_EQ(Cpp::GetVariableOffset(datamembers_klass3[0] DFLT_0), 0);
+  EXPECT_EQ(Cpp::GetVariableOffset(datamembers_klass3[1] DFLT_0),
             ((intptr_t) & (k3.a)) - ((intptr_t) & (k3.num)));
-  EXPECT_EQ(Cpp::GetVariableOffset(datamembers_klass3[2]),
+  EXPECT_EQ(Cpp::GetVariableOffset(datamembers_klass3[2] DFLT_0),
             ((intptr_t) & (k3.b)) - ((intptr_t) & (k3.num)));
-  EXPECT_EQ(Cpp::GetVariableOffset(datamembers_klass3[3]),
+  EXPECT_EQ(Cpp::GetVariableOffset(datamembers_klass3[3] DFLT_0),
             ((intptr_t) & (k3.c)) - ((intptr_t) & (k3.num)));
-  EXPECT_EQ(Cpp::GetVariableOffset(datamembers_klass3[4]),
+  EXPECT_EQ(Cpp::GetVariableOffset(datamembers_klass3[4] DFLT_0),
             ((intptr_t) & (k3.num2)) - ((intptr_t) & (k3.num)));
+  // NOLINTEND(cppcoreguidelines-pro-type-union-access)
 #ifdef _WIN32
 #pragma warning(default : 4201)
 #endif
 }
 
-TYPED_TEST(CppInterOpTest, VariableReflectionTestGetTypeAsString) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, VariableReflection_GetTypeAsString) {
   if (llvm::sys::RunningOnValgrind())
     GTEST_SKIP() << "XFAIL due to Valgrind report";
 
@@ -181,7 +183,7 @@ TYPED_TEST(CppInterOpTest, VariableReflectionTestGetTypeAsString) {
   )";
 
   TestFixture::CreateInterpreter();
-  EXPECT_EQ(Cpp::Declare(code.c_str()), 0);
+  EXPECT_EQ(Cpp::Declare(code.c_str() DFLT_FALSE), 0);
 
   Cpp::TCppScope_t wrapper =
       Cpp::GetScopeFromCompleteName("my_namespace::Wrapper");
@@ -195,7 +197,7 @@ TYPED_TEST(CppInterOpTest, VariableReflectionTestGetTypeAsString) {
             "my_namespace::Container");
 }
 
-TYPED_TEST(CppInterOpTest, VariableReflectionTestLookupDatamember) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, VariableReflection_LookupDatamember) {
   std::vector<Decl*> Decls;
   std::string code = R"(
     class C {
@@ -219,7 +221,7 @@ TYPED_TEST(CppInterOpTest, VariableReflectionTestLookupDatamember) {
   EXPECT_EQ(Cpp::GetQualifiedName(Cpp::LookupDatamember("k", Decls[0])), "<unnamed>");
 }
 
-TYPED_TEST(CppInterOpTest, VariableReflectionTestGetVariableType) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, VariableReflection_GetVariableType) {
   std::vector<Decl*> Decls;
   std::string code = R"(
     class C {};
@@ -268,7 +270,7 @@ TYPED_TEST(CppInterOpTest, VariableReflectionTestGetVariableType) {
 
 CODE
 
-TYPED_TEST(CppInterOpTest, VariableReflectionTestGetVariableOffset) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, VariableReflection_GetVariableOffset) {
 #ifdef EMSCRIPTEN
 #if CLANG_VERSION_MAJOR < 20
   GTEST_SKIP() << "Test fails for Emscipten builds";
@@ -287,63 +289,62 @@ TYPED_TEST(CppInterOpTest, VariableReflectionTestGetVariableOffset) {
   std::vector<Cpp::TCppScope_t> datamembers;
   Cpp::GetDatamembers(Decls[4], datamembers);
 
-  EXPECT_TRUE((bool) Cpp::GetVariableOffset(Decls[0])); // a
-  EXPECT_TRUE((bool) Cpp::GetVariableOffset(Decls[1])); // N
-  EXPECT_TRUE((bool)Cpp::GetVariableOffset(Decls[2]));  // S
-  EXPECT_TRUE((bool)Cpp::GetVariableOffset(Decls[3]));  // SN
+  EXPECT_TRUE((bool)Cpp::GetVariableOffset(Decls[0] DFLT_0)); // a
+  EXPECT_TRUE((bool)Cpp::GetVariableOffset(Decls[1] DFLT_0)); // N
+  EXPECT_TRUE((bool)Cpp::GetVariableOffset(Decls[2] DFLT_0)); // S
+  EXPECT_TRUE((bool)Cpp::GetVariableOffset(Decls[3] DFLT_0)); // SN
 
-  EXPECT_EQ(Cpp::GetVariableOffset(datamembers[0]), 0);
+  EXPECT_EQ(Cpp::GetVariableOffset(datamembers[0] DFLT_0), 0);
 
-  EXPECT_EQ(Cpp::GetVariableOffset(datamembers[1]),
-          ((intptr_t) &(c.b)) - ((intptr_t) &(c.a)));
-  EXPECT_EQ(Cpp::GetVariableOffset(datamembers[2]),
-          ((intptr_t) &(c.c)) - ((intptr_t) &(c.a)));
-  EXPECT_EQ(Cpp::GetVariableOffset(datamembers[3]),
-          ((intptr_t) &(c.d)) - ((intptr_t) &(c.a)));
+  EXPECT_EQ(Cpp::GetVariableOffset(datamembers[1] DFLT_0),
+            ((intptr_t) & (c.b)) - ((intptr_t) & (c.a)));
+  EXPECT_EQ(Cpp::GetVariableOffset(datamembers[2] DFLT_0),
+            ((intptr_t) & (c.c)) - ((intptr_t) & (c.a)));
+  EXPECT_EQ(Cpp::GetVariableOffset(datamembers[3] DFLT_0),
+            ((intptr_t) & (c.d)) - ((intptr_t) & (c.a)));
 
   auto* VD_C_s_a = Cpp::GetNamed("s_a", Decls[4]); // C::s_a
-  EXPECT_TRUE((bool) Cpp::GetVariableOffset(VD_C_s_a));
+  EXPECT_TRUE((bool)Cpp::GetVariableOffset(VD_C_s_a DFLT_0));
 
   struct K {
     int x;
     int y;
     int z;
   };
-  Cpp::Declare("struct K;");
-  Cpp::TCppScope_t k = Cpp::GetNamed("K");
+  Cpp::Declare("struct K;" DFLT_FALSE);
+  Cpp::TCppScope_t k = Cpp::GetNamed("K" DFLT_NULLPTR);
   EXPECT_TRUE(k);
 
-  Cpp::Declare("struct K { int x; int y; int z; };");
-
+  Cpp::Declare("struct K { int x; int y; int z; };" DFLT_FALSE);
   datamembers.clear();
   Cpp::GetDatamembers(k, datamembers);
   EXPECT_EQ(datamembers.size(), 3);
 
-  EXPECT_EQ(Cpp::GetVariableOffset(datamembers[0]), offsetof(K, x));
-  EXPECT_EQ(Cpp::GetVariableOffset(datamembers[1]), offsetof(K, y));
-  EXPECT_EQ(Cpp::GetVariableOffset(datamembers[2]), offsetof(K, z));
+  EXPECT_EQ(Cpp::GetVariableOffset(datamembers[0] DFLT_0), offsetof(K, x));
+  EXPECT_EQ(Cpp::GetVariableOffset(datamembers[1] DFLT_0), offsetof(K, y));
+  EXPECT_EQ(Cpp::GetVariableOffset(datamembers[2] DFLT_0), offsetof(K, z));
 
   Cpp::Declare(R"(
     template <typename T> struct ClassWithStatic {
       static T const ref_value;
     };
     template <typename T> T constexpr ClassWithStatic<T>::ref_value = 42;
-  )");
+  )" DFLT_FALSE);
 
-  Cpp::TCppScope_t klass = Cpp::GetNamed("ClassWithStatic");
+  Cpp::TCppScope_t klass = Cpp::GetNamed("ClassWithStatic" DFLT_NULLPTR);
   EXPECT_TRUE(klass);
 
   ASTContext& C = Interp->getCI()->getASTContext();
   std::vector<Cpp::TemplateArgInfo> template_args = {
       {C.IntTy.getAsOpaquePtr()}};
   Cpp::TCppScope_t klass_instantiated = Cpp::InstantiateTemplate(
-      klass, template_args.data(), template_args.size());
+      klass, template_args.data(), template_args.size() DFLT_FALSE);
   EXPECT_TRUE(klass_instantiated);
 
   Cpp::TCppScope_t var = Cpp::GetNamed("ref_value", klass_instantiated);
   EXPECT_TRUE(var);
 
-  EXPECT_TRUE(Cpp::GetVariableOffset(var));
+  EXPECT_TRUE(Cpp::GetVariableOffset(var DFLT_0));
 }
 
 #define CODE                                                                   \
@@ -379,7 +380,7 @@ TYPED_TEST(CppInterOpTest, VariableReflectionTestGetVariableOffset) {
 
 CODE
 
-TYPED_TEST(CppInterOpTest, VariableReflectionTestVariableOffsetsWithInheritance) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, VariableReflection_VariableOffsetsWithInheritance) {
 #if CLANG_VERSION_MAJOR == 18 && defined(CPPINTEROP_USE_CLING) &&              \
     defined(_WIN32) && (defined(_M_ARM) || defined(_M_ARM64))
   GTEST_SKIP() << "Test fails with Cling on Windows on ARM";
@@ -390,16 +391,16 @@ TYPED_TEST(CppInterOpTest, VariableReflectionTestVariableOffsetsWithInheritance)
   std::vector<const char*> interpreter_args = {"-include", "new"};
   TestFixture::CreateInterpreter(interpreter_args);
 
-  Cpp::Declare("#include<string>");
+  Cpp::Declare("#include<string>" DFLT_FALSE);
 
 #define Stringify(s) Stringifyx(s)
 #define Stringifyx(...) #__VA_ARGS__
-  Cpp::Declare(Stringify(CODE));
+  Cpp::Declare(Stringify(CODE) DFLT_FALSE);
 #undef Stringifyx
 #undef Stringify
 #undef CODE
 
-  Cpp::TCppScope_t myklass = Cpp::GetNamed("MyKlass");
+  Cpp::TCppScope_t myklass = Cpp::GetNamed("MyKlass" DFLT_NULLPTR);
   EXPECT_TRUE(myklass);
 
   size_t num_bases = Cpp::GetNumBases(myklass);
@@ -435,7 +436,7 @@ TYPED_TEST(CppInterOpTest, VariableReflectionTestVariableOffsetsWithInheritance)
             ((intptr_t)&(my_k.s)) - ((intptr_t)&(my_k)));
 }
 
-TYPED_TEST(CppInterOpTest, VariableReflectionTestIsPublicVariable) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, VariableReflection_IsPublicVariable) {
   std::vector<Decl *> Decls, SubDecls;
   std::string code = R"(
     class C {
@@ -458,7 +459,7 @@ TYPED_TEST(CppInterOpTest, VariableReflectionTestIsPublicVariable) {
   EXPECT_FALSE(Cpp::IsPublicVariable(SubDecls[7]));
 }
 
-TYPED_TEST(CppInterOpTest, VariableReflectionTestIsProtectedVariable) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, VariableReflection_IsProtectedVariable) {
   std::vector<Decl *> Decls, SubDecls;
   std::string code = R"(
     class C {
@@ -479,7 +480,7 @@ TYPED_TEST(CppInterOpTest, VariableReflectionTestIsProtectedVariable) {
   EXPECT_TRUE(Cpp::IsProtectedVariable(SubDecls[6]));
 }
 
-TYPED_TEST(CppInterOpTest, VariableReflectionTestIsPrivateVariable) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, VariableReflection_IsPrivateVariable) {
   std::vector<Decl *> Decls, SubDecls;
   std::string code = R"(
     class C {
@@ -500,7 +501,7 @@ TYPED_TEST(CppInterOpTest, VariableReflectionTestIsPrivateVariable) {
   EXPECT_FALSE(Cpp::IsPrivateVariable(SubDecls[6]));
 }
 
-TYPED_TEST(CppInterOpTest, VariableReflectionTestIsStaticVariable) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, VariableReflection_IsStaticVariable) {
   std::vector<Decl *> Decls, SubDecls;
   std::string code =  R"(
     class C {
@@ -516,7 +517,7 @@ TYPED_TEST(CppInterOpTest, VariableReflectionTestIsStaticVariable) {
   EXPECT_TRUE(Cpp::IsStaticVariable(SubDecls[2]));
 }
 
-TYPED_TEST(CppInterOpTest, VariableReflectionTestIsConstVariable) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, VariableReflection_IsConstVariable) {
   std::vector<Decl *> Decls, SubDecls;
   std::string code =  R"(
     class C {
@@ -533,7 +534,8 @@ TYPED_TEST(CppInterOpTest, VariableReflectionTestIsConstVariable) {
   EXPECT_TRUE(Cpp::IsConstVariable(SubDecls[2]));
 }
 
-TYPED_TEST(CppInterOpTest, VariableReflectionTestDISABLED_GetArrayDimensions) {
+TYPED_TEST(CPPINTEROP_TEST_MODE,
+           VariableReflection_DISABLED_GetArrayDimensions) {
   std::vector<Decl *> Decls;
   std::string code =  R"(
     int a;
@@ -557,7 +559,7 @@ TYPED_TEST(CppInterOpTest, VariableReflectionTestDISABLED_GetArrayDimensions) {
   // EXPECT_TRUE(is_vec_eq(Cpp::GetArrayDimensions(Decls[2]), {1,2}));
 }
 
-TYPED_TEST(CppInterOpTest, VariableReflectionTestStaticConstExprDatamember) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, VariableReflection_StaticConstExprDatamember) {
   if (llvm::sys::RunningOnValgrind())
     GTEST_SKIP() << "XFAIL due to Valgrind report";
 
@@ -588,40 +590,40 @@ TYPED_TEST(CppInterOpTest, VariableReflectionTestStaticConstExprDatamember) {
   template<typename... Eles>
   struct Elements
   : public integral_constant<int, sizeof...(Eles)> {};
-  )");
+  )" DFLT_FALSE);
 
-  Cpp::TCppScope_t MyClass = Cpp::GetNamed("MyClass");
+  Cpp::TCppScope_t MyClass = Cpp::GetNamed("MyClass" DFLT_NULLPTR);
   EXPECT_TRUE(MyClass);
 
   std::vector<Cpp::TCppScope_t> datamembers;
   Cpp::GetStaticDatamembers(MyClass, datamembers);
   EXPECT_EQ(datamembers.size(), 1);
 
-  intptr_t offset = Cpp::GetVariableOffset(datamembers[0]);
+  intptr_t offset = Cpp::GetVariableOffset(datamembers[0] DFLT_0);
   EXPECT_EQ(3, *(size_t*)offset);
 
   ASTContext& C = Interp->getCI()->getASTContext();
   std::vector<Cpp::TemplateArgInfo> template_args = {
       {C.IntTy.getAsOpaquePtr(), "5"}};
 
-  Cpp::TCppFunction_t MyTemplatedClass =
-      Cpp::InstantiateTemplate(Cpp::GetNamed("MyTemplatedClass"),
-                               template_args.data(), template_args.size());
+  Cpp::TCppFunction_t MyTemplatedClass = Cpp::InstantiateTemplate(
+      Cpp::GetNamed("MyTemplatedClass" DFLT_NULLPTR), template_args.data(),
+      template_args.size() DFLT_FALSE);
   EXPECT_TRUE(MyTemplatedClass);
 
   datamembers.clear();
   Cpp::GetStaticDatamembers(MyTemplatedClass, datamembers);
   EXPECT_EQ(datamembers.size(), 1);
 
-  offset = Cpp::GetVariableOffset(datamembers[0]);
+  offset = Cpp::GetVariableOffset(datamembers[0] DFLT_0);
   EXPECT_EQ(5, *(size_t*)offset);
 
   std::vector<Cpp::TemplateArgInfo> ele_template_args = {
       {C.IntTy.getAsOpaquePtr()}, {C.FloatTy.getAsOpaquePtr()}};
 
   Cpp::TCppFunction_t Elements = Cpp::InstantiateTemplate(
-      Cpp::GetNamed("Elements"), ele_template_args.data(),
-      ele_template_args.size());
+      Cpp::GetNamed("Elements" DFLT_NULLPTR), ele_template_args.data(),
+      ele_template_args.size() DFLT_FALSE);
   EXPECT_TRUE(Elements);
 
   EXPECT_EQ(1, Cpp::GetNumBases(Elements));
@@ -632,11 +634,12 @@ TYPED_TEST(CppInterOpTest, VariableReflectionTestStaticConstExprDatamember) {
   Cpp::GetStaticDatamembers(IC, datamembers);
   EXPECT_EQ(datamembers.size(), 1);
 
-  offset = Cpp::GetVariableOffset(datamembers[0]);
+  offset = Cpp::GetVariableOffset(datamembers[0] DFLT_0);
   EXPECT_EQ(2, *(size_t*)offset);
 }
 
-TYPED_TEST(CppInterOpTest, VariableReflectionTestGetEnumConstantDatamembers) {
+TYPED_TEST(CPPINTEROP_TEST_MODE,
+           VariableReflection_GetEnumConstantDatamembers) {
   TestFixture::CreateInterpreter();
 
   Cpp::Declare(R"(
@@ -645,13 +648,13 @@ TYPED_TEST(CppInterOpTest, VariableReflectionTestGetEnumConstantDatamembers) {
     enum A { ONE, TWO, THREE };
     enum class B { SEVEN, EIGHT, NINE };
   };
-  )");
+  )" DFLT_FALSE);
 
-  Cpp::TCppScope_t MyEnumClass = Cpp::GetNamed("MyEnumClass");
+  Cpp::TCppScope_t MyEnumClass = Cpp::GetNamed("MyEnumClass" DFLT_NULLPTR);
   EXPECT_TRUE(MyEnumClass);
 
   std::vector<Cpp::TCppScope_t> datamembers;
-  Cpp::GetEnumConstantDatamembers(MyEnumClass, datamembers);
+  Cpp::GetEnumConstantDatamembers(MyEnumClass, datamembers DFLT_TRUE);
   EXPECT_EQ(datamembers.size(), 9);
   EXPECT_TRUE(Cpp::IsEnumType(Cpp::GetVariableType(datamembers[0])));
 
@@ -660,7 +663,7 @@ TYPED_TEST(CppInterOpTest, VariableReflectionTestGetEnumConstantDatamembers) {
   EXPECT_EQ(datamembers2.size(), 6);
 }
 
-TYPED_TEST(CppInterOpTest, VariableReflectionTestIs_Get_Pointer) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, VariableReflection_Is_Get_Pointer) {
   TestFixture::CreateInterpreter();
   std::vector<Decl*> Decls;
   std::string code = R"(
@@ -692,7 +695,7 @@ TYPED_TEST(CppInterOpTest, VariableReflectionTestIs_Get_Pointer) {
   EXPECT_FALSE(Cpp::GetPointeeType(Cpp::GetVariableType(Decls[5])));
 }
 
-TYPED_TEST(CppInterOpTest, VariableReflectionTestIs_Get_Reference) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, VariableReflection_Is_Get_Reference) {
   TestFixture::CreateInterpreter();
   std::vector<Decl*> Decls;
   std::string code = R"(
@@ -725,7 +728,7 @@ TYPED_TEST(CppInterOpTest, VariableReflectionTestIs_Get_Reference) {
 
   EXPECT_EQ(Cpp::GetValueKind(Cpp::GetVariableType(Decls[2])),
             Cpp::ValueKind::LValue);
-  EXPECT_EQ(Cpp::GetReferencedType(Cpp::GetVariableType(Decls[1])),
+  EXPECT_EQ(Cpp::GetReferencedType(Cpp::GetVariableType(Decls[1]) DFLT_FALSE),
             Cpp::GetVariableType(Decls[2]));
   EXPECT_EQ(Cpp::GetValueKind(
                 Cpp::GetReferencedType(Cpp::GetVariableType(Decls[1]), true)),
@@ -734,7 +737,7 @@ TYPED_TEST(CppInterOpTest, VariableReflectionTestIs_Get_Reference) {
             Cpp::ValueKind::None);
 }
 
-TYPED_TEST(CppInterOpTest, VariableReflectionTestGetPointerType) {
+TYPED_TEST(CPPINTEROP_TEST_MODE, VariableReflection_GetPointerType) {
   TestFixture::CreateInterpreter();
   std::vector<Decl*> Decls;
   std::string code = R"(


### PR DESCRIPTION
(fresh PR on top of https://github.com/compiler-research/CppInterOp/pull/730, see https://github.com/compiler-research/CppInterOp/pull/730#issuecomment-3763250010)

This PR defines the mechanism which enables dispatching CppInterOp's API without linking to it, preventing any LLVM or Clang symbols from being leaked into the client application.

This allows us to run cppyy without linking to CppInterOp motivated by the use case in ROOT. Can be used to deploy CppInterOp in an environment where dynamic linking is not favourable and the only option is dlopen'ing `libClangCppInterOp.so` with `RTLD_LOCAL`

TODO:

- [x] Failures in the CPyCppyy build step are expected since it redefines `TemplateArgInfo` and expects the symbols to match the ones in cppyy-backend, which is no longer the case. Corresponding PR: https://github.com/compiler-research/CPyCppyy/pull/148 and https://github.com/compiler-research/cppyy-backend/pull/177 to be merged following this PR 

- [x] clang-format has to be run over all changes, will do that once the PR has been refactored into atomic commits (once approved and ready to be merged)

- [x] dev docs to be added explaining how a client would use this system