### PR TITLE
make path resolved absolute in detection test

### DIFF
--- a/unittests/CppInterOp/InterpreterTest.cpp
+++ b/unittests/CppInterOp/InterpreterTest.cpp
@@ -272,7 +272,11 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, Interpreter_DISABLED_DetectResourceDir) {
     GTEST_SKIP() << "Test not run (Clang binary does not exist)";
 
   std::string DetectedPath = Cpp::DetectResourceDir(Clang.str().str().c_str());
-  EXPECT_STREQ(DetectedPath.c_str(), Cpp::GetResourceDir());
+  llvm::SmallString<256> absPath(Cpp::GetResourceDir());
+  EXPECT_TRUE(!llvm::sys::fs::make_absolute(absPath));
+  llvm::SmallString<256> realPath;
+  EXPECT_TRUE(!llvm::sys::fs::real_path(absPath, realPath));
+  EXPECT_STREQ(DetectedPath.c_str(), realPath.str().str().c_str());
 }
 
 TYPED_TEST(CPPINTEROP_TEST_MODE, Interpreter_DetectSystemCompilerIncludePaths) {


### PR DESCRIPTION
# Description

In environments where links and a mix of relative paths are used, finding a fixed point to compare is necessary.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [x] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

previous test is still covering, an external env that was failing test before is now passing.

## Checklist

- [x] I have read the contribution guide recently
