### PR TITLE
Build and test cppyy in ci for multiple build standards

### DIFF
--- a/.github/actions/Build_and_Test_cppyy/action.yml
+++ b/.github/actions/Build_and_Test_cppyy/action.yml
@@ -1,5 +1,8 @@
 name: 'Builds and test cppyy'
 description: 'This action builds and tests cppyy for native platforms'
+inputs:
+  cxx-standard:
+    required: true
 
 runs:
   using: composite
@@ -15,7 +18,7 @@ runs:
         # Install CppInterOp
         (cd $CPPINTEROP_BUILD_DIR && cmake --build . --target install --parallel ${{ env.ncpus }} )
         # Build and Install cppyy-backend
-        cmake -DCppInterOp_DIR=$CPPINTEROP_DIR ..
+        cmake -DCppInterOp_DIR=$CPPINTEROP_DIR -DCMAKE_CXX_STANDARD=${{ inputs.cxx-standard }} ..
         cmake --build . --parallel ${{ env.ncpus }}
         os="${{ matrix.os }}"
         if [[ "${os}" == "macos"* ]]; then
@@ -35,7 +38,7 @@ runs:
         git clone --depth=1 https://github.com/compiler-research/CPyCppyy.git
         mkdir CPyCppyy/build
         cd CPyCppyy/build
-        cmake ..
+        cmake -DCMAKE_CXX_STANDARD=${{ inputs.cxx-standard }} ..
         cmake --build . --parallel ${{ env.ncpus }}
         #
         export CPYCPPYY_DIR=$PWD
@@ -137,4 +140,5 @@ runs:
         echo "XFAIL Summary:"
         tail -n1 test_xfailed.log
         echo "Return Code: ${RETCODE}"
+        rm -rf ../../.venv ../../CPyCppyy ../../cppyy-backend ../../cppyy
         exit $RETCODE

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -301,8 +301,20 @@ jobs:
         verbose: true
         token: ${{ secrets.CODECOV_TOKEN }}
 
-    - name: Build and test cppyy
+    - name: Build and test cppyy (c++17 standard)
       uses: ./.github/actions/Build_and_Test_cppyy        
+      with:
+        cxx-standard: 17
+
+    - name: Build and test cppyy (c++20 standard)
+      uses: ./.github/actions/Build_and_Test_cppyy        
+      with:
+        cxx-standard: 20
+
+    - name: Build and test cppyy (c++23 standard)
+      uses: ./.github/actions/Build_and_Test_cppyy        
+      with:
+        cxx-standard: 23
 
     - name: Show debug info
       if: ${{ failure() }}
@@ -315,6 +327,7 @@ jobs:
       uses: mxschmitt/action-tmate@v3
       # When debugging increase to a suitable value!
       timeout-minutes: 30
+
 
 
 


### PR DESCRIPTION
@vgvassilev I think this is what you was asking for. Assumming the ci passes with this change, cppyy will now be built and tested with multiple c++ standards for every single job. I'll port this over to the other cppyy repos when I finish the reusable actions.