### PR TITLE
Fix self-hosted runner labels for CUDA CI job

### DIFF
--- a/.github/actions/Build_and_Test_CppInterOp/action.yml
+++ b/.github/actions/Build_and_Test_CppInterOp/action.yml
@@ -8,15 +8,21 @@ runs:
       if: ${{ runner.os != 'Windows' && !endsWith(matrix.name, '-emscripten') }}
       shell: bash
       run: |
-        LLVM_DIR="$(pwd)/llvm-project"
-        LLVM_BUILD_DIR="$(pwd)/llvm-project/build"
-        cling_on=$(echo "${{ matrix.cling }}" | tr '[:lower:]' '[:upper:]')
-        if [[ "${cling_on}" == "ON" ]]; then
-          CLING_DIR="$(pwd)/cling"
-          CLING_BUILD_DIR="$(pwd)/cling/build"
-          CPLUS_INCLUDE_PATH="${CLING_DIR}/tools/cling/include:${CLING_BUILD_DIR}/include:${LLVM_DIR}/llvm/include:${LLVM_DIR}/clang/include:${LLVM_BUILD_DIR}/include:${LLVM_BUILD_DIR}/tools/clang/include:$PWD/include"
+        if [[ "${{ runner.environment }}" == "self-hosted" ]]; then
+          LLVM_DIR="/usr/lib/llvm-${{ matrix.clang-runtime }}"
+          LLVM_BUILD_DIR="/usr/lib/llvm-${{ matrix.clang-runtime }}"
+          CPLUS_INCLUDE_PATH="/usr/lib/llvm-${{ matrix.clang-runtime }}/include:$PWD/include"
         else
-          CPLUS_INCLUDE_PATH="${LLVM_DIR}/llvm/include:${LLVM_DIR}/clang/include:${LLVM_BUILD_DIR}/include:${LLVM_BUILD_DIR}/tools/clang/include:$PWD/include"
+          LLVM_DIR="$(pwd)/llvm-project"
+          LLVM_BUILD_DIR="$(pwd)/llvm-project/build"
+          cling_on=$(echo "${{ matrix.cling }}" | tr '[:lower:]' '[:upper:]')
+          if [[ "${cling_on}" == "ON" ]]; then
+            CLING_DIR="$(pwd)/cling"
+            CLING_BUILD_DIR="$(pwd)/cling/build"
+            CPLUS_INCLUDE_PATH="${CLING_DIR}/tools/cling/include:${CLING_BUILD_DIR}/include:${LLVM_DIR}/llvm/include:${LLVM_DIR}/clang/include:${LLVM_BUILD_DIR}/include:${LLVM_BUILD_DIR}/tools/clang/include:$PWD/include"
+          else
+            CPLUS_INCLUDE_PATH="${LLVM_DIR}/llvm/include:${LLVM_DIR}/clang/include:${LLVM_BUILD_DIR}/include:${LLVM_BUILD_DIR}/tools/clang/include:$PWD/include"
+          fi
         fi
 
         export CB_PYTHON_DIR="$PWD/cppyy-backend/python"

--- a/.github/actions/Miscellaneous/Install_Dependencies/action.yml
+++ b/.github/actions/Miscellaneous/Install_Dependencies/action.yml
@@ -27,7 +27,7 @@ runs:
         pip install distro pytest
 
     - name: Install dependencies on Linux
-      if: runner.os == 'Linux'
+      if: runner.os == 'Linux' && runner.environment != 'self-hosted'
       shell: bash
       run: |
         # Install deps

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ concurrency:
 jobs:
   prepare-dell:
     name: Activate self-host infrastructure
-    runs-on: self-hosted
+    runs-on: [self-hosted, spotter]
     steps:
       - name: Send Magic Packet
         env:
@@ -105,7 +105,7 @@ jobs:
             python-version: '3.14'
           # Ubuntu X86 Jobs
           - name: self-hosted-ubu22-x86-gcc12-clang-repl-21-cuda
-            os: self-hosted
+            os: [self-hosted, cuda, heavy]
             compiler: gcc-12
             clang-runtime: '21'
             llvm_enable_projects: "clang"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -297,6 +297,7 @@ jobs:
       uses: ./.github/actions/Miscellaneous/Save_PR_Info
 
     - name: Restore cached LLVM-${{ matrix.clang-runtime }} and ${{ matrix.cling == 'On' && 'Cling' || 'Clang-REPL' }} build
+      if: ${{ runner.environment != 'self-hosted' }}
       uses: actions/cache/restore@v4
       id: cache
       with:
@@ -314,14 +315,22 @@ jobs:
     - name: Install dependencies
       uses: ./.github/actions/Miscellaneous/Install_Dependencies
     
+    - name: Install LLVM-${{ matrix.clang-runtime }} dependencies on self-hosted
+      if: ${{ runner.environment == 'self-hosted' }}
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y llvm-${{ matrix.clang-runtime }}-dev libclang-${{ matrix.clang-runtime }}-dev clang-${{ matrix.clang-runtime }} libzstd-dev gcc-12 g++-12
+
     - name: Build LLVM-${{ matrix.clang-runtime }} and ${{ matrix.cling == 'On' && 'Cling' || 'Clang-REPL' }}
+      if: ${{ runner.environment != 'self-hosted' }}
       uses: ./.github/actions/Build_LLVM
       with:
         cache-hit: ${{ steps.cache.outputs.cache-hit }}
 
     - name: Cache LLVM-${{ matrix.clang-runtime }} and ${{ matrix.cling == 'On' && 'Cling' || 'Clang-REPL' }} build
       uses: actions/cache/save@v4
-      if: ${{ steps.cache.outputs.cache-hit != 'true' }}
+      if: ${{ runner.environment != 'self-hosted' && steps.cache.outputs.cache-hit != 'true' }}
       with:
         path: |
           llvm-project


### PR DESCRIPTION
The prepare-dell job needs the 'spotter' label to target the always-on runner, otherwise the wake-onlan packet never reaches the ip. The build matrix entry also needs [self-hosted, cuda, heavy] to route to the correct machine once it's awake. adapted from the working clad CI configuration