### PR TITLE
Add containerization

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,32 @@
+FROM ubuntu:24.04
+
+SHELL ["/bin/bash", "-c"]
+
+RUN apt update && \
+    apt install -y \
+        git \
+        cmake \
+        build-essential \
+        python3 \
+        python3-dev \
+        python3-pip \
+        python3-virtualenv && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /compiler-research
+
+RUN mkdir -p env-setup
+
+COPY clone.sh env-setup/clone.sh
+COPY setup.sh env-setup/setup.sh
+COPY env.sh env-setup/env.sh
+
+RUN chmod +x env-setup/*.sh
+
+RUN ./env-setup/clone.sh
+RUN ./env-setup/setup.sh
+RUN ./env-setup/env.sh
+
+RUN echo 'source /compiler-research/env-setup/env.sh' >> /etc/bash.bashrc
+
+CMD ["bash"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,25 @@
+# Environment Setup using Docker
+Fast automated setup procedure for [CppInterOp](https://github.com/compiler-research/CppInterOp).
+
+## Setup
+
+### Build Dockerfile
+```bash
+docker build -t CppInterOp:v1 . # Build Docker image
+```
+
+## Run & test
+Run the container,
+```bash
+docker run -it CppInterOp:v1 bash
+```
+To test,
+```bash
+cd compiler-research
+source env-setup/env.sh
+cd CppInterOp/build
+# Run tests
+cmake --build . --target check-cppinterop --parallel $(nproc --all)
+```
+You should see this after running the tests - 
+![image](docs/image.png)

--- a/docker/clone.sh
+++ b/docker/clone.sh
@@ -1,0 +1,4 @@
+git clone --depth=1 https://github.com/compiler-research/CppInterOp.git
+git clone --depth=1 https://github.com/compiler-research/cppyy-backend.git
+git clone --depth=1 --branch release/21.x https://github.com/llvm/llvm-project.git
+git clone --depth=1 https://github.com/compiler-research/CPyCppyy.git

--- a/docker/env.sh
+++ b/docker/env.sh
@@ -1,0 +1,7 @@
+export PARENT_DIR="/compiler-research"
+export LLVM_DIR="$PARENT_DIR/llvm-project"
+export CB_PYTHON_DIR="$PARENT_DIR/cppyy-backend/python"
+export CPPINTEROP_DIR="$CB_PYTHON_DIR/cppyy_backend"
+export CPLUS_INCLUDE_PATH="${CPLUS_INCLUDE_PATH}:${LLVM_DIR}/llvm/include:${LLVM_DIR}/clang/include:${LLVM_DIR}/build/include:${LLVM_DIR}/build/tools/clang/include"
+export CPYCPPYY_DIR="$PARENT_DIR/CPyCppyy"
+export PYTHONPATH=$PYTHONPATH:$CPYCPPYY_DIR:$CB_PYTHON_DIR

--- a/docker/setup.sh
+++ b/docker/setup.sh
@@ -1,0 +1,60 @@
+# Build LLVM
+cd llvm-project
+mkdir build 
+cd build 
+cmake -DLLVM_ENABLE_PROJECTS=clang                                  \
+                -DLLVM_TARGETS_TO_BUILD="host;NVPTX"                \
+                -DCMAKE_BUILD_TYPE=Release                          \
+                -DLLVM_ENABLE_ASSERTIONS=ON                         \
+                -DCLANG_ENABLE_STATIC_ANALYZER=OFF                  \
+                -DCLANG_ENABLE_ARCMT=OFF                            \
+                -DCLANG_ENABLE_FORMAT=OFF                           \
+                -DCLANG_ENABLE_BOOTSTRAP=OFF                        \
+                ../llvm
+cmake --build . --target clang clang-repl --parallel $(nproc --all)
+cmake --build . --target clang clang-repl llvm-jitlink-executor orc_rt-x86_64 --parallel $(nproc --all)
+
+cd ..
+export LLVM_DIR=$PWD
+
+cd ..
+
+export CB_PYTHON_DIR="$PWD/cppyy-backend/python"
+export CPPINTEROP_DIR="$CB_PYTHON_DIR/cppyy_backend"
+export CPLUS_INCLUDE_PATH="${CPLUS_INCLUDE_PATH}:${LLVM_DIR}/llvm/include:${LLVM_DIR}/clang/include:${LLVM_DIR}/build/include:${LLVM_DIR}/build/tools/clang/include"
+
+# Build CppInterOp
+mkdir CppInterOp/build/
+cd CppInterOp/build/
+cmake -DBUILD_SHARED_LIBS=ON -DLLVM_DIR=$LLVM_DIR/build/lib/cmake/llvm -DClang_DIR=$LLVM_DIR/build/lib/cmake/clang -DCMAKE_INSTALL_PREFIX=$CPPINTEROP_DIR -DCMAKE_BUILD_TYPE=Release ..
+cmake --build . --target install --parallel $(nproc --all)
+
+cd ../..
+
+# Build cppyy-backend
+cd cppyy-backend
+mkdir -p python/cppyy_backend/lib build 
+cd build
+cmake -DCppInterOp_DIR=$CPPINTEROP_DIR ..
+cmake --build .
+cp libcppyy-backend.so ../python/cppyy_backend/lib/
+
+# Build CPyCppyy
+virtualenv .venv
+source .venv/bin/activate
+git clone --depth=1 https://github.com/compiler-research/CPyCppyy.git
+mkdir CPyCppyy/build
+cd CPyCppyy/build
+cmake ..
+cmake --build .
+export CPYCPPYY_DIR=$PWD
+
+cd ../..
+
+# Install Cppyy
+export PYTHONPATH=$PYTHONPATH:$CPYCPPYY_DIR:$CB_PYTHON_DIR
+git clone --depth=1 https://github.com/compiler-research/cppyy.git
+cd cppyy
+pip install setuptools
+python3 -m pip install --upgrade . --no-deps --no-build-isolation
+cd ..


### PR DESCRIPTION
# Description

I created a Dockerfile setup procedure to allow users to quickly build and use CppInterOp regardless of their environment. The instructions on how to build and use the Dockerfile are in ``docker/README.md``. This PR aims to resolve issue #746 . More changes may be required to create Dockerfiles with different build options.

Includes
Fixes #746 

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [X] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

I ran CppInterOp build tests, which worked - 
```bash
cmake --build . --target check-cppinterop --parallel $(nproc --all)
```


## Checklist

- [X] I have read the contribution guide recently
