### PR TITLE
Fix llvm, lld and clang max supported versions in cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,14 +71,14 @@ include(GNUInstallDirs)
   ## Define supported version of clang and llvm
 
   set(CLANG_MIN_SUPPORTED 19.0)
-  set(CLANG_MAX_SUPPORTED "22.1.x")
-  set(CLANG_VERSION_UPPER_BOUND 23.0.0)
+  set(CLANG_MAX_SUPPORTED "21.1.x")
+  set(CLANG_VERSION_UPPER_BOUND 22.0.0)
   set(LLD_MIN_SUPPORTED 19.0)
-  set(LLD_MAX_SUPPORTED "22.1.x")
-  set(LLD_VERSION_UPPER_BOUND 23.0.0)
+  set(LLD_MAX_SUPPORTED "21.1.x")
+  set(LLD_VERSION_UPPER_BOUND 22.0.0)
   set(LLVM_MIN_SUPPORTED 19.0)
-  set(LLVM_MAX_SUPPORTED "22.1.x")
-  set(LLVM_VERSION_UPPER_BOUND 23.0.0)
+  set(LLVM_MAX_SUPPORTED "21.1.x")
+  set(LLVM_VERSION_UPPER_BOUND 22.0.0)
 
   ## Set Cmake packages search order
 


### PR DESCRIPTION
The max llvm, lld and clang versions in the cmakelists.txt allow you to try and build with llvm 22, despite CppInterOp not currently supporting it yet. This change accidentally got included in my PR which dropped llvm 18 support. This PR reverts them to the correct values until we actually have llvm 22 support.