### PR TITLE
fix GetFunctionAddress resolution with explicit name change

### DIFF
--- a/include/CppInterOp/CppInterOp.h
+++ b/include/CppInterOp/CppInterOp.h
@@ -560,7 +560,8 @@ CPPINTEROP_API bool IsStaticMethod(TCppConstFunction_t method);
 CPPINTEROP_API bool IsExplicit(TCppConstFunction_t method);
 
 ///\returns the address of the function given its potentially mangled name.
-CPPINTEROP_API TCppFuncAddr_t GetFunctionAddress(const char* mangled_name);
+CPPINTEROP_API TCppFuncAddr_t
+GetFunctionAddressFromMangledName(const char* mangled_name);
 
 ///\returns the address of the function given its function declaration.
 CPPINTEROP_API TCppFuncAddr_t GetFunctionAddress(TCppFunction_t method);

--- a/include/CppInterOp/Dispatch.h
+++ b/include/CppInterOp/Dispatch.h
@@ -184,8 +184,7 @@ extern "C" CPPINTEROP_API CppFnPtrTy CppGetProcAddress(const char* procname);
   DISPATCH_API(IsExplicit, decltype(&CppImpl::IsExplicit))                     \
   DISPATCH_API(MakeFunctionCallable,                                           \
                CppImpl::JitCall (*)(CppImpl::TCppConstFunction_t))             \
-  DISPATCH_API(GetFunctionAddress,                                             \
-               CppImpl::TCppFuncAddr_t (*)(CppImpl::TCppFunction_t))           \
+  DISPATCH_API(GetFunctionAddress, decltype(&CppImpl::GetFunctionAddress))     \
   /*DISPATCH_API(API_name, fnptr_ty)*/
 
 // TODO: implement overload that takes an existing opened DL handle

--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -1430,7 +1430,7 @@ bool IsExplicit(TCppConstFunction_t method) {
   return false;
 }
 
-TCppFuncAddr_t GetFunctionAddress(const char* mangled_name) {
+TCppFuncAddr_t GetFunctionAddressFromMangledName(const char* mangled_name) {
   auto& I = getInterp();
   auto FDAorErr = compat::getSymbolAddress(I, mangled_name);
   if (llvm::Error Err = FDAorErr.takeError())
@@ -1462,7 +1462,7 @@ static TCppFuncAddr_t GetFunctionAddress(const FunctionDecl* FD) {
 
   // Constructor and Destructors needs to be handled differently
   if (!llvm::isa<CXXConstructorDecl>(FD) && !llvm::isa<CXXDestructorDecl>(FD))
-    return GetFunctionAddress(get_mangled_name(FD).c_str());
+    return GetFunctionAddressFromMangledName(get_mangled_name(FD).c_str());
 
   return 0;
 }

--- a/unittests/CppInterOp/DynamicLibraryManagerTest.cpp
+++ b/unittests/CppInterOp/DynamicLibraryManagerTest.cpp
@@ -33,7 +33,7 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, DynamicLibraryManager_Sanity) {
     GTEST_SKIP() << "Test fails for OOP JIT builds";
 
   EXPECT_TRUE(TestFixture::CreateInterpreter());
-  EXPECT_FALSE(Cpp::GetFunctionAddress("ret_zero"));
+  EXPECT_FALSE(Cpp::GetFunctionAddressFromMangledName("ret_zero"));
 
   std::string BinaryPath = GetExecutablePath(/*Argv0=*/nullptr);
   llvm::StringRef Dir = llvm::sys::path::parent_path(BinaryPath);
@@ -59,14 +59,14 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, DynamicLibraryManager_Sanity) {
   Cpp::Process("");
   // FIXME: Conda returns false to run this code on osx.
 #ifndef __APPLE__
-  EXPECT_TRUE(Cpp::GetFunctionAddress("ret_zero"));
+  EXPECT_TRUE(Cpp::GetFunctionAddressFromMangledName("ret_zero"));
 #endif //__APPLE__
 
   Cpp::UnloadLibrary("TestSharedLib");
   // We have no reliable way to check if it was unloaded because posix does not
   // require the library to be actually unloaded but just the handle to be
   // invalidated...
-  // EXPECT_FALSE(Cpp::GetFunctionAddress("ret_zero"));
+  // EXPECT_FALSE(Cpp::GetFunctionAddressFromMangledName("ret_zero"));
 }
 
 TYPED_TEST(CPPINTEROP_TEST_MODE, DynamicLibraryManager_BasicSymbolLookup) {
@@ -81,7 +81,7 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, DynamicLibraryManager_BasicSymbolLookup) {
     GTEST_SKIP() << "Test fails for OOP JIT builds";
 
   ASSERT_TRUE(TestFixture::CreateInterpreter());
-  EXPECT_FALSE(Cpp::GetFunctionAddress("ret_zero"));
+  EXPECT_FALSE(Cpp::GetFunctionAddressFromMangledName("ret_zero"));
 
   // Load the library manually. Use known preload path (MEMFS path)
   const char* wasmLibPath = "libTestSharedLib.so";  // Preloaded path in MEMFS
@@ -89,7 +89,7 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, DynamicLibraryManager_BasicSymbolLookup) {
 
   Cpp::Process("");
 
-  void* Addr = Cpp::GetFunctionAddress("ret_zero");
+  void* Addr = Cpp::GetFunctionAddressFromMangledName("ret_zero");
   EXPECT_NE(Addr, nullptr) << "Symbol 'ret_zero' not found after dlopen.";
 
   using RetZeroFn = int (*)();


### PR DESCRIPTION
# Description

We have stricter compiler/flags in our env, and resolution fails due to two `GetFunctionAddress` definitions. This PR moves the internal function to a different name `GetFunctionAddressFromMangledName` to fix the resolution.

## Type of change

Please tick all options which are relevant.

- [ x ] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

In our env, stricter flag for compiler now resolve the issue, no tests added to `CppInterOp`, just a rename on the surface.

## Checklist

- [ x ] I have read the contribution guide recently
