### PR TITLE
Replace string comparison with AST check in IsBuiltin for std::complex

### DIFF
--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -412,8 +412,16 @@ bool IsBuiltin(TCppType_t type) {
   QualType Ty = QualType::getFromOpaquePtr(type);
   if (Ty->isBuiltinType() || Ty->isAnyComplexType())
     return true;
-  // FIXME: Figure out how to avoid the string comparison.
-  return llvm::StringRef(Ty.getAsString()).contains("complex");
+  // Check for std::complex<T> specializations.
+  if (const auto* RD = Ty->getAsCXXRecordDecl()) {
+    if (const auto* CTSD = dyn_cast<ClassTemplateSpecializationDecl>(RD)) {
+      IdentifierInfo* II = CTSD->getSpecializedTemplate()->getIdentifier();
+      if (II && II->isStr("complex") &&
+          CTSD->getDeclContext()->isStdNamespace())
+        return true;
+    }
+  }
+  return false;
 }
 
 bool IsTemplate(TCppScope_t handle) {

--- a/unittests/CppInterOp/ScopeReflectionTest.cpp
+++ b/unittests/CppInterOp/ScopeReflectionTest.cpp
@@ -237,6 +237,13 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, ScopeReflection_IsBuiltin) {
   auto *CTD = cast<ClassTemplateDecl>(lookup.front());
   for (ClassTemplateSpecializationDecl *CTSD : CTD->specializations())
     EXPECT_TRUE(Cpp::IsBuiltin(C.getTypeDeclType(CTSD).getAsOpaquePtr()));
+
+  // User-defined records (even with "complex" in the name) are not builtins.
+  Interp->declare("class complex_number {}; class regular_record {};");
+  EXPECT_FALSE(
+      Cpp::IsBuiltin(Cpp::GetTypeFromScope(Cpp::GetNamed("complex_number", nullptr))));
+  EXPECT_FALSE(
+      Cpp::IsBuiltin(Cpp::GetTypeFromScope(Cpp::GetNamed("regular_record", nullptr))));
 }
 
 TYPED_TEST(CPPINTEROP_TEST_MODE, ScopeReflection_IsTemplate) {


### PR DESCRIPTION
# Description

Replace the fragile string-based check for `std::complex` in `IsBuiltin()` with a proper Clang AST query.

he old code was checking if a type's name contained the word "complex" as a string, which is pretty hacky cuz any random user class with "complex" in the name would get wrongly treated as a builtin. I swapped it out for a proper AST check that looks at whether the type is actually a `std::complex<T>`specialization by walking the Clang AST. Same approach that's already used in other parts of the codebase, so it fits right in.

Resolves the FIXME at line 411: `// FIXME: Figure out how to avoid the string comparison.`

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

- Ran the existing `ScopeReflection_IsBuiltin` test which covers:
  - Builtin types (`bool`, `char`, `signed char`, `void`)
  - C `_Complex` types (`_Complex float`, `_Complex double`, `_Complex long double`, `_Complex __float128`)
  - `std::complex<T>` template specializations (via `#include <complex>` and iterating over specializations)
- Full test suite: **100% tests passed, 0 tests failed out of 3**

```
$ CppInterOpTests --gtest_filter="*IsBuiltin*"
[ RUN      ] CppInterOpTest/InProcessJIT.ScopeReflection_IsBuiltin
[       OK ] CppInterOpTest/InProcessJIT.ScopeReflection_IsBuiltin (290 ms)
[  PASSED  ] 1 test.
```

## Checklist

- [x] I have read the contribution guide recently