### PR TITLE
make GetTypeAsString() use printing policy from ASTContext

### DIFF
--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -1821,8 +1821,7 @@ TCppType_t GetUnderlyingType(TCppType_t type) {
 
 std::string GetTypeAsString(TCppType_t var) {
   QualType QT = QualType::getFromOpaquePtr(var);
-  // FIXME: Get the default printing policy from the ASTContext.
-  PrintingPolicy Policy((LangOptions()));
+  PrintingPolicy Policy(getASTContext().getPrintingPolicy());
   Policy.Bool = true;               // Print bool instead of _Bool.
   Policy.SuppressTagKeyword = true; // Do not print `class std::string`.
   Policy.SuppressElaboration = true;


### PR DESCRIPTION
# Description
Resolves this `FIXME`:
https://github.com/compiler-research/CppInterOp/blob/5b9435c203debe57e9c12c2c905f785faa52cc5e/lib/CppInterOp/CppInterOp.cpp#L1824

## Type of change

Please tick all options which are relevant.

- [X] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

All unit tests passed.

## Checklist

- [X] I have read the contribution guide recently
