### PR TITLE
Enable benchmark CppInterOp in an Emscripten environment

### DIFF
--- a/.github/actions/Build_and_Test_CppInterOp/action.yml
+++ b/.github/actions/Build_and_Test_CppInterOp/action.yml
@@ -79,6 +79,7 @@ runs:
             fi
           fi
         fi
+        cmake --build . --target run-cppinterop-benchmarks --parallel ${{ env.ncpus }}
         echo "CB_PYTHON_DIR=$CB_PYTHON_DIR" >> $GITHUB_ENV
         echo "CPPINTEROP_BUILD_DIR=$CPPINTEROP_BUILD_DIR" >> $GITHUB_ENV
         echo "CPPINTEROP_DIR=$CPPINTEROP_DIR" >> $GITHUB_ENV
@@ -152,6 +153,7 @@ runs:
                 -DClang_DIR="$env:LLVM_BUILD_DIR\lib\cmake\clang"  -DCODE_COVERAGE=${{ env.CODE_COVERAGE }}  -DCMAKE_INSTALL_PREFIX="$env:CPPINTEROP_DIR"  ..\
         }
         cmake --build . --config ${{ env.BUILD_TYPE }} --target check-cppinterop --parallel ${{ env.ncpus }}
+        cmake --build . --target run-cppinterop-benchmarks --parallel ${{ env.ncpus }}
 
     - name: Emscripten build of CppInterOp on Unix systems (shared library)
       if: ${{ runner.os != 'Windows' && endsWith(matrix.name, '-emscripten') }}
@@ -211,6 +213,7 @@ runs:
                 ../
         fi
         emmake make -j ${{ env.ncpus }} check-cppinterop
+        emmake make -j ${{ env.ncpus }}  run-cppinterop-benchmarks
         os="${{ matrix.os }}"
         if [[ "${os}" != macos* ]] ; then
           actual_size=$(stat -c%s "./lib/libclangCppInterOp.so")
@@ -373,6 +376,7 @@ runs:
         else
           emmake make -j ${{ env.ncpus }} check-cppinterop
         fi
+        emmake make -j ${{ env.ncpus }}  run-cppinterop-benchmarks
         cd ./unittests/CppInterOp/
         os="${{ matrix.os }}"
         if [[ "${os}" == "macos"* ]]; then

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,8 +12,8 @@ set(CMAKE_CXX_EXTENSIONS NO)
 option(CPPINTEROP_USE_CLING "Use Cling as backend" OFF)
 option(CPPINTEROP_USE_REPL "Use clang-repl as backend" ON)
 option(CPPINTEROP_ENABLE_TESTING "Enable the CppInterOp testing infrastructure." ON)
+option(CPPINTEROP_ENABLE_BENCHMARKS "Enable the CppInterOp benchmark infrastructure." ON)
 if(EMSCRIPTEN)
-  option(CPPINTEROP_ENABLE_BENCHMARKS "Enable the CppInterOp benchmark infrastructure." ON)
   set(CPPINTEROP_EXTRA_WASM_FLAGS "-fwasm-exceptions" CACHE STRING "Extra flags for wasm")
 endif()
 
@@ -538,11 +538,9 @@ endif()
 
 add_subdirectory(lib)
 
-if (EMSCRIPTEN)
 if (CPPINTEROP_ENABLE_BENCHMARKS)
   add_subdirectory(benchmarks)
 endif(CPPINTEROP_ENABLE_BENCHMARKS)
-endif(EMSCRIPTEN)
 
 if (CPPINTEROP_ENABLE_TESTING)
   add_subdirectory(unittests)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ option(CPPINTEROP_USE_CLING "Use Cling as backend" OFF)
 option(CPPINTEROP_USE_REPL "Use clang-repl as backend" ON)
 option(CPPINTEROP_ENABLE_TESTING "Enable the CppInterOp testing infrastructure." ON)
 if(EMSCRIPTEN)
+  option(CPPINTEROP_ENABLE_BENCHMARKS "Enable the CppInterOp benchmark infrastructure." ON)
   set(CPPINTEROP_EXTRA_WASM_FLAGS "-fwasm-exceptions" CACHE STRING "Extra flags for wasm")
 endif()
 
@@ -536,6 +537,13 @@ if (CPPINTEROP_INCLUDE_DOCS)
 endif()
 
 add_subdirectory(lib)
+
+if (EMSCRIPTEN)
+if (CPPINTEROP_ENABLE_BENCHMARKS)
+  add_subdirectory(benchmarks)
+endif(CPPINTEROP_ENABLE_BENCHMARKS)
+endif(EMSCRIPTEN)
+
 if (CPPINTEROP_ENABLE_TESTING)
   add_subdirectory(unittests)
 endif(CPPINTEROP_ENABLE_TESTING)

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -4,29 +4,43 @@ add_dependencies(cppinterop-benchmarks clangCppInterOp)
 
 target_link_libraries(cppinterop-benchmarks PRIVATE clangCppInterOp)
 
