### PR TITLE
enable dispatch load/reload in single binary, add error message with dlerror

### DIFF
--- a/unittests/CppInterOp/DispatchTest.cpp
+++ b/unittests/CppInterOp/DispatchTest.cpp
@@ -68,4 +68,19 @@ TEST(CPPINTEROP_TEST_MODE, DispatchAPI_CppGetProcAddress_Advanced) {
   EXPECT_NE(demangled_add_double.find(GetQualifiedCompleteNameFn(Decls[1])),
             std::string::npos);
 }
+
+TEST(CPPINTEROP_TEST_MODE, DispatchAPI_LoadUnloadCycle) {
+  Cpp::UnloadDispatchAPI(); // make sure we're no loaded already...
+  EXPECT_FALSE(Cpp::LoadDispatchAPI("some/random/invalid/directory.so"));
+
+  Cpp::UnloadDispatchAPI(); // should reset for next load to be successfull
+  EXPECT_TRUE(Cpp::LoadDispatchAPI(CPPINTEROP_LIB_PATH));
+
+  Cpp::UnloadDispatchAPI(); // should reset for next load to fail
+  EXPECT_FALSE(Cpp::LoadDispatchAPI("some/other/random/invalid/directory.so"));
+
+  // NOTE: minimize side-effects: reload assuming the static set is still
+  // and other test may depend of this being loaded
+  EXPECT_TRUE(Cpp::LoadDispatchAPI(CPPINTEROP_LIB_PATH));
+}
 // NOLINTEND(cppcoreguidelines-pro-type-reinterpret-cast)


### PR DESCRIPTION
# Description

Problem: Load/UnloadDispatchAPI can't but be used multiple time in an application.

Solution: Enable Load/UnloadDispatchAPI by moving data out and allowing controlled reset of static data via UnloadDispatchAPI.

Also: add `dlerror()` when load fails to get diagnostics on reason for failure (e.g., file not found vs symbols not defined)

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [x] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [x] I have read the contribution guide recently
