### PR TITLE
Remove no soname from cmake

### DIFF
--- a/lib/CppInterOp/CMakeLists.txt
+++ b/lib/CppInterOp/CMakeLists.txt
@@ -125,9 +125,6 @@ if(EMSCRIPTEN)
   # Replace newlines with spaces
   string(REPLACE "\n" " " SYMBOLS_LIST "${SYMBOLS_LIST}")
 
-  set_target_properties(clangCppInterOp
-    PROPERTIES NO_SONAME 1
-  )
   target_compile_options(clangCppInterOp
     PRIVATE "SHELL: -Oz"
     PRIVATE "SHELL: -flto"

--- a/unittests/CppInterOp/TestSharedLib/CMakeLists.txt
+++ b/unittests/CppInterOp/TestSharedLib/CMakeLists.txt
@@ -11,9 +11,6 @@ set_output_directory(TestSharedLib
 
 
 if (EMSCRIPTEN)
-  set_target_properties(TestSharedLib
-    PROPERTIES NO_SONAME 1
-  )
   target_compile_options(TestSharedLib
     PUBLIC "SHELL: ${CPPINTEROP_EXTRA_WASM_FLAGS}"
   )


### PR DESCRIPTION
```
  set_target_properties(clangCppInterOp
    PROPERTIES NO_SONAME 1
  )
```

was added to be warning free when doing an Emscripten build of CppInterOp for emsdk 3.1.73 . Now that we are using emsdk 4.0.9, this can be removed from CppInterOps cmake, assuming we don't care about introducing a warning for those still building with emsdk 3.1.73 .