### PR TITLE
Turn cppyy to on for cling jobs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,7 +61,7 @@ jobs:
             compiler: gcc-9
             clang-runtime: '18'
             cling: On
-            cppyy: Off
+            cppyy: On
             cling-version: '1.2'
             llvm_enable_projects: "clang"
             llvm_targets_to_build: "host;NVPTX"
@@ -125,7 +125,7 @@ jobs:
             compiler: gcc-9
             clang-runtime: '18'
             cling: On
-            cppyy: Off
+            cppyy: On
             cling-version: '1.2'
             llvm_enable_projects: "clang"
             llvm_targets_to_build: "host;NVPTX"


### PR DESCRIPTION
I noticed while working on the PR which drops llvm 18 support that the Ubuntu cling jobs have cppyy to set off. This PR sets it to on.