### PR TITLE
fix SynthesizingCodeRAII for clang-repl

### DIFF
--- a/lib/CppInterOp/Compatibility.h
+++ b/lib/CppInterOp/Compatibility.h
@@ -429,10 +429,15 @@ private:
 public:
   SynthesizingCodeRAII(Interpreter* i) : m_Interpreter(i) {}
   ~SynthesizingCodeRAII() {
-    auto GeneratedPTU = m_Interpreter->Parse("");
-    if (!GeneratedPTU)
-      llvm::logAllUnhandledErrors(GeneratedPTU.takeError(), llvm::errs(),
-                                  "Failed to generate PTU:");
+    clang::Sema& S = m_Interpreter->getSema();
+    clang::DiagnosticsEngine& Diags = S.getDiagnostics();
+    if (Diags.hasErrorOccurred()) {
+      // do we need a the following?
+      // IncrementalParser::CleanUpPTU(
+      //  S.getASTContext().getTranslationUnitDecl())
+      Diags.Reset(/*soft=*/true);
+      Diags.getClient()->clear();
+    }
   }
 };
 } // namespace compat

--- a/lib/CppInterOp/Compatibility.h
+++ b/lib/CppInterOp/Compatibility.h
@@ -424,21 +424,11 @@ using Interpreter = CppInternal::Interpreter;
 
 class SynthesizingCodeRAII {
 private:
-  Interpreter* m_Interpreter;
+  [[maybe_unused]] Interpreter* m_Interpreter;
 
 public:
   SynthesizingCodeRAII(Interpreter* i) : m_Interpreter(i) {}
-  ~SynthesizingCodeRAII() {
-    clang::Sema& S = m_Interpreter->getSema();
-    clang::DiagnosticsEngine& Diags = S.getDiagnostics();
-    if (Diags.hasErrorOccurred()) {
-      // do we need a the following?
-      // IncrementalParser::CleanUpPTU(
-      //  S.getASTContext().getTranslationUnitDecl())
-      Diags.Reset(/*soft=*/true);
-      Diags.getClient()->clear();
-    }
-  }
+  // ~SynthesizingCodeRAII() {} // TODO: implement
 };
 } // namespace compat
 

--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -308,6 +308,13 @@ static void InstantiateFunctionDefinition(Decl* D) {
     getSema().InstantiateFunctionDefinition(SourceLocation(), FD,
                                             /*Recursive=*/true,
                                             /*DefinitionRequired=*/true);
+    // FIXME: this can go into a RAII object
+    clang::DiagnosticsEngine& Diags = getSema().getDiagnostics();
+    if (!FD->isDefined() && Diags.hasErrorOccurred()) {
+      // instantiation failed, need to reset DiagnosticsEngine
+      Diags.Reset(/*soft=*/true);
+      Diags.getClient()->clear();
+    }
   }
 }
 


### PR DESCRIPTION
# Description

This was a problem with the state of the IntermentalParser in clang.
If the `TranslationUnit` has some problems, then it is not passed to `Execute`, and I believe it is not pushed into `PTUs`.
This is the minimum change that was required to get the tests to pass, in CppInterOp as well as cppyy.
I don't know if we will have problems later when using PCHs and modules.

Maybe we should consider upstreaming this?

## Fixes # (issue)

Regression introduced by #787, that cases `test_leakcheck.py` cppyy test to fail after running for an hour.

Please tick all options which are relevant.

- [x] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [x] I have read the contribution guide recently
