### PR TITLE
Run ci for python 3.12 to 3.14

### DIFF
--- a/.github/actions/Build_and_Test_cppyy/action.yml
+++ b/.github/actions/Build_and_Test_cppyy/action.yml
@@ -52,6 +52,7 @@ runs:
         # Install cppyy
         git clone --depth=1 https://github.com/compiler-research/cppyy.git
         cd cppyy
+        python -m pip install uv
         python -m pip install --upgrade . --no-deps
         cd ..
 
@@ -78,7 +79,9 @@ runs:
         python -m pip install --upgrade pip
         python -m pip install pytest
         python -m pip install pytest-xdist
-        python -m pip install numba==0.61.2
+        if [[ "${{ matrix.python-version }}" != "3.14" ]]; then
+          python -m uv pip install numba==0.61.2
+        fi
         echo ::endgroup::
         echo ::group::Run complete test suite
         set -o pipefail

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,6 +31,7 @@ jobs:
             llvm_enable_projects: "clang"
             llvm_targets_to_build: "host;NVPTX"
             Valgrind: On
+            python-version: '3.14'
           - name: ubu24-arm-gcc12-clang-repl-20
             os: ubuntu-24.04-arm
             compiler: gcc-12
@@ -38,6 +39,7 @@ jobs:
             cppyy: On
             llvm_enable_projects: "clang"
             llvm_targets_to_build: "host;NVPTX"
+            python-version: '3.13'
           - name: ubu24-arm-gcc12-clang-repl-19-cppyy
             os: ubuntu-24.04-arm
             compiler: gcc-12
@@ -45,6 +47,7 @@ jobs:
             cppyy: On
             llvm_enable_projects: "clang"
             llvm_targets_to_build: "host;NVPTX"
+            python-version: '3.12'
           - name: ubu24-arm-gcc14-clang20-cling-cppyy
             os: ubuntu-24.04-arm
             compiler: gcc-14
@@ -54,6 +57,7 @@ jobs:
             cling-version: '1.3'
             llvm_enable_projects: "clang"
             llvm_targets_to_build: "host;NVPTX"
+            python-version: '3.14'
           # Ubuntu X86 Jobs
           - name: ubu24-x86-gcc12-clang-repl-21
             os: ubuntu-24.04
@@ -63,6 +67,7 @@ jobs:
             llvm_enable_projects: "clang"
             llvm_targets_to_build: "host;NVPTX"
             Valgrind: On
+            python-version: '3.14'
           - name: ubu24-x86-gcc12-clang-repl-20
             os: ubuntu-24.04
             compiler: gcc-12
@@ -70,6 +75,7 @@ jobs:
             cppyy: On
             llvm_enable_projects: "clang"
             llvm_targets_to_build: "host;NVPTX"
+            python-version: '3.13'
           - name: ubu24-x86-gcc12-clang-repl-20-out-of-process
             os: ubuntu-24.04
             compiler: gcc-12
@@ -79,6 +85,7 @@ jobs:
             oop-jit: On
             coverage: true
             Valgrind: On
+            python-version: '3.13'
           - name: ubu24-x86-gcc12-clang-repl-20-out-of-process-coverage
             os: ubuntu-24.04
             compiler: gcc-12
@@ -87,6 +94,7 @@ jobs:
             llvm_targets_to_build: "host;NVPTX"
             oop-jit: On
             coverage: true
+            python-version: '3.13'
           - name: ubu24-x86-gcc12-clang-repl-19-cppyy
             os: ubuntu-24.04
             compiler: gcc-12
@@ -94,6 +102,7 @@ jobs:
             cppyy: On
             llvm_enable_projects: "clang"
             llvm_targets_to_build: "host;NVPTX"
+            python-version: '3.12'
           - name: ubu24-x86-gcc14-clang20-cling-cppyy
             os: ubuntu-24.04
             compiler: gcc-14
@@ -103,6 +112,7 @@ jobs:
             cling-version: '1.3'
             llvm_enable_projects: "clang"
             llvm_targets_to_build: "host;NVPTX"
+            python-version: '3.14'
           # MacOS Arm Jobs
           - name: osx26-arm-clang-clang-repl-21
             os: macos-26
@@ -111,6 +121,7 @@ jobs:
             cppyy: On
             llvm_enable_projects: "clang"
             llvm_targets_to_build: "host"
