### PR TITLE
Constrain xeus to < 6.0.0 in Emscripten environment

### DIFF
--- a/environment-wasm.yml
+++ b/environment-wasm.yml
@@ -7,7 +7,7 @@ dependencies:
   - nlohmann_json
   - nlohmann_json-abi
   - xeus-lite
-  - xeus
+  - xeus<6.0.0
   - cpp-argparse
   - pugixml
   - doctest


### PR DESCRIPTION
@Vipul-Cariappa @aaronj0 The Emscripten ci should pass with this change. The restriction on xeus can be removed once https://github.com/compiler-research/xeus-cpp/pull/453 has been approved and merged in (its currently under review by someone from Quant Stack).