### PR TITLE
Merge GetCompleteName and GetQualifiedCompleteName into shared helper

### DIFF
--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -596,19 +596,24 @@ std::string GetName(TCppType_t klass) {
   return "<unnamed>";
 }
 
-std::string GetCompleteName(TCppType_t klass) {
+static std::string GetCompleteNameImpl(TCppType_t klass, bool qualified) {
   auto& C = getSema().getASTContext();
   auto* D = (Decl*)klass;
 
-  PrintingPolicy Policy = C.getPrintingPolicy();
-  Policy.SuppressUnwrittenScope = true;
-  Policy.SuppressScope = true;
-  Policy.AnonymousTagLocations = false;
-  Policy.SuppressTemplateArgsInCXXConstructors = false;
-  Policy.SuppressDefaultTemplateArgs = false;
-  Policy.AlwaysIncludeTypeForTemplateArgument = true;
-
   if (auto* ND = llvm::dyn_cast_or_null<NamedDecl>(D)) {
+    PrintingPolicy Policy = C.getPrintingPolicy();
+    Policy.SuppressUnwrittenScope = true;
+    if (qualified) {
+      Policy.FullyQualifiedName = true;
+      Policy.SuppressElaboration = true;
+    } else {
+      Policy.SuppressScope = true;
+      Policy.AnonymousTagLocations = false;
+      Policy.SuppressTemplateArgsInCXXConstructors = false;
+      Policy.SuppressDefaultTemplateArgs = false;
+      Policy.AlwaysIncludeTypeForTemplateArgument = true;
+    }
+
     if (auto* TD = llvm::dyn_cast<TagDecl>(ND)) {
       std::string type_name;
       QualType QT = C.getTagDeclType(TD);
@@ -618,12 +623,12 @@ std::string GetCompleteName(TCppType_t klass) {
     if (auto* FD = llvm::dyn_cast<FunctionDecl>(ND)) {
       std::string func_name;
       llvm::raw_string_ostream name_stream(func_name);
-      FD->getNameForDiagnostic(name_stream, Policy, false);
+      FD->getNameForDiagnostic(name_stream, Policy, qualified);
       name_stream.flush();
       return func_name;
     }
 
-    return ND->getNameAsString();
+    return qualified ? ND->getQualifiedNameAsString() : ND->getNameAsString();
   }
 
   if (llvm::isa_and_nonnull<TranslationUnitDecl>(D)) {
@@ -631,6 +636,10 @@ std::string GetCompleteName(TCppType_t klass) {
   }
 
   return "<unnamed>";
+}
+
+std::string GetCompleteName(TCppType_t klass) {
+  return GetCompleteNameImpl(klass, /*qualified=*/false);
 }
 
 std::string GetQualifiedName(TCppType_t klass) {
@@ -646,32 +655,8 @@ std::string GetQualifiedName(TCppType_t klass) {
   return "<unnamed>";
 }
 
-// FIXME: Figure out how to merge with GetCompleteName.
 std::string GetQualifiedCompleteName(TCppType_t klass) {
-  auto& C = getSema().getASTContext();
-  auto* D = (Decl*)klass;
-
-  if (auto* ND = llvm::dyn_cast_or_null<NamedDecl>(D)) {
-    if (auto* TD = llvm::dyn_cast<TagDecl>(ND)) {
-      std::string type_name;
-      QualType QT = C.getTagDeclType(TD);
-      PrintingPolicy PP = C.getPrintingPolicy();
-      PP.FullyQualifiedName = true;
-      PP.SuppressUnwrittenScope = true;
-      PP.SuppressElaboration = true;
-      QT.getAsStringInternal(type_name, PP);
-
-      return type_name;
-    }
-
-    return ND->getQualifiedNameAsString();
-  }
-
-  if (llvm::isa_and_nonnull<TranslationUnitDecl>(D)) {
-    return "";
-  }
-
-  return "<unnamed>";
+  return GetCompleteNameImpl(klass, /*qualified=*/true);
 }
 
 std::string GetDoxygenComment(TCppScope_t scope, bool strip_comment_markers) {


### PR DESCRIPTION


# Description

Refactor `GetCompleteName` and `GetQualifiedCompleteName` into a shared static helper `GetCompleteNameImpl` to eliminate code duplication.

The two functions had kind of identical logic.

The only differences were a few `PrintingPolicy` flags and whether to use the qualified names. I made this change to unify both of them into a common param thats boolean (`qualified`)

While this wasnt mentioned in the fix me as bonus, I tried to implement `GetQualifiedCompleteName`in away that it also handles the `FunctionDecl` which it was missing.

Resolves the FIXME at line 645: 
`// FIXME: Figure out how to merge with GetCompleteName.`

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

- `ScopeReflection_GetCompleteName` — PASSED
- `ScopeReflection_GetQualifiedCompleteName` — PASSED
- `ScopeReflection_Demangle` (also exercises `GetQualifiedCompleteName`) — PASSED
- Full test suite: 100% tests passed, 0 failed out of 3 (307 tests total)

## Checklist

- [x] I have read the contribution guide recently