### PR TITLE
Change branch for JIT execution instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,19 +103,16 @@ git clone --depth=1 https://github.com/compiler-research/cppyy-backend.git
 ```
 
 #### Setup Clang-REPL
-
-Clone the 21.x release of the LLVM project repository.
-
+Clone the LLVM project repository. If you need out-of-process JIT execution enabled (Linux x86_64 and macOS arm64 only), you must use LLVM 20 with a patch applied
+```bash
+git clone --depth=1 --branch release/20.x https://github.com/llvm/llvm-project.git
+cd llvm-project
+git apply -v ../CppInterOp/patches/llvm/clang20-1-out-of-process.patch
+```
+Otherwise clone the latest LLVM supported by CppInterOp
 ```bash
 git clone --depth=1 --branch release/21.x https://github.com/llvm/llvm-project.git
 cd llvm-project
-```
-
-If you want to have out-of-process JIT execution enabled in CppInterOp, then apply this patch on Linux-x86_64 and MacOS arm64 environment.
-> Note that this patch will not work for Windows because out-of-process JIT execution is currently implemented for Linux-x86_64 and MacOS arm64 only.
-
-```bash
-git apply -v ../CppInterOp/patches/llvm/clang20-1-out-of-process.patch
 ```
 
 ##### Build Clang-REPL

--- a/docs/DevelopersDocumentation.rst
+++ b/docs/DevelopersDocumentation.rst
@@ -34,21 +34,21 @@ library
  Setup Clang-REPL
 ******************
 
-Clone the 21.x release of the LLVM project repository.
+Clone the LLVM project repository. If you need out-of-process JIT execution enabled (Linux x86_64 and macOS arm64 only), you must use LLVM 20 with a patch applied
+
+.. code:: bash
+
+   git clone --depth=1 --branch release/20.x https://github.com/llvm/llvm-project.git
+   cd llvm-project
+   git apply -v ../CppInterOp/patches/llvm/clang20-1-out-of-process.patch
+
+Otherwise clone the latest LLVM supported by CppInterOp
 
 .. code:: bash
 
    git clone --depth=1 --branch release/21.x https://github.com/llvm/llvm-project.git
    cd llvm-project
 
-If you want to have out-of-process JIT execution enabled in CppInterOp, then apply this patch on Linux-x86_64 and MacOS arm64 environment.
-.. note::
-
-   This patch will not work for Windows because out-of-process JIT execution is currently implemented for Linux and MacOS only.
-
-.. code:: bash
-
-   git apply -v ../CppInterOp/patches/llvm/clang20-1-out-of-process.patch
 
 ******************
  Build Clang-REPL

--- a/docs/InstallationAndUsage.rst
+++ b/docs/InstallationAndUsage.rst
@@ -34,22 +34,21 @@ library
  Setup Clang-REPL
 ******************
 
-Clone the 21.x release of the LLVM project repository.
+Clone the LLVM project repository. If you need out-of-process JIT execution enabled (Linux x86_64 and macOS arm64 only), you must use LLVM 20 with a patch applied
+
+.. code:: bash
+
+   git clone --depth=1 --branch release/20.x https://github.com/llvm/llvm-project.git
+   cd llvm-project
+   git apply -v ../CppInterOp/patches/llvm/clang20-1-out-of-process.patch
+
+Otherwise clone the latest LLVM supported by CppInterOp
 
 .. code:: bash
 
    git clone --depth=1 --branch release/21.x https://github.com/llvm/llvm-project.git
    cd llvm-project
-
-If you want to have out-of-process JIT execution enabled in CppInterOp, then apply this patch on Linux-x86_64 and MacOS arm64 environment.
-.. note::
-
-   This patch will not work for Windows because out-of-process JIT execution is currently implemented for Linux and MacOS only.
-
-.. code:: bash
-
-   git apply -v ../CppInterOp/patches/llvm/clang20-1-out-of-process.patch
-
+ 
 ******************
  Build Clang-REPL
 ******************


### PR DESCRIPTION
# Description
Updated instructions for enabling out-of-process JIT execution in CppInterOp.
Fixes #833 

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [ ] New feature
- [X] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [X] I have read the contribution guide recently
