### PR TITLE
No longer qualify CXXMethodDecls in JitCall

### DIFF
--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -2269,9 +2269,6 @@ void make_narg_call(const FunctionDecl* FD, const std::string& return_type,
       callbuf << "((const " << class_name << "*)obj)->";
     else
       callbuf << "((" << class_name << "*)obj)->";
-
-    if (op_flag)
-      callbuf << class_name << "::";
   } else if (isa<NamedDecl>(get_non_transparent_decl_context(FD))) {
     // This is a namespace member.
     if (op_flag || N <= 1)


### PR DESCRIPTION
The earlier patch for overloaded operator introduced class name qualifications on CXXMethodDecls. I observed incorrect codegen:

```cpp
 #pragma clang diagnostic push
#pragma clang diagnostic ignored "-Wformat-security"
__attribute__((used)) __attribute__((annotate("__cling__ptrcheck(off)")))
extern "C" void __jc_13(void* obj, unsigned long nargs, void** args, void* ret)
{
   if (ret) {
      new (ret) (bool) (((TInterpreter*)obj)->TInterpreter::Declare(*(const char**)args[0]));
      return;
   }
   else {
      (void)(((TInterpreter*)obj)->TInterpreter::Declare(*(const char**)args[0]));
      return;
   }
}
#pragma clang diagnostic pop
```

TInterpreter is an abstract interface with virtual functions, so we should not prepend the class name. Brings the codegen closer to what TClingCallFunc does