### PR TITLE
[cmake] explicitly link against stdc++fs if GCC<9

### DIFF
--- a/lib/CppInterOp/CMakeLists.txt
+++ b/lib/CppInterOp/CMakeLists.txt
@@ -54,6 +54,10 @@ if(NOT WIN32 AND NOT EMSCRIPTEN)
   list(APPEND link_libs dl)
 endif()
 
+if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9.0)
+ list(APPEND link_libs stdc++fs)
+endif()
+
 # Get rid of libLLVM-X.so which is appended to the list of static libraries.
 if (LLVM_LINK_LLVM_DYLIB)
   set(new_libs ${link_libs})


### PR DESCRIPTION
Commmit 9d2f4c5d3b11c179c23dbdba15fcc404567e3d08 introduced a dependency on `std::filesystem` which requires explicit linker flags for GCC versions below 9 This fixes a build failure on Alma 8 jobs on ROOT's CI, which still uses GCC8.5