### PR TITLE
Remove restriction on xeus

### DIFF
--- a/environment-wasm.yml
+++ b/environment-wasm.yml
@@ -7,7 +7,7 @@ dependencies:
   - nlohmann_json
   - nlohmann_json-abi
   - xeus-lite
-  - xeus<6.0.0
+  - xeus
   - cpp-argparse
   - pugixml
   - doctest


### PR DESCRIPTION
Now that the PR updating xeus-cpp to be compatible with xeus 6.0 has gone in, this PR is needed to make the Emscripten ci again.