+            python-version: '3.14'
           - name: osx26-arm-clang-clang-repl-20-out-of-process
             os: macos-26
             compiler: clang
@@ -118,6 +129,7 @@ jobs:
             llvm_enable_projects: "clang;compiler-rt"
             llvm_targets_to_build: "host"
             oop-jit: On
+            python-version: '3.13'
           - name: osx26-arm-clang-clang-repl-20
             os: macos-26
             compiler: clang
@@ -125,6 +137,7 @@ jobs:
             cppyy: On
             llvm_enable_projects: "clang"
             llvm_targets_to_build: "host"
+            python-version: '3.13'
           - name: osx26-arm-clang-clang-repl-19-cppyy
             os: macos-26
             compiler: clang
@@ -132,6 +145,7 @@ jobs:
             cppyy: On
             llvm_enable_projects: "clang"
             llvm_targets_to_build: "host"
+            python-version: '3.12'
           - name: osx26-arm-clang-clang20-cling-cppyy
             os: macos-26
             compiler: clang
@@ -141,6 +155,7 @@ jobs:
             cling-version: '1.3'
             llvm_enable_projects: "clang"
             llvm_targets_to_build: "host;NVPTX"
+            python-version: '3.14'
           # MacOS X86 Jobs
           - name: osx15-x86-clang-clang-repl-21
             os: macos-15-intel
@@ -149,6 +164,7 @@ jobs:
             cppyy: On
             llvm_enable_projects: "clang"
             llvm_targets_to_build: "host"
+            python-version: '3.14'
           - name: osx15-x86-clang-clang-repl-20
             os: macos-15-intel
             compiler: clang
@@ -156,6 +172,7 @@ jobs:
             cppyy: On
             llvm_enable_projects: "clang"
             llvm_targets_to_build: "host"
+            python-version: '3.13'
           - name: osx15-x86-clang-clang-repl-19-cppyy
             os: macos-15-intel
             compiler: clang
@@ -163,6 +180,7 @@ jobs:
             cppyy: On
             llvm_enable_projects: "clang"
             llvm_targets_to_build: "host"
+            python-version: '3.12'
           - name: osx15-x86-clang-clang20-cling-cppyy
             os: macos-15-intel
             compiler: clang
@@ -172,6 +190,7 @@ jobs:
             cling-version: '1.3'
             llvm_enable_projects: "clang"
             llvm_targets_to_build: "host;NVPTX"
+            python-version: '3.14'
           # Windows Arm Jobs
           - name: win11-msvc-clang-repl-21
             os: windows-11-arm
@@ -179,6 +198,7 @@ jobs:
             clang-runtime: '21'
             llvm_enable_projects: "clang"
             llvm_targets_to_build: "host;NVPTX"
+            python-version: '3.14'
           - name: win11-msvc-clang20-cling
             os: windows-11-arm
             compiler: msvc
@@ -187,6 +207,7 @@ jobs:
             cling-version: '1.3'
             llvm_enable_projects: "clang"
             llvm_targets_to_build: "host;NVPTX"
+            python-version: '3.14'
           # Windows X86 Jobs
           - name: win2025-msvc-clang-repl-21
             os: windows-2025
@@ -194,6 +215,7 @@ jobs:
             clang-runtime: '21'
             llvm_enable_projects: "clang"
             llvm_targets_to_build: "host;NVPTX"
+            python-version: '3.14'
           - name: win2025-msvc-clang20-cling
             os: windows-2025
             compiler: msvc
@@ -202,6 +224,7 @@ jobs:
             cling-version: '1.3'
             llvm_enable_projects: "clang"
             llvm_targets_to_build: "host;NVPTX"
+            python-version: '3.14'
 
     steps:
     - uses: actions/checkout@v6
@@ -211,7 +234,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v6
       with:
-        python-version: '3.11'
+        python-version: ${{ matrix.python-version }}
 
     - name: Save PR Info
       uses: ./.github/actions/Miscellaneous/Save_PR_Info


### PR DESCRIPTION
This ports @Vipul-Cariappa cppyy ci patch https://github.com/compiler-research/cppyy/pull/171/changes to CppInterOp. The llvm cache will need deleting before this PR goes in.