-target_compile_options(cppinterop-benchmarks
-  PUBLIC "SHELL: ${CPPINTEROP_EXTRA_WASM_FLAGS}"
-)
-
-target_link_options(cppinterop-benchmarks
-  PUBLIC "SHELL: ${CPPINTEROP_EXTRA_WASM_FLAGS}"
-  PUBLIC "SHELL: -s MAIN_MODULE=1"
-  PUBLIC "SHELL: -s WASM_BIGINT"
-  PUBLIC "SHELL: -s ALLOW_MEMORY_GROWTH=1"
-  PUBLIC "SHELL: -s STACK_SIZE=32mb"
-  PUBLIC "SHELL: -s INITIAL_MEMORY=64mb"
-  PUBLIC "SHELL: --emrun"
-)
-
 set_output_directory(cppinterop-benchmarks
     BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}
 )
 
-add_custom_command(TARGET cppinterop-benchmarks POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:clangCppInterOp> ${CMAKE_CURRENT_BINARY_DIR}
-)
+if (EMSCRIPTEN)
+  target_compile_options(cppinterop-benchmarks
+    PUBLIC "SHELL: ${CPPINTEROP_EXTRA_WASM_FLAGS}"
+  )
 
-add_custom_target(run-cppinterop-benchmarks
-    COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_CURRENT_BINARY_DIR} node cppinterop-benchmarks.js
-    DEPENDS cppinterop-benchmarks
-)
+  target_link_options(cppinterop-benchmarks
+    PUBLIC "SHELL: ${CPPINTEROP_EXTRA_WASM_FLAGS}"
+    PUBLIC "SHELL: -s MAIN_MODULE=1"
+    PUBLIC "SHELL: -s WASM_BIGINT"
+    PUBLIC "SHELL: -s ALLOW_MEMORY_GROWTH=1"
+    PUBLIC "SHELL: -s STACK_SIZE=32mb"
+    PUBLIC "SHELL: -s INITIAL_MEMORY=64mb"
+    PUBLIC "SHELL: --emrun"
+  )
+
+  add_custom_command(TARGET cppinterop-benchmarks POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:clangCppInterOp> ${CMAKE_CURRENT_BINARY_DIR}
+  )
+
+  add_custom_command(TARGET cppinterop-benchmarks POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:clangCppInterOp> ${CMAKE_CURRENT_BINARY_DIR}
+  )
+
+  add_custom_target(run-cppinterop-benchmarks
+      COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_CURRENT_BINARY_DIR} node cppinterop-benchmarks.js
+      DEPENDS cppinterop-benchmarks
+  )
+
+else()
+
+  add_custom_target(run-cppinterop-benchmarks
+      COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_CURRENT_BINARY_DIR} ./cppinterop-benchmarks
+      DEPENDS cppinterop-benchmarks
+  )
+
+endif ()

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -1,0 +1,32 @@
+add_executable(cppinterop-benchmarks benchmark.cpp)
+
+add_dependencies(cppinterop-benchmarks clangCppInterOp)
+
+target_link_libraries(cppinterop-benchmarks PRIVATE clangCppInterOp)
+
+target_compile_options(cppinterop-benchmarks
+  PUBLIC "SHELL: ${CPPINTEROP_EXTRA_WASM_FLAGS}"
+)
+
+target_link_options(cppinterop-benchmarks
+  PUBLIC "SHELL: ${CPPINTEROP_EXTRA_WASM_FLAGS}"
+  PUBLIC "SHELL: -s MAIN_MODULE=1"
+  PUBLIC "SHELL: -s WASM_BIGINT"
+  PUBLIC "SHELL: -s ALLOW_MEMORY_GROWTH=1"
+  PUBLIC "SHELL: -s STACK_SIZE=32mb"
+  PUBLIC "SHELL: -s INITIAL_MEMORY=64mb"
+  PUBLIC "SHELL: --emrun"
+)
+
+set_output_directory(cppinterop-benchmarks
+    BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}
+)
+
+add_custom_command(TARGET cppinterop-benchmarks POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:clangCppInterOp> ${CMAKE_CURRENT_BINARY_DIR}
+)
+
+add_custom_target(run-cppinterop-benchmarks
+    COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_CURRENT_BINARY_DIR} node cppinterop-benchmarks.js
+    DEPENDS cppinterop-benchmarks
+)

--- a/benchmarks/benchmark.cpp
+++ b/benchmarks/benchmark.cpp
@@ -2,6 +2,7 @@
 #include <cstdio>
 #include <emscripten.h>
 #include <functional>
+#include <string>
 #include <vector>
 
 constexpr int iterations = 1000;

--- a/benchmarks/benchmark.cpp
+++ b/benchmarks/benchmark.cpp
@@ -48,11 +48,7 @@ static void cpp_getversion() {
 }
 
 static void cpp_process() {
-  static bool initialized = false;
-  if (!initialized) {
-    Cpp::CreateInterpreter();
-    initialized = true;
-  }
+  Cpp::CreateInterpreter();
   Cpp::Process("int a = 12;");
 }
 

--- a/benchmarks/benchmark.cpp
+++ b/benchmarks/benchmark.cpp
@@ -1,6 +1,9 @@
 #include "CppInterOp/CppInterOp.h"
