### PR TITLE
Add DiagnosticsEngineRAII

### DIFF
--- a/lib/CppInterOp/Compatibility.h
+++ b/lib/CppInterOp/Compatibility.h
@@ -430,6 +430,7 @@ public:
   SynthesizingCodeRAII(Interpreter* i) : m_Interpreter(i) {}
   // ~SynthesizingCodeRAII() {} // TODO: implement
 };
+
 } // namespace compat
 
 #endif // CPPINTEROP_USE_REPL
@@ -466,6 +467,25 @@ inline void InstantiateClassTemplateSpecialization(
       /*PrimaryHasMatchedPackOnParmToNonPackOnArg=*/false);
 #endif
 }
+
+class DiagnosticsEngineRAII {
+private:
+  clang::DiagnosticsEngine& diags;
+
+public:
+  bool reset_condition; // additional condition to reset diagnostics
+
+  DiagnosticsEngineRAII(clang::DiagnosticsEngine& d, bool c = true)
+      : diags(d), reset_condition(c) {}
+  ~DiagnosticsEngineRAII() {
+    if (diags.hasErrorOccurred() && reset_condition) {
+      // instantiation failed, need to reset DiagnosticsEngine
+      diags.Reset(/*soft=*/true);
+      diags.getClient()->clear();
+    }
+  }
+};
+
 } // namespace compat
 
 #endif // CPPINTEROP_COMPATIBILITY_H

--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -312,13 +312,8 @@ static void InstantiateFunctionDefinition(Decl* D) {
     getSema().InstantiateFunctionDefinition(SourceLocation(), FD,
                                             /*Recursive=*/true,
                                             /*DefinitionRequired=*/true);
-    // FIXME: this can go into a RAII object
-    clang::DiagnosticsEngine& Diags = getSema().getDiagnostics();
-    if (!FD->isDefined() && Diags.hasErrorOccurred()) {
-      // instantiation failed, need to reset DiagnosticsEngine
-      Diags.Reset(/*soft=*/true);
-      Diags.getClient()->clear();
-    }
+    compat::DiagnosticsEngineRAII diagsRAII(getSema().getDiagnostics(),
+                                            !FD->isDefined());
   }
 }
 


### PR DESCRIPTION
# Description

Fixes ``FIXME: this can go into a RAII object``. Reference:
https://github.com/compiler-research/CppInterOp/blob/852f6d43ea38c3066351c0a4d014ac0d862fa67d/lib/CppInterOp/CppInterOp.cpp#L311

Implementation details-
I added a RAII class (`compat::DiagnosticsEngineRAII`) that automatically checks if it should reset the DiagnosticsEngine before the RAII object goes out of scope. It checks for `diags.hasErrorOccurred()` and a user-provided boolean `reset_condition`. 

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [X] New feature
- [ ] Requires documentation updates

## Testing

```
100% tests passed, 0 tests failed out of 3

Label Time Summary:
DEPENDS    =  12.35 sec*proc (3 tests)

Total Test time (real) =  12.36 sec
[100%] Built target check-cppinterop
```

## Checklist

- [X] I have read the contribution guide recently
