### PR TITLE
Add `IsExplicit` for constructors and conversion operators

### DIFF
--- a/include/CppInterOp/CppInterOp.h
+++ b/include/CppInterOp/CppInterOp.h
@@ -556,6 +556,9 @@ CPPINTEROP_API bool IsDestructor(TCppConstFunction_t method);
 /// Checks if the provided parameter is a 'Static' method.
 CPPINTEROP_API bool IsStaticMethod(TCppConstFunction_t method);
 
+/// Checks if the provided constructor or conversion operator is explicit
+CPPINTEROP_API bool IsExplicit(TCppConstFunction_t method);
+
 ///\returns the address of the function given its potentially mangled name.
 CPPINTEROP_API TCppFuncAddr_t GetFunctionAddress(const char* mangled_name);
 

--- a/include/CppInterOp/Dispatch.h
+++ b/include/CppInterOp/Dispatch.h
@@ -181,6 +181,7 @@ extern "C" CPPINTEROP_API CppFnPtrTy CppGetProcAddress(const char* procname);
   DISPATCH_API(BeginStdStreamCapture,                                          \
                decltype(&CppImpl::BeginStdStreamCapture))                      \
   DISPATCH_API(GetDoxygenComment, decltype(&CppImpl::GetDoxygenComment))       \
+  DISPATCH_API(IsExplicit, decltype(&CppImpl::IsExplicit))                     \
   DISPATCH_API(MakeFunctionCallable,                                           \
                CppImpl::JitCall (*)(CppImpl::TCppConstFunction_t))             \
   DISPATCH_API(GetFunctionAddress,                                             \

--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -1409,6 +1409,27 @@ bool IsStaticMethod(TCppConstFunction_t method) {
   return false;
 }
 
+bool IsExplicit(TCppConstFunction_t method) {
+  if (!method)
+    return false;
+
+  const auto* D = static_cast<const Decl*>(method);
+
+  if (const auto* FTD = llvm::dyn_cast_or_null<FunctionTemplateDecl>(D))
+    D = FTD->getTemplatedDecl();
+
+  if (const auto* CD = llvm::dyn_cast_or_null<CXXConstructorDecl>(D))
+    return CD->isExplicit();
+
+  if (const auto* CD = llvm::dyn_cast_or_null<CXXConversionDecl>(D))
+    return CD->isExplicit();
+
+  if (const auto* DGD = llvm::dyn_cast_or_null<CXXDeductionGuideDecl>(D))
+    return DGD->isExplicit();
+
+  return false;
+}
+
 TCppFuncAddr_t GetFunctionAddress(const char* mangled_name) {
   auto& I = getInterp();
   auto FDAorErr = compat::getSymbolAddress(I, mangled_name);


### PR DESCRIPTION
Required for implementing https://github.com/root-project/root/pull/19513 in our forks