### PR TITLE
Fix deployment job name to enable deployment after https://github.com/compiler-research/CppInterOp/pull/781

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: osx26-arm-clang-repl-21-emscripten_wasm
+          - name: osx26-arm-clang-repl-21-emscripten
             os: macos-26
             clang-runtime: '21'
             cling: Off


### PR DESCRIPTION
https://github.com/compiler-research/CppInterOp/pull/781 broke the deployment, as the deployment job name was not updated so that the new reusable action was used correctly. It wasn't spotted as part of the previous PR, as we don't run the deployment ci as part of PRs.