### PR TITLE
fix build instructions in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ Now CppInterOp can be built. This can be done by executing
 ```bash
 mkdir CppInterOp/build/
 cd CppInterOp/build/
-cmake -DBUILD_SHARED_LIBS=ON -DLLVM_DIR=$LLVM_DIR/build/lib/cmake/llvm -DClang_DIR=$LLVM_DIR/build/lib/cmake/clang -DCMAKE_INSTALL_PREFIX=$CPPINTEROP_DIR ..
+cmake -DBUILD_SHARED_LIBS=ON -DLLVM_DIR=$LLVM_DIR/build/lib/cmake/llvm -DClang_DIR=$LLVM_DIR/build/lib/cmake/clang -DCMAKE_INSTALL_PREFIX=$CPPINTEROP_DIR -DCMAKE_BUILD_TYPE=Release ..
 cmake --build . --target install --parallel $(nproc --all)
 ```
 
@@ -311,7 +311,7 @@ Now CppInterOp can be built. This can be done by executing
 ```bash
 mkdir CppInterOp/build/
 cd CppInterOp/build/
-cmake -DBUILD_SHARED_LIBS=ON -DCPPINTEROP_USE_CLING=ON -DCPPINTEROP_USE_REPL=Off -DCling_DIR=$LLVM_DIR/build/tools/cling -DLLVM_DIR=$LLVM_DIR/build/lib/cmake/llvm -DClang_DIR=$LLVM_DIR/build/lib/cmake/clang -DCMAKE_INSTALL_PREFIX=$CPPINTEROP_DIR ..
+cmake -DBUILD_SHARED_LIBS=ON -DCPPINTEROP_USE_CLING=ON -DCPPINTEROP_USE_REPL=Off -DCling_DIR=$LLVM_DIR/build/tools/cling -DLLVM_DIR=$LLVM_DIR/build/lib/cmake/llvm -DClang_DIR=$LLVM_DIR/build/lib/cmake/clang -DCMAKE_INSTALL_PREFIX=$CPPINTEROP_DIR -DCMAKE_BUILD_TYPE=Release ..
 cmake --build . --target install --parallel $(nproc --all)
 ```
 


### PR DESCRIPTION
# Description

Problem: Building CppInterOp using original README instructions results in an error.
```bash
# Build CppInterOp
cmake -DBUILD_SHARED_LIBS=ON -DLLVM_DIR=$LLVM_DIR/build/lib/cmake/llvm -DClang_DIR=$LLVM_DIR/build/lib/cmake/clang -DCMAKE_INSTALL_PREFIX=$CPPINTEROP_DIR ..
cmake --build . --target install --parallel $(nproc --all)
```
```
[ 76%] Performing configure step for 'googletest'
-- googletest configure command succeeded.  See also /dvolume/CppInterOp/build/unittests/googletest-prefix/src/googletest-stamp/googletest-configure-*.log
[ 82%] Performing build step for 'googletest'
CMake Error at /dvolume/CppInterOp/build/unittests/googletest-prefix/src/googletest-stamp/googletest-build-.cmake:49 (message):
  Command failed: 1

   '/usr/bin/cmake' '--build' '/dvolume/CppInterOp/build/unittests/googletest-prefix/src/googletest-build/' '--config' ''

  See also

    /dvolume/CppInterOp/build/unittests/googletest-prefix/src/googletest-stamp/googletest-build-*.log
gmake[2]: *** [unittests/CMakeFiles/googletest.dir/build.make:86: unittests/googletest-prefix/src/googletest-stamp/googletest-build] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:410: unittests/CMakeFiles/googletest.dir/all] Error 2
gmake[1]: *** Waiting for unfinished jobs....
[ 88%] Linking CXX shared library ../libclangCppInterOp.so
[ 88%] Built target clangCppInterOp
gmake: *** [Makefile:136: all] Error 2
```
Upon viewing logs, we observe - 
```
> cat  /dvolume/CppInterOp/build/unittests/googletest-prefix/src/googletest-stamp/googletest-build-*.log
CMake Error: Invalid value used with --config
Usage: cmake --build <dir>             [options] [-- [native-options]]
       cmake --build --preset <preset> [options] [-- [native-options]]
```
Cause: Since the build type is not set, it results in an invalid argument being given downstream.
Solution: Add `-DCMAKE_BUILD_TYPE=Release` flag to README in the command to build CppInterOp.

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [ ] New feature
- [X] Requires documentation updates

## Testing

The build procedure works when you specify the flag.

## Checklist

- [X] I have read the contribution guide recently
