### PR TITLE
Reduce initial memory in creation of tests to 64Mb

### DIFF
--- a/unittests/CppInterOp/CMakeLists.txt
+++ b/unittests/CppInterOp/CMakeLists.txt
@@ -69,7 +69,7 @@ if(EMSCRIPTEN)
     PUBLIC "SHELL: -s WASM_BIGINT"
     PUBLIC "SHELL: -s ALLOW_MEMORY_GROWTH=1"
     PUBLIC "SHELL: -s STACK_SIZE=32mb"
-    PUBLIC "SHELL: -s INITIAL_MEMORY=128mb"
+    PUBLIC "SHELL: -s INITIAL_MEMORY=64mb"
     PUBLIC "SHELL: --preload-file ${ESCAPED_SYSROOT_PATH}/include@/include"
     PUBLIC "SHELL: --emrun"
   )
@@ -100,7 +100,7 @@ if(EMSCRIPTEN)
     PUBLIC "SHELL: -s WASM_BIGINT"
     PUBLIC "SHELL: -s ALLOW_MEMORY_GROWTH=1"
     PUBLIC "SHELL: -s STACK_SIZE=32mb"
-    PUBLIC "SHELL: -s INITIAL_MEMORY=128mb"
+    PUBLIC "SHELL: -s INITIAL_MEMORY=64mb"
     PUBLIC "SHELL: --preload-file ${ESCAPED_SYSROOT_PATH}/include@/include"
     PUBLIC "SHELL: --emrun"
     PUBLIC "SHELL: --preload-file ${ESCAPED_TEST_SHARED_LIBRARY_PATH}/libTestSharedLib.so@/libTestSharedLib.so"


### PR DESCRIPTION
In the xeus-cpp PR https://github.com/compiler-research/xeus-cpp/pull/444 the initial memory flag was reduced to 64Mb. This PR does the same for CppInterOps tests.