### PR TITLE
fix: Move runtime codes to own separate header file

### DIFF
--- a/include/CppInterOp/CppInterOpRuntime.h
+++ b/include/CppInterOp/CppInterOpRuntime.h
@@ -1,0 +1,22 @@
+//===--- CppInterOpRuntime.h - Runtime codes for language interoperability ---*- C++ -*-===//
+//
+// Part of the compiler-research project, under the Apache License v2.0 with
+// LLVM Exceptions.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CPPINTEROP_CPPINTEROPRUNTIME_H
+#define CPPINTEROP_CPPINTEROPRUNTIME_H
+
+namespace __internal_CppInterOp {
+template <typename Signature>
+struct function;
+
+template <typename Res, typename... ArgTypes>
+struct function<Res(ArgTypes...)> {
+  using result_type = Res;
+};
+}  // namespace __internal_CppInterOp
+
+#endif // CPPINTEROP_CPPINTEROPRUNTIME_H

--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -3413,16 +3413,7 @@ TInterp_t CreateInterpreter(const std::vector<const char*>& Args /*={}*/,
 
   if (GetLanguage(I) != InterpreterLanguage::C) {
     I->declare(R"(
-    namespace __internal_CppInterOp {
-    template <typename Signature>
-    struct function;
-    template <typename Res, typename... ArgTypes>
-    struct function<Res(ArgTypes...)> {
-      typedef Res result_type;
-    };
-    }  // namespace __internal_CppInterOp
-  )");
-  }
+    #include <CppInterOp/CppInterOpRuntime.h>
 
   sInterpreters->emplace_back(I, /*Owned=*/true);
 


### PR DESCRIPTION
Fixes https://github.com/compiler-research/CppInterOp/issues/697

### Description
This addresses #697, which required extracting the dynamically declared code block inside `CppInterOp.cpp` (the `__internal_CppInterOp` wrapper signatures) out into its own dedicated header file. 

### Changes Made
- Created `include/CppInterOp/CppInterOpRuntime.h` to house the runtime code signatures.
- Replaced the string literal `I->declare` payload in `CppInterOp.cpp` with a standard runtime `#include <CppInterOp/CppInterOpRuntime.h>` preprocessor directive. 

This cleans up the interpreter startup code and makes extending the runtime capabilities much easier.