### PR TITLE
fix error prone failure path in `GetTypeFromScope`

### DIFF
--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -1981,12 +1981,14 @@ TCppType_t GetTypeFromScope(TCppScope_t klass) {
     return 0;
 
   auto* D = (Decl*)klass;
-  ASTContext& C = getASTContext();
 
-  if (ValueDecl* VD = dyn_cast<ValueDecl>(D))
+  if (auto* VD = dyn_cast<ValueDecl>(D))
     return VD->getType().getAsOpaquePtr();
 
-  return C.getTypeDeclType(cast<TypeDecl>(D)).getAsOpaquePtr();
+  if (auto* TD = dyn_cast<TypeDecl>(D))
+    return getASTContext().getTypeDeclType(TD).getAsOpaquePtr();
+
+  return (TCppType_t) nullptr;
 }
 
 // Internal functions that are not needed outside the library are

--- a/unittests/CppInterOp/TypeReflectionTest.cpp
+++ b/unittests/CppInterOp/TypeReflectionTest.cpp
@@ -380,19 +380,23 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, TypeReflection_GetComplexType) {
 }
 
 TYPED_TEST(CPPINTEROP_TEST_MODE, TypeReflection_GetTypeFromScope) {
-  std::vector<Decl *> Decls;
+  std::vector<Decl*> Decls, SubDecls;
 
-  std::string code =  R"(
+  std::string code = R"(
+  namespace N {
     class C {};
     struct S {};
     int a = 10;
+  }
     )";
 
   GetAllTopLevelDecls(code, Decls);
+  EXPECT_EQ(Cpp::GetTypeAsString(Cpp::GetTypeFromScope(Decls[0])), "NULL TYPE");
 
-  EXPECT_EQ(Cpp::GetTypeAsString(Cpp::GetTypeFromScope(Decls[0])), "C");
-  EXPECT_EQ(Cpp::GetTypeAsString(Cpp::GetTypeFromScope(Decls[1])), "S");
-  EXPECT_EQ(Cpp::GetTypeAsString(Cpp::GetTypeFromScope(Decls[2])), "int");
+  GetAllSubDecls(Decls[0], SubDecls);
+  EXPECT_EQ(Cpp::GetTypeAsString(Cpp::GetTypeFromScope(SubDecls[0])), "N::C");
+  EXPECT_EQ(Cpp::GetTypeAsString(Cpp::GetTypeFromScope(SubDecls[1])), "N::S");
+  EXPECT_EQ(Cpp::GetTypeAsString(Cpp::GetTypeFromScope(SubDecls[2])), "int");
   EXPECT_EQ(Cpp::GetTypeAsString(Cpp::GetTypeFromScope(nullptr)), "NULL TYPE");
 }
 


### PR DESCRIPTION
The earlier path forced a cast to TypeDecl, which will assert if that's not a valid cast, eg. if you have a NamespaceDecl.

```
llvm/include/llvm/Support/Casting.h:578: decltype(auto) llvm::cast(From*) [with To = clang::TypeDecl; From = clang::Decl]: Assertion `isa<To>(Val) && "cast<Ty>() argument of incompatible type!"' failed.
```

Allows for more flexible calls from cppyy, being less crash-prone. The old test has been extended.
