### PR TITLE
Reduce Emscripten shared library size back to 38 Mb for llvm 21

### DIFF
--- a/.github/actions/Build_and_Test_CppInterOp/action.yml
+++ b/.github/actions/Build_and_Test_CppInterOp/action.yml
@@ -208,9 +208,9 @@ runs:
         os="${{ matrix.os }}"
         if [[ "${os}" != macos* ]] ; then
           actual_size=$(stat -c%s "./lib/libclangCppInterOp.so")
-          max_size=$((50 * 1024 * 1024))
+          max_size=$((40 * 1024 * 1024))
           if [[ "$actual_size" -gt "$max_size" ]]; then
-            echo "Error: libclangCppInterOp.so is larger than 50 MB."
+            echo "Error: libclangCppInterOp.so is larger than 40 MB."
             exit 1
           fi
         fi

--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -332,6 +332,7 @@ jobs:
             git apply -v emscripten-clang21-1-shift-temporary-files-to-tmp-dir.patch
             git apply -v emscripten-clang21-2-enable_exception_handling.patch
             git apply -v emscripten-clang21-3-webassembly_target_machine_reordering.patch
+            git apply -v emscripten-clang21-reduce-emscripten-shared-library-size.patch
           }
           cd build
           echo "Apply clang${{ matrix.clang-runtime }}-*.patch patches:"

--- a/Emscripten-build-instructions.md
+++ b/Emscripten-build-instructions.md
@@ -66,6 +66,7 @@ cp -r ..\patches\llvm\emscripten-clang21*
 git apply -v emscripten-clang21-1-shift-temporary-files-to-tmp-dir.patch
 git apply -v emscripten-clang21-2-enable_exception_handling.patch
 git apply -v emscripten-clang21-3-webassembly_target_machine_reordering.patch
+git apply -v emscripten-clang21-reduce-emscripten-shared-library-size.patch
 ```
 
 We are now in a position to build an emscripten build of llvm by executing the following on Linux

--- a/docs/Emscripten-build-instructions.rst
+++ b/docs/Emscripten-build-instructions.rst
@@ -85,6 +85,7 @@ On Windows execute the following
    git apply -v emscripten-clang21-1-shift-temporary-files-to-tmp-dir.patch
    git apply -v emscripten-clang21-2-enable_exception_handling.patch
    git apply -v emscripten-clang21-3-webassembly_target_machine_reordering.patch
+   git apply -v emscripten-clang21-reduce-emscripten-shared-library-size.patch
 
 We are now in a position to build an emscripten build of llvm by executing the following on Linux
 and osx

--- a/patches/llvm/emscripten-clang21-reduce-emscripten-shared-library-size.patch
+++ b/patches/llvm/emscripten-clang21-reduce-emscripten-shared-library-size.patch
@@ -1,0 +1,13 @@
+diff --git a/llvm/include/llvm/Support/Compiler.h b/llvm/include/llvm/Support/Compiler.h
+index 297d3e9b0..bf11024cf 100644
+--- a/llvm/include/llvm/Support/Compiler.h
++++ b/llvm/include/llvm/Support/Compiler.h
+@@ -202,7 +202,7 @@
+ #define LLVM_EXPORT_TEMPLATE
+ #define LLVM_ABI_EXPORT LLVM_ABI
+ #elif defined(__MACH__) || defined(__WASM__) || defined(__EMSCRIPTEN__)
+-#define LLVM_ABI __attribute__((visibility("default")))
++#define LLVM_ABI
+ #define LLVM_TEMPLATE_ABI
+ #define LLVM_EXPORT_TEMPLATE
+ #define LLVM_ABI_EXPORT LLVM_ABI


### PR DESCRIPTION
We know the LLVM_ABI annotation being defined as `__attribute__((visibility("default")))` for Emscripten build was having a negative impact on the size of our Emscripten shared library (by making it so a large number of symbols are not eliminated as dead code). This PR patches llvm so that it is blank, and our Emscripten shared library drops back down to its size we had for llvm 20. When this patch is applied locally all Emscripten tests pass for CppInterOp and xeus-cpp, so the ci should pass.