### PR TITLE
include API after undef windows.h `LoadLibrary`

### DIFF
--- a/include/CppInterOp/Dispatch.h
+++ b/include/CppInterOp/Dispatch.h
@@ -21,19 +21,19 @@
 #error "To use the Dispatch mechanism, do not include CppInterOp.h directly."
 #endif
 
-#include <CppInterOp/CppInterOp.h>
-
-#include <cstdlib>
-#include <iostream>
-#include <memory>
-#include <mutex>
-
 #ifdef _WIN32
 #include <windows.h>
 #undef LoadLibrary
 #else
 #include <dlfcn.h>
 #endif
+
+#include <CppInterOp/CppInterOp.h>
+
+#include <cstdlib>
+#include <iostream>
+#include <memory>
+#include <mutex>
 
 using CppFnPtrTy = void (*)();
 ///\param[in] procname - the name of the FunctionEntry in the symbol lookup


### PR DESCRIPTION
We lose `CppImpl::LoadLibrary` otherwise, fixed an error on ROOT's Windows CI when using Dispatch to load the API