### PR TITLE
use a common `compat::Value` to avoid macro guard duplication

### DIFF
--- a/lib/CppInterOp/CXCppInterOp.cpp
+++ b/lib/CppInterOp/CXCppInterOp.cpp
@@ -346,30 +346,17 @@ enum CXErrorCode clang_Interpreter_process(CXInterpreter I, const char* code) {
 }
 
 CXValue clang_createValue(void) {
-#ifdef CPPINTEROP_USE_CLING
-  auto val = std::make_unique<cling::Value>();
-#else
-  auto val = std::make_unique<clang::Value>();
-#endif // CPPINTEROP_USE_CLING
-
+  auto val = std::make_unique<compat::Value>();
   return val.release();
 }
 
 void clang_Value_dispose(CXValue V) {
-#ifdef CPPINTEROP_USE_CLING
-  delete static_cast<cling::Value*>(V); // NOLINT(*-owning-memory)
-#else
-  delete static_cast<clang::Value*>(V); // NOLINT(*-owning-memory)
-#endif // CPPINTEROP_USE_CLING
+  delete static_cast<compat::Value*>(V); // NOLINT(*-owning-memory)
 }
 
 enum CXErrorCode clang_Interpreter_evaluate(CXInterpreter I, const char* code,
                                             CXValue V) {
-#ifdef CPPINTEROP_USE_CLING
-  auto* val = static_cast<cling::Value*>(V);
-#else
-  auto* val = static_cast<clang::Value*>(V);
-#endif // CPPINTEROP_USE_CLING
+  auto* val = static_cast<compat::Value*>(V);
 
   if (getInterpreter(I)->evaluate(code, *val))
     return CXError_Failure;

--- a/lib/CppInterOp/Compatibility.h
+++ b/lib/CppInterOp/Compatibility.h
@@ -436,6 +436,12 @@ public:
 
 namespace compat {
 
+#ifdef CPPINTEROP_USE_CLING
+using Value = cling::Value;
+#else
+using Value = clang::Value;
+#endif
+
 // Clang >= 16 (=16 with Value patch) change castAs to convertTo
 #ifdef CPPINTEROP_USE_CLING
 template <typename T> inline T convertTo(cling::Value V) {

--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -3632,11 +3632,7 @@ int Declare(const char* code, bool silent) {
 int Process(const char* code) { return getInterp().process(code); }
 
 intptr_t Evaluate(const char* code, bool* HadError /*=nullptr*/) {
-#ifdef CPPINTEROP_USE_CLING
-  cling::Value V;
-#else
-  clang::Value V;
-#endif // CPPINTEROP_USE_CLING
+  compat::Value V;
 
   if (HadError)
     *HadError = false;


### PR DESCRIPTION
Noticed when condensing duplication in named lookups. This is mainly visible in the C-API, with just one occurrence in the source