### PR TITLE
Fix read the docs developer documentation

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,8 +9,8 @@ build:
   tools:
     python: "3.11"
   apt_packages:
-    - clang-18
+    - clang-20
     - cmake
-    - libclang-18-dev
-    - llvm-18-dev
-    - llvm-18-tools
+    - libclang-20-dev
+    - llvm-20-dev
+    - llvm-20-tools

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,8 +50,8 @@ CPPINTEROP_ROOT = os.path.abspath('..')
 html_extra_path = [CPPINTEROP_ROOT + '/build/docs/']
 
 import subprocess
-command = 'mkdir {0}/build; cd {0}/build; cmake ../ -DClang_DIR=/usr/lib/llvm-16/build/lib/cmake/clang\
-         -DLLVM_DIR=/usr/lib/llvm-16/build/lib/cmake/llvm -DCPPINTEROP_ENABLE_DOXYGEN=ON\
+command = 'mkdir {0}/build; cd {0}/build; cmake ../ -DClang_DIR=/usr/lib/llvm-20/build/lib/cmake/clang\
+         -DLLVM_DIR=/usr/lib/llvm-20/build/lib/cmake/llvm -DCPPINTEROP_ENABLE_DOXYGEN=ON\
          -DCPPINTEROP_INCLUDE_DOCS=ON'.format(CPPINTEROP_ROOT)
 subprocess.call(command, shell=True)
 subprocess.call('doxygen {0}/build/docs/doxygen.cfg'.format(CPPINTEROP_ROOT), shell=True)


### PR DESCRIPTION
If you visit the developer documentation link in the readme you'll notice it is currently broken. This is because the read the docs config is currently set to use llvm 16 and for some reason llvm 18 was being installed despite trying to build with llvm 16 (given we haven't supported llvm 16 for a while means the read the docs developer documentation has been broken for a long time). This PR should fix everything by updating the docs build to reference an llvm 20 install.