### PR TITLE
[test] Enable cppyy leakcheck tests

### DIFF
--- a/.github/actions/Build_and_Test_cppyy/action.yml
+++ b/.github/actions/Build_and_Test_cppyy/action.yml
@@ -79,6 +79,7 @@ runs:
         python -m pip install pytest
         python -m pip install pytest-xdist
         python -m pip install numba==0.61.2
+        python -m pip install psutil
         echo ::endgroup::
         echo ::group::Run complete test suite
         set -o pipefail


### PR DESCRIPTION
Let's see if the failures go away. Then I can move CppInterOp to use the requirements.txt file, and update the file to enable psutil