### PR TITLE
Fix missing xlocale.h errors in Emscripten tests

### DIFF
--- a/unittests/CppInterOp/ScopeReflectionTest.cpp
+++ b/unittests/CppInterOp/ScopeReflectionTest.cpp
@@ -214,7 +214,7 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, ScopeReflection_IsBuiltin) {
   //  "int", "unsigned int", "long", "unsigned long", "long long", "unsigned long long",
   //  "float", "double", "long double", "void"}
 
-  std::vector<const char*> interpreter_args = { "-include", "new" };
+  std::vector<const char*> interpreter_args = { "-include", "new", "-Xclang", "-iwithsysroot/include/compat" };
 
   TestFixture::CreateInterpreter(interpreter_args);
   ASTContext &C = Interp->getCI()->getASTContext();
@@ -1103,7 +1103,7 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, ScopeReflection_IncludeVector) {
     #include <vector>
     #include <iostream>
   )";
-  std::vector<const char*> interpreter_args = {"-include", "new"};
+  std::vector<const char*> interpreter_args = {"-include", "new", "-Xclang", "-iwithsysroot/include/compat"};
   TestFixture::CreateInterpreter(interpreter_args);
   Interp->declare(code);
 }


### PR DESCRIPTION
If you look here https://github.com/compiler-research/CppInterOp/actions/runs/22098680580/job/63862337816#step:16:683 and https://github.com/compiler-research/CppInterOp/actions/runs/22098680580/job/63862337816#step:16:748 from CppInterOps ci run on main, you'll see errors about not being able to find the  xlocale.h header. This PR will fix those errors.

It fixes this error in the same way it was done in the PR which update CppInterOp to be compatible with emsdk 4.0.9 (this PR https://github.com/compiler-research/CppInterOp/pull/753/changes#diff-f2a694225b366b51ca1eac35ce0794a0142da89d18fcd20a7f2e7cd2317be848).