### PR TITLE
Re: Adding API functions for detecting interpreter language and standard

### DIFF
--- a/include/CppInterOp/CppInterOp.h
+++ b/include/CppInterOp/CppInterOp.h
@@ -102,6 +102,69 @@ enum QualKind : unsigned char {
   Restrict = 1 << 2
 };
 
+/// Enum modelling programming languages.
+enum class InterpreterLanguage : unsigned char {
+  Unknown,
+  Asm,
+  CIR,
+  LLVM_IR,
+  C,
+  CPlusPlus,
+  ObjC,
+  ObjCPlusPlus,
+  OpenCL,
+  OpenCLCXX,
+  CUDA,
+  HIP,
+  HLSL
+};
+
+/// Enum modelling language standards.
+enum class InterpreterLanguageStandard : unsigned char {
+  c89,
+  c94,
+  gnu89,
+  c99,
+  gnu99,
+  c11,
+  gnu11,
+  c17,
+  gnu17,
+  c23,
+  gnu23,
+  c2y,
+  gnu2y,
+  cxx98,
+  gnucxx98,
+  cxx11,
+  gnucxx11,
+  cxx14,
+  gnucxx14,
+  cxx17,
+  gnucxx17,
+  cxx20,
+  gnucxx20,
+  cxx23,
+  gnucxx23,
+  cxx26,
+  gnucxx26,
+  opencl10,
+  opencl11,
+  opencl12,
+  opencl20,
+  opencl30,
+  openclcpp10,
+  openclcpp2021,
+  hlsl,
+  hlsl2015,
+  hlsl2016,
+  hlsl2017,
+  hlsl2018,
+  hlsl2021,
+  hlsl202x,
+  hlsl202y,
+  lang_unspecified
+};
 inline QualKind operator|(QualKind a, QualKind b) {
   return static_cast<QualKind>(static_cast<unsigned char>(a) |
                                static_cast<unsigned char>(b));
@@ -727,6 +790,13 @@ CPPINTEROP_API bool ActivateInterpreter(TInterp_t I);
 /// matter, since the library will function in the same way.
 ///\returns the current interpreter instance, if any.
 CPPINTEROP_API TInterp_t GetInterpreter();
+
+/// Returns the programming language of the interpreter.
+CPPINTEROP_API InterpreterLanguage GetLanguage(TInterp_t I = nullptr);
+
+/// Returns the language standard of the interpreter.
+CPPINTEROP_API InterpreterLanguageStandard
+GetLanguageStandard(TInterp_t I = nullptr);
 
 /// Sets the Interpreter instance with an external interpreter, meant to
 /// be called by an external library that manages it's own interpreter.

--- a/include/CppInterOp/Dispatch.h
+++ b/include/CppInterOp/Dispatch.h
@@ -63,6 +63,8 @@ extern "C" CPPINTEROP_API CppFnPtrTy CppGetProcAddress(const char* procname);
   DISPATCH_API(IsEnumType, decltype(&CppImpl::IsEnumType))                     \
   DISPATCH_API(GetIntegerTypeFromEnumType,                                     \
                decltype(&CppImpl::GetIntegerTypeFromEnumType))                 \
+  DISPATCH_API(GetLanguage, decltype(&CppImpl::GetLanguage))                   \
+  DISPATCH_API(GetLanguageStandard, decltype(&CppImpl::GetLanguageStandard))   \
   DISPATCH_API(GetReferencedType, decltype(&CppImpl::GetReferencedType))       \
   DISPATCH_API(IsPointerType, decltype(&CppImpl::IsPointerType))               \
   DISPATCH_API(GetPointeeType, decltype(&CppImpl::GetPointeeType))             \

--- a/include/clang-c/CXCppInterOp.h
+++ b/include/clang-c/CXCppInterOp.h
@@ -88,6 +88,74 @@ typedef enum {
 } CXInterpreter_CompilationResult;
 
 /**
+ * Enum to represent the programming language of the interpreter.
+ */
+typedef enum {
+  CXInterpreterLanguage_Unknown,
+  CXInterpreterLanguage_Asm,
+  CXInterpreterLanguage_CIR,
+  CXInterpreterLanguage_LLVM_IR,
+  CXInterpreterLanguage_C,
+  CXInterpreterLanguage_CPlusPlus,
+  CXInterpreterLanguage_ObjC,
+  CXInterpreterLanguage_ObjCPlusPlus,
+  CXInterpreterLanguage_OpenCL,
+  CXInterpreterLanguage_OpenCLCXX,
+  CXInterpreterLanguage_CUDA,
+  CXInterpreterLanguage_HIP,
+  CXInterpreterLanguage_HLSL
+} CXInterpreterLanguage;
+
+/**
+ * Enum to represent the language standard of the interpreter.
+ */
+typedef enum {
+  CXInterpreterLanguageStandard_c89,
+  CXInterpreterLanguageStandard_c94,
+  CXInterpreterLanguageStandard_gnu89,
+  CXInterpreterLanguageStandard_c99,
+  CXInterpreterLanguageStandard_gnu99,
+  CXInterpreterLanguageStandard_c11,
+  CXInterpreterLanguageStandard_gnu11,
+  CXInterpreterLanguageStandard_c17,
+  CXInterpreterLanguageStandard_gnu17,
+  CXInterpreterLanguageStandard_c23,
+  CXInterpreterLanguageStandard_gnu23,
+  CXInterpreterLanguageStandard_c2y,
+  CXInterpreterLanguageStandard_gnu2y,
+  CXInterpreterLanguageStandard_cxx98,
+  CXInterpreterLanguageStandard_gnucxx98,
+  CXInterpreterLanguageStandard_cxx11,
+  CXInterpreterLanguageStandard_gnucxx11,
+  CXInterpreterLanguageStandard_cxx14,
+  CXInterpreterLanguageStandard_gnucxx14,
+  CXInterpreterLanguageStandard_cxx17,
+  CXInterpreterLanguageStandard_gnucxx17,
+  CXInterpreterLanguageStandard_cxx20,
+  CXInterpreterLanguageStandard_gnucxx20,
+  CXInterpreterLanguageStandard_cxx23,
+  CXInterpreterLanguageStandard_gnucxx23,
+  CXInterpreterLanguageStandard_cxx26,
+  CXInterpreterLanguageStandard_gnucxx26,
+  CXInterpreterLanguageStandard_opencl10,
+  CXInterpreterLanguageStandard_opencl11,
+  CXInterpreterLanguageStandard_opencl12,
+  CXInterpreterLanguageStandard_opencl20,
+  CXInterpreterLanguageStandard_opencl30,
+  CXInterpreterLanguageStandard_openclcpp10,
+  CXInterpreterLanguageStandard_openclcpp2021,
+  CXInterpreterLanguageStandard_hlsl,
+  CXInterpreterLanguageStandard_hlsl2015,
+  CXInterpreterLanguageStandard_hlsl2016,
+  CXInterpreterLanguageStandard_hlsl2017,
+  CXInterpreterLanguageStandard_hlsl2018,
+  CXInterpreterLanguageStandard_hlsl2021,
+  CXInterpreterLanguageStandard_hlsl202x,
+  CXInterpreterLanguageStandard_hlsl202y,
+  CXInterpreterLanguageStandard_lang_unspecified
+} CXInterpreterLanguageStandard;
+
+/**
  * Add a search path to the interpreter.
  *
  * \param I The interpreter.
@@ -209,6 +277,26 @@ CINDEX_LINKAGE CXInterpreter_CompilationResult clang_Interpreter_loadLibrary(
  */
 CINDEX_LINKAGE void clang_Interpreter_unloadLibrary(CXInterpreter I,
                                                     const char* lib_stem);
+
+/**
+ * Returns the programming language of the interpreter.
+ *
+ * \param I The interpreter.
+ *
+ * \returns CXInterpreterLanguage value.
+ */
+CINDEX_LINKAGE CXInterpreterLanguage
+clang_Interpreter_getLanguage(CXInterpreter I);
+
+/**
+ * Returns the language standard of the interpreter.
+ *
+ * \param I The interpreter.
+ *
+ * \returns CXInterpreterLanguageStandard value.
+ */
+CINDEX_LINKAGE CXInterpreterLanguageStandard
+clang_Interpreter_getLanguageStandard(CXInterpreter I);
 
 /**
  * @}

--- a/lib/CppInterOp/CXCppInterOp.cpp
+++ b/lib/CppInterOp/CXCppInterOp.cpp
@@ -397,6 +397,17 @@ void clang_Interpreter_unloadLibrary(CXInterpreter I, const char* lib_stem) {
   interp->getDynamicLibraryManager()->unloadLibrary(lib_stem);
 }
 
+CXInterpreterLanguage clang_Interpreter_getLanguage(CXInterpreter I) {
+  return static_cast<CXInterpreterLanguage>(
+      Cpp::GetLanguage(getInterpreter(I)));
+}
+
+CXInterpreterLanguageStandard
+clang_Interpreter_getLanguageStandard(CXInterpreter I) {
+  return static_cast<CXInterpreterLanguageStandard>(
+      Cpp::GetLanguageStandard(getInterpreter(I)));
+}
+
 CXString clang_Interpreter_searchLibrariesForSymbol(CXInterpreter I,
                                                     const char* mangled_name,
                                                     bool search_system) {

--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -30,6 +30,7 @@
 #include "clang/AST/Stmt.h"
 #include "clang/AST/Type.h"
 #include "clang/Basic/DiagnosticSema.h"
+#include "clang/Basic/LangStandard.h"
 #include "clang/Basic/Linkage.h"
 #include "clang/Basic/OperatorKinds.h"
 #include "clang/Basic/SourceLocation.h"
@@ -164,11 +165,14 @@ struct InterpreterInfo {
 // std::deque avoids relocations and calling the dtor of InterpreterInfo.
 static llvm::ManagedStatic<std::deque<InterpreterInfo>> sInterpreters;
 
-static compat::Interpreter& getInterp() {
+static compat::Interpreter& getInterp(TInterp_t I = nullptr) {
+  if (I)
+    return *static_cast<compat::Interpreter*>(I);
   assert(!sInterpreters->empty() &&
          "Interpreter instance must be set before calling this!");
   return *sInterpreters->back().Interpreter;
 }
+
 static clang::Sema& getSema() { return getInterp().getCI()->getSema(); }
 static clang::ASTContext& getASTContext() { return getSema().getASTContext(); }
 
@@ -3414,7 +3418,8 @@ TInterp_t CreateInterpreter(const std::vector<const char*>& Args /*={}*/,
   if (!T.isWasm())
     AddLibrarySearchPaths(ResourceDir, I);
 
-  I->declare(R"(
+  if (GetLanguage(I) != InterpreterLanguage::C) {
+    I->declare(R"(
     namespace __internal_CppInterOp {
     template <typename Signature>
     struct function;
@@ -3424,6 +3429,7 @@ TInterp_t CreateInterpreter(const std::vector<const char*>& Args /*={}*/,
     };
     }  // namespace __internal_CppInterOp
   )");
+  }
 
   sInterpreters->emplace_back(I, /*Owned=*/true);
 
@@ -3440,7 +3446,7 @@ TInterp_t CreateInterpreter(const std::vector<const char*>& Args /*={}*/,
   // obtain mangled name
   auto* D = static_cast<clang::Decl*>(
       Cpp::GetNamed("__clang_Interpreter_SetValueWithAlloc"));
-  if (auto* FD = llvm::dyn_cast<FunctionDecl>(D)) {
+  if (auto* FD = llvm::dyn_cast_or_null<FunctionDecl>(D)) {
     auto GD = GlobalDecl(FD);
     std::string mangledName;
     compat::maybeMangleDeclName(GD, mangledName);
@@ -3493,6 +3499,31 @@ TInterp_t GetInterpreter() {
   if (sInterpreters->empty())
     return nullptr;
   return sInterpreters->back().Interpreter;
+}
+
+InterpreterLanguage GetLanguage(TInterp_t I /*=nullptr*/) {
+  compat::Interpreter* interp = &getInterp(I);
+  const auto& LO = interp->getCI()->getLangOpts();
+  auto standard = clang::LangStandard::getLangStandardForKind(LO.LangStd);
+  auto lang = static_cast<InterpreterLanguage>(standard.getLanguage());
+  assert(lang != InterpreterLanguage::Unknown && "Unknown language");
+  assert(static_cast<unsigned char>(lang) <=
+             static_cast<unsigned char>(InterpreterLanguage::HLSL) &&
+         "Unhandled Language");
+  return lang;
+}
+
+InterpreterLanguageStandard GetLanguageStandard(TInterp_t I /*=nullptr*/) {
+  compat::Interpreter* interp = &getInterp(I);
+  const auto& LO = interp->getCI()->getLangOpts();
+  auto langStandard = static_cast<InterpreterLanguageStandard>(LO.LangStd);
+  assert(langStandard != InterpreterLanguageStandard::lang_unspecified &&
+         "Unspecified language standard");
+  assert(static_cast<unsigned char>(langStandard) <=
+             static_cast<unsigned char>(
+                 InterpreterLanguageStandard::lang_unspecified) &&
+         "Unhandled language standard.");
+  return langStandard;
 }
 
 void UseExternalInterpreter(TInterp_t I) {

--- a/unittests/CppInterOp/CUDATest.cpp
+++ b/unittests/CppInterOp/CUDATest.cpp
@@ -80,3 +80,18 @@ TEST(CUDATest, CUDARuntime) {
 
   EXPECT_TRUE(HasCudaRuntime());
 }
+
+TEST(CUDATest, Interpreter_GetLanguageCUDA) {
+#ifdef _WIN32
+  GTEST_SKIP() << "Disabled on Windows. Needs fixing.";
+#endif
+  if (!HasCudaRuntime())
+    GTEST_SKIP() << "Skipping CUDA tests as CUDA runtime not found";
+
+  auto* I =
+      Cpp::CreateInterpreter({}, {"-x", "cuda", "--cuda-path=/usr/local/cuda"});
+  if (!I) {
+    GTEST_SKIP() << "Skipping CUDA test as CUDA SDK not found";
+  }
+  EXPECT_EQ(Cpp::GetLanguage(nullptr), Cpp::InterpreterLanguage::CUDA);
+}

--- a/unittests/CppInterOp/InterpreterTest.cpp
+++ b/unittests/CppInterOp/InterpreterTest.cpp
@@ -337,6 +337,75 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, Interpreter_CodeCompletion) {
   EXPECT_EQ(2U, cnt); // float and foo
 }
 
+TYPED_TEST(CPPINTEROP_TEST_MODE, Interpreter_GetLanguageCpp) {
+  // Default interpreter (C++14)
+  TestFixture::CreateInterpreter();
+  EXPECT_EQ(Cpp::GetLanguage(nullptr), Cpp::InterpreterLanguage::CPlusPlus);
+}
+
+TYPED_TEST(CPPINTEROP_TEST_MODE, Interpreter_GetLanguageStandardCpp) {
+  // Other C++ standards
+  TestFixture::CreateInterpreter({"-std=c++14"});
+  EXPECT_EQ(Cpp::GetLanguageStandard(nullptr),
+            Cpp::InterpreterLanguageStandard::cxx14);
+
+  TestFixture::CreateInterpreter({"-std=c++17"});
+  EXPECT_EQ(Cpp::GetLanguageStandard(nullptr),
+            Cpp::InterpreterLanguageStandard::cxx17);
+
+  TestFixture::CreateInterpreter({"-std=c++20"});
+  EXPECT_EQ(Cpp::GetLanguageStandard(nullptr),
+            Cpp::InterpreterLanguageStandard::cxx20);
+
+  TestFixture::CreateInterpreter({"-std=c++23"});
+  EXPECT_EQ(Cpp::GetLanguageStandard(nullptr),
+            Cpp::InterpreterLanguageStandard::cxx23);
+}
+
+TYPED_TEST(CPPINTEROP_TEST_MODE, Interpreter_GetLanguageCAPI) {
+  auto* I = TestFixture::CreateInterpreter();
+  auto* CXI = clang_createInterpreterFromRawPtr(I);
+  EXPECT_EQ(clang_Interpreter_getLanguage(CXI),
+            CXInterpreterLanguage_CPlusPlus);
+  EXPECT_EQ(clang_Interpreter_getLanguageStandard(CXI),
+            CXInterpreterLanguageStandard_cxx14);
+  clang_Interpreter_dispose(CXI);
+}
+
+TYPED_TEST(CPPINTEROP_TEST_MODE, Interpreter_GetLanguageC) {
+  TestFixture::CreateInterpreter({"-xc", "-std=c99"});
+  EXPECT_EQ(Cpp::GetLanguage(nullptr), Cpp::InterpreterLanguage::C);
+  EXPECT_EQ(Cpp::GetLanguageStandard(nullptr),
+            Cpp::InterpreterLanguageStandard::c99);
+}
+TYPED_TEST(CPPINTEROP_TEST_MODE, Interpreter_GetLanguageStandardC) {
+  TestFixture::CreateInterpreter({"-xc", "-std=c89"});
+  EXPECT_EQ(Cpp::GetLanguageStandard(nullptr),
+            Cpp::InterpreterLanguageStandard::c89);
+
+  TestFixture::CreateInterpreter({"-xc", "-std=c11"});
+  EXPECT_EQ(Cpp::GetLanguageStandard(nullptr),
+            Cpp::InterpreterLanguageStandard::c11);
+
+  TestFixture::CreateInterpreter({"-xc", "-std=c17"});
+  EXPECT_EQ(Cpp::GetLanguageStandard(nullptr),
+            Cpp::InterpreterLanguageStandard::c17);
+
+  TestFixture::CreateInterpreter({"-xc", "-std=c23"});
+  EXPECT_EQ(Cpp::GetLanguageStandard(nullptr),
+            Cpp::InterpreterLanguageStandard::c23);
+}
+
+TYPED_TEST(CPPINTEROP_TEST_MODE, Interpreter_GetLanguageStandardGNU) {
+  TestFixture::CreateInterpreter({"-std=gnu++14"});
+  EXPECT_EQ(Cpp::GetLanguageStandard(nullptr),
+            Cpp::InterpreterLanguageStandard::gnucxx14);
+
+  TestFixture::CreateInterpreter({"-std=gnu++17"});
+  EXPECT_EQ(Cpp::GetLanguageStandard(nullptr),
+            Cpp::InterpreterLanguageStandard::gnucxx17);
+}
+
 TYPED_TEST(CPPINTEROP_TEST_MODE, Interpreter_ExternalInterpreter) {
 
   if (llvm::sys::RunningOnValgrind())


### PR DESCRIPTION
Two API functions; InterpreterLanguage GetLanguage(), InterpreterLanguageStandard GetLanguageStandard() and enums for interpreter language, standard added.

Fixes https://github.com/compiler-research/CppInterOp/issues/744