+#include <chrono>
 #include <cstdio>
+#ifdef __EMSCRIPTEN__
 #include <emscripten.h>
+#endif
 #include <functional>
 #include <string>
 #include <vector>
@@ -12,15 +15,26 @@ struct Benchmark {
    std::function<void()> func;
 };
 
+static double now_ms() {
+#ifdef __EMSCRIPTEN__
+    return emscripten_get_now();
+#else
+    using namespace std::chrono;
+    return duration<double, std::milli>(
+        high_resolution_clock::now().time_since_epoch()
+    ).count();
+#endif
+}
+
 static void run_benchmarks(const std::vector<Benchmark>& benchmarks) {
    for (const auto& bench : benchmarks) {
        bench.func();
 
-       double start = emscripten_get_now();
+       double start = now_ms();
        for (int i = 0; i < iterations; ++i) {
            bench.func();
        }
-       double end = emscripten_get_now();
+       double end = now_ms();
        double elapsed_ms = end - start;
        double avg_time = elapsed_ms / iterations;
 
@@ -34,7 +48,11 @@ static void cpp_getversion() {
 }
 
 static void cpp_process() {
-  Cpp::CreateInterpreter();
+  static bool initialized = false;
+  if (!initialized) {
+    Cpp::CreateInterpreter();
+    initialized = true;
+  }
   Cpp::Process("int a = 12;");
 }
 

--- a/benchmarks/benchmark.cpp
+++ b/benchmarks/benchmark.cpp
@@ -1,9 +1,8 @@
-#include <emscripten.h>
-#include <cstdio>
-#include <vector>
-#include <string>
-#include <functional>
 #include "CppInterOp/CppInterOp.h"
+#include <cstdio>
+#include <emscripten.h>
+#include <functional>
+#include <vector>
 
 constexpr int iterations = 1000;
 
@@ -12,9 +11,9 @@ struct Benchmark {
    std::function<void()> func;
 };
 
-void run_benchmarks(const std::vector<Benchmark>& benchmarks) {
+static void run_benchmarks(const std::vector<Benchmark>& benchmarks) {
    for (const auto& bench : benchmarks) {
-       bench.func(); // warmup
+       bench.func();
 
        double start = emscripten_get_now();
        for (int i = 0; i < iterations; ++i) {
@@ -29,11 +28,11 @@ void run_benchmarks(const std::vector<Benchmark>& benchmarks) {
    }
 }
 
-void cpp_getversion() {
+static void cpp_getversion() {
   Cpp::GetVersion();
 }
 
-void cpp_process() {
+static void cpp_process() {
   Cpp::CreateInterpreter();
   Cpp::Process("int a = 12;");
 }

--- a/benchmarks/benchmark.cpp
+++ b/benchmarks/benchmark.cpp
@@ -1,0 +1,50 @@
+#include <emscripten.h>
+#include <cstdio>
+#include <vector>
+#include <string>
+#include <functional>
+#include "CppInterOp/CppInterOp.h"
+
+constexpr int iterations = 1000;
+
+struct Benchmark {
+   std::string name;
+   std::function<void()> func;
+};
+
+void run_benchmarks(const std::vector<Benchmark>& benchmarks) {
+   for (const auto& bench : benchmarks) {
+       bench.func(); // warmup
+
+       double start = emscripten_get_now();
+       for (int i = 0; i < iterations; ++i) {
+           bench.func();
+       }
+       double end = emscripten_get_now();
+       double elapsed_ms = end - start;
+       double avg_time = elapsed_ms / iterations;
+
+       printf("Benchmark: %-20s | Avg time: %.6f ms (over %d runs)\n",
+              bench.name.c_str(), avg_time, iterations);
+   }
+}
+
+void cpp_getversion() {
+  Cpp::GetVersion();
+}
+
+void cpp_process() {
+  Cpp::CreateInterpreter();
+  Cpp::Process("int a = 12;");
+}
+
+
+int main() {
+   std::vector<Benchmark> benchmarks = {
+       {"getversion", cpp_getversion},
+       {"process", cpp_process},
+   };
+
+   run_benchmarks(benchmarks);
+   return 0;
+}


### PR DESCRIPTION
@vgvassilev @anutosh491 Google Benchmark doesn't work for Emscripten environment. Therefore this PR is effectively an in house approach. Worked on the idea through a toy code a few months ago with the help of chatgpt, but only now getting around to putting the PR in implementing it for CppInterOp. The PR as it stands doesn't include any useful benchmarks, and what is there is currently just there to show the approach. The output coming from the benchmarks running looks like (results taken from running the benchmarks on my local machine in node)

```
Benchmark: getversion           | Avg time: 0.001485 ms (over 1000 runs)
Benchmark: process              | Avg time: 18.854234 ms (over 1000 runs)
```

Let me know what you think about the approach, and if you like it I will create useful benchmarks. I don't plan to deal with benchmarking the native case in this PR. I will do that in a separate PR. If you like the approach then I will add something similar to xeus-cpp.