### PR TITLE
Add required cling transactions when performing named lookups

### DIFF
--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -1024,10 +1024,7 @@ TCppScope_t GetNamed(const std::string& name,
     D = GetUnderlyingScope(D);
     Within = llvm::dyn_cast<clang::DeclContext>(D);
   }
-#ifdef CPPINTEROP_USE_CLING
-  if (Within)
-    Within->getPrimaryContext()->buildLookup();
-#endif
+
   compat::SynthesizingCodeRAII RAII(&getInterp());
   auto* ND = CppInternal::utils::Lookup::Named(&getSema(), name, Within);
   if (ND && ND != (clang::NamedDecl*)-1) {
@@ -1162,6 +1159,8 @@ int64_t GetBaseClassOffset(TCppScope_t derived, TCppScope_t base) {
     return INTEROP_RETURN(0);
 
   assert(derived || base);
+
+  compat::SynthesizingCodeRAII RAII(&getInterp());
 
   auto* DD = (Decl*)derived;
   auto* BD = (Decl*)base;
@@ -1315,6 +1314,7 @@ std::vector<TCppFunction_t> GetFunctionsUsingName(TCppScope_t scope,
   clang::LookupResult R(S, DName, SourceLocation(), Sema::LookupOrdinaryName,
                         RedeclarationKind::ForVisibleRedeclaration);
 
+  compat::SynthesizingCodeRAII RAII(&getInterp());
   CppInternal::utils::Lookup::Named(&S, R, Decl::castToDeclContext(D));
 
   if (R.empty())
@@ -1469,6 +1469,7 @@ bool ExistsFunctionTemplate(const std::string& name, TCppScope_t parent) {
     Within = llvm::dyn_cast<DeclContext>(D);
   }
 
+  compat::SynthesizingCodeRAII RAII(&getInterp());
   auto* ND = CppInternal::utils::Lookup::Named(&getSema(), name, Within);
 
   if ((intptr_t)ND == (intptr_t)0)
@@ -1517,6 +1518,8 @@ bool GetClassTemplatedMethods(const std::string& name, TCppScope_t parent,
   clang::LookupResult R(S, DName, SourceLocation(), Sema::LookupOrdinaryName,
                         RedeclarationKind::ForVisibleRedeclaration);
   auto* DC = clang::Decl::castToDeclContext(D);
+
+  compat::SynthesizingCodeRAII RAII(&getInterp());
   CppInternal::utils::Lookup::Named(&S, R, DC);
 
   if (R.getResultKind() == clang_LookupResult_Not_Found && funcs.empty())
@@ -1850,6 +1853,7 @@ TCppScope_t LookupDatamember(const std::string& name, TCppScope_t parent) {
     Within = llvm::dyn_cast<clang::DeclContext>(D);
   }
 
+  compat::SynthesizingCodeRAII RAII(&getInterp());
   auto* ND = CppInternal::utils::Lookup::Named(&getSema(), name, Within);
   if (ND && ND != (clang::NamedDecl*)-1) {
     if (llvm::isa_and_nonnull<clang::FieldDecl>(ND)) {
@@ -1898,6 +1902,7 @@ intptr_t GetVariableOffset(compat::Interpreter& I, Decl* D,
     return 0;
 
   auto& C = I.getSema().getASTContext();
+  compat::SynthesizingCodeRAII RAII(&getInterp());
 
   if (auto* FD = llvm::dyn_cast<FieldDecl>(D)) {
     clang::RecordDecl* FieldParentRecordDecl = FD->getParent();

--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -1526,6 +1526,8 @@ int64_t GetBaseClassOffset(ConstDeclRef derived, ConstDeclRef base) {
 
   assert(derived || base);
 
+  compat::SynthesizingCodeRAII RAII(&getInterp());
+
   const auto* DD = unwrap<Decl>(derived);
   const auto* BD = unwrap<Decl>(base);
   if (!isa<CXXRecordDecl>(DD) || !isa<CXXRecordDecl>(BD))
@@ -1716,6 +1718,7 @@ std::vector<FuncRef> GetFunctionsUsingName(ConstDeclRef DRef,
   clang::LookupResult R(S, DName, SourceLocation(), Sema::LookupOrdinaryName,
                         RedeclarationKind::ForVisibleRedeclaration);
 
+  compat::SynthesizingCodeRAII RAII(&getInterp());
   CppInternal::utils::Lookup::Named(&S, R, Decl::castToDeclContext(D));
 
   if (R.empty())
@@ -2469,6 +2472,7 @@ bool ExistsFunctionTemplate(const std::string& name, ConstDeclRef parent) {
     Within = llvm::dyn_cast<DeclContext>(D);
   }
 
+  compat::SynthesizingCodeRAII RAII(&getInterp());
   auto* ND = CppInternal::utils::Lookup::Named(&getSema(), name, Within);
 
   if ((intptr_t)ND == (intptr_t)0)
@@ -2506,6 +2510,9 @@ void LookupConstructors(const std::string& name, ConstDeclRef parent,
   auto* D = const_cast<Decl*>(unwrap<Decl>(parent));
 
   if (auto* CXXRD = llvm::dyn_cast_or_null<CXXRecordDecl>(D)) {
+    // Both calls below declare implicit members lazily and can deserialize
+    // decls from an AST file, which must happen within a transaction.
+    compat::SynthesizingCodeRAII RAII(&getInterp());
     getSema().ForceDeclarationOfImplicitMembers(CXXRD);
     DeclContextLookupResult Result = getSema().LookupConstructors(CXXRD);
     // Obtaining all constructors when we intend to lookup a method under a
@@ -2534,6 +2541,8 @@ bool GetClassTemplatedMethods(const std::string& name, ConstDeclRef parent,
   clang::LookupResult R(S, DName, SourceLocation(), Sema::LookupOrdinaryName,
                         RedeclarationKind::ForVisibleRedeclaration);
   auto* DC = clang::Decl::castToDeclContext(DU);
+
+  compat::SynthesizingCodeRAII RAII(&getInterp());
   CppInternal::utils::Lookup::Named(&S, R, DC);
 
   if (R.getResultKind() == clang_LookupResult_Not_Found && funcs.empty())
@@ -3223,6 +3232,7 @@ DeclRef LookupDatamember(const std::string& name, ConstDeclRef parent) {
     Within = llvm::dyn_cast<clang::DeclContext>(D);
   }
 
+  compat::SynthesizingCodeRAII RAII(&getInterp());
   auto* ND = CppInternal::utils::Lookup::Named(&getSema(), name, Within);
   if (ND && ND != (clang::NamedDecl*)-1) {
     if (llvm::isa_and_nonnull<clang::FieldDecl>(ND)) {
@@ -3283,6 +3293,7 @@ intptr_t GetVariableOffset(compat::Interpreter& I, Decl* D,
   auto& C = I.getSema().getASTContext();
 
   if (auto* FD = llvm::dyn_cast<FieldDecl>(D)) {
+    compat::SynthesizingCodeRAII RAII(&getInterp());
     clang::RecordDecl* FieldParentRecordDecl = FD->getParent();
     intptr_t offset = C.toCharUnitsFromBits(C.getFieldOffset(FD)).getQuantity();
     while (FieldParentRecordDecl->isAnonymousStructOrUnion()) {

--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -1333,11 +1333,9 @@ DeclRef GetNamed(const std::string& name, ConstDeclRef parent /*= nullptr*/) {
     auto* D = unwrap<clang::Decl>(GetUnderlyingScope(parent));
     Within = llvm::dyn_cast<clang::DeclContext>(D);
   }
-#ifdef CPPINTEROP_USE_CLING
+  compat::SynthesizingCodeRAII RAII(&getInterp());
   if (Within)
     Within->getPrimaryContext()->buildLookup();
-#endif
-  compat::SynthesizingCodeRAII RAII(&getInterp());
 
   // Fast path: qualified lookup. Cheap, no DRef-chain allocation, and
   // resolves every name not brought into `Within` via a using-directive.

--- a/lib/CppInterOp/CppInterOpInterpreter.h
+++ b/lib/CppInterOp/CppInterOpInterpreter.h
@@ -97,6 +97,10 @@ inline clang::NamespaceDecl* Namespace(clang::Sema* S, const char* Name,
 
 inline void Named(clang::Sema* S, clang::LookupResult& R,
                   const clang::DeclContext* Within = nullptr) {
+#ifdef CPPINTEROP_USE_CLING
+  if (Within)
+    Within->getPrimaryContext()->buildLookup();
+#endif
   R.suppressDiagnostics();
   if (!Within)
     S->LookupName(R, S->TUScope);

--- a/lib/CppInterOp/CppInterOpInterpreter.h
+++ b/lib/CppInterOp/CppInterOpInterpreter.h
@@ -97,10 +97,8 @@ inline clang::NamespaceDecl* Namespace(clang::Sema* S, const char* Name,
 
 inline void Named(clang::Sema* S, clang::LookupResult& R,
                   const clang::DeclContext* Within = nullptr) {
-#ifdef CPPINTEROP_USE_CLING
   if (Within)
     Within->getPrimaryContext()->buildLookup();
-#endif
   R.suppressDiagnostics();
   if (!Within)
     S->LookupName(R, S->TUScope);


### PR DESCRIPTION
From the ROOT migration
Also folds usages of `DeclContext::buildLookup` into `utils::Lookup::Named` to avoid repetition