### PR TITLE
Remove compat::getExecutionEngine wrapper

### DIFF
--- a/lib/CppInterOp/Compatibility.h
+++ b/lib/CppInterOp/Compatibility.h
@@ -95,21 +95,12 @@ inline void maybeMangleDeclName(const clang::GlobalDecl& GD,
   cling::utils::Analyze::maybeMangleDeclName(GD, mangledName);
 }
 
-/// The getExecutionEngine() interface was been added for Cling based on LLVM
-/// >=18. For previous versions, the LLJIT was obtained by computing the object
-/// offsets in the cling::Interpreter instance(IncrementalExecutor):
-/// sizeof (m_Opts) + sizeof(m_LLVMContext). The IncrementalJIT and JIT itself
-/// have an offset of 0 as the first datamember.
-inline llvm::orc::LLJIT* getExecutionEngine(cling::Interpreter& I) {
-  return I.getExecutionEngine();
-}
-
 inline llvm::Expected<llvm::JITTargetAddress>
 getSymbolAddress(cling::Interpreter& I, llvm::StringRef IRName) {
   if (void* Addr = I.getAddressOfGlobal(IRName))
     return (llvm::JITTargetAddress)Addr;
 
-  llvm::orc::LLJIT& Jit = *compat::getExecutionEngine(I);
+  llvm::orc::LLJIT& Jit = *I.getExecutionEngine();
   llvm::orc::SymbolNameVector Names;
   llvm::orc::ExecutionSession& ES = Jit.getExecutionSession();
   Names.push_back(ES.intern(IRName));
@@ -347,11 +338,6 @@ inline void maybeMangleDeclName(const clang::GlobalDecl& GD,
 
 // Clang 18 - Add new Interpreter methods: CodeComplete
 
-inline llvm::orc::LLJIT* getExecutionEngine(clang::Interpreter& I) {
-  auto* engine = &llvm::cantFail(I.getExecutionEngine());
-  return const_cast<llvm::orc::LLJIT*>(engine);
-}
-
 inline llvm::Expected<llvm::JITTargetAddress>
 getSymbolAddress(clang::Interpreter& I, llvm::StringRef IRName) {
 
@@ -371,7 +357,8 @@ getSymbolAddress(clang::Interpreter& I, clang::GlobalDecl GD) {
 inline llvm::Expected<llvm::JITTargetAddress>
 getSymbolAddressFromLinkerName(clang::Interpreter& I,
                                llvm::StringRef LinkerName) {
-  const auto& DL = getExecutionEngine(I)->getDataLayout();
+  auto& Jit = llvm::cantFail(I.getExecutionEngine());
+  const auto& DL = Jit.getDataLayout();
   char GlobalPrefix = DL.getGlobalPrefix();
   std::string LinkerNameTmp(LinkerName);
   if (GlobalPrefix != '\0') {

--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -3258,7 +3258,8 @@ bool DefineAbsoluteSymbol(compat::Interpreter& I,
   using namespace llvm;
   using namespace llvm::orc;
 
-  llvm::orc::LLJIT& Jit = *compat::getExecutionEngine(I);
+  llvm::orc::LLJIT& Jit =
+      llvm::cantFail(static_cast<clang::Interpreter&>(I).getExecutionEngine());
   llvm::orc::ExecutionSession& ES = Jit.getExecutionSession();
   JITDylib& DyLib = *Jit.getProcessSymbolsJITDylib().get();
 
@@ -3678,7 +3679,8 @@ bool InsertOrReplaceJitSymbol(compat::Interpreter& I,
   using namespace llvm::orc;
 
   auto Symbol = compat::getSymbolAddress(I, linker_mangled_name);
-  llvm::orc::LLJIT& Jit = *compat::getExecutionEngine(I);
+  llvm::orc::LLJIT& Jit =
+      llvm::cantFail(static_cast<clang::Interpreter&>(I).getExecutionEngine());
   llvm::orc::ExecutionSession& ES = Jit.getExecutionSession();
   JITDylib& DyLib = *Jit.getProcessSymbolsJITDylib().get();
 
@@ -3700,7 +3702,7 @@ bool InsertOrReplaceJitSymbol(compat::Interpreter& I,
 
   // Let's inject it.
   llvm::orc::SymbolMap InjectedSymbols;
-  auto& DL = compat::getExecutionEngine(I)->getDataLayout();
+  auto& DL = Jit.getDataLayout();
   char GlobalPrefix = DL.getGlobalPrefix();
   std::string tmp(linker_mangled_name);
   if (GlobalPrefix != '\0') {

--- a/lib/CppInterOp/CppInterOpInterpreter.h
+++ b/lib/CppInterOp/CppInterOpInterpreter.h
@@ -293,9 +293,6 @@ public:
     return inner->getCompilerInstance();
   }
 
-  llvm::orc::LLJIT* getExecutionEngine() const {
-    return compat::getExecutionEngine(*inner);
-  }
 
   llvm::Expected<clang::PartialTranslationUnit&> Parse(llvm::StringRef Code) {
     return inner->Parse(Code);
@@ -464,7 +461,7 @@ public:
   clang::Sema& getSema() const { return getCI()->getSema(); }
 
   const DynamicLibraryManager* getDynamicLibraryManager() const {
-    assert(compat::getExecutionEngine(*inner) && "We must have an executor");
+    assert(inner && "We must have an interpreter");
     static std::unique_ptr<DynamicLibraryManager> DLM = nullptr;
     if (!DLM) {
       DLM.reset(new DynamicLibraryManager());


### PR DESCRIPTION
# Description

Remove the `compat::getExecutionEngine()` wrapper functions that exposed `clang::Interpreter::getExecutionEngine()` and `cling::Interpreter::getExecutionEngine()` as `LLJIT*` pointers.

This wrapper causes compatibility issues when upgrading CppInterOp to be compatible with LLVM 22, where `getExecutionEngine()` returns `IncrementalExecutor&` instead of `LLJIT&`.

**Changes:**
- Remove `compat::getExecutionEngine()` for both Cling and Clang-REPL paths in [Compatibility.h](cci:7://file:///home/aniketgiri/cern/CppInterOp/lib/CppInterOp/Compatibility.h:0:0-0:0)
- Remove `CppInternal::Interpreter::getExecutionEngine()` wrapper in [CppInterOpInterpreter.h](cci:7://file:///home/aniketgiri/cern/CppInterOp/lib/CppInterOp/CppInterOpInterpreter.h:0:0-0:0)
- Callers that need LLJIT access ([DefineAbsoluteSymbol](cci:1://file:///home/aniketgiri/cern/CppInterOp/lib/CppInterOp/CppInterOp.cpp:3254:0-3274:1), [InsertOrReplaceJitSymbol](cci:1://file:///home/aniketgiri/cern/CppInterOp/lib/CppInterOp/CppInterOp.cpp:3731:0-3734:1)) now call `clang::Interpreter::getExecutionEngine()` directly
- [getSymbolAddressFromLinkerName](cci:1://file:///home/aniketgiri/cern/CppInterOp/lib/CppInterOp/Compatibility.h:356:0-370:1) now accesses `DataLayout` via the LLJIT reference directly
- Relaxed assert in [getDynamicLibraryManager()](cci:1://file:///home/aniketgiri/cern/CppInterOp/lib/CppInterOp/CppInterOpInterpreter.h:474:2-477:3) to check interpreter validity instead of execution engine availability

Fixes #774

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

- Built CppInterOp against LLVM 21.x (release/21.x) — **zero warnings**
- Ran `check-cppinterop` — **100% tests passed, 0 tests failed out of 3**
- Verified no remaining references to `compat::getExecutionEngine` via `grep`

## Checklist

- [x] I have read the contribution guide recently
