### PR TITLE
Fix CUDA tests

### DIFF
--- a/lib/CppInterOp/Compatibility.h
+++ b/lib/CppInterOp/Compatibility.h
@@ -7,11 +7,31 @@
 
 #include "clang/AST/DeclTemplate.h"
 #include "clang/AST/GlobalDecl.h"
+#include "clang/Basic/DiagnosticIDs.h"
+#include "clang/Basic/DiagnosticOptions.h"
+#if CLANG_VERSION_MAJOR < 21
+#include "clang/Basic/Cuda.h"
+#else
+#include "clang/Basic/OffloadArch.h"
+#endif
 #include "clang/Basic/SourceLocation.h"
 #include "clang/Basic/Specifiers.h"
 #include "clang/Basic/Version.h"
 #include "clang/Config/config.h"
+#include "clang/Driver/Compilation.h"
+#include "clang/Driver/Driver.h"
+#include "clang/Driver/Options.h"
+#include "clang/Frontend/TextDiagnosticBuffer.h"
 #include "clang/Sema/Sema.h"
+
+#include "llvm/ADT/IntrusiveRefCntPtr.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/FileSystem.h"
+
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <string>
 
 #ifdef _MSC_VER
 #define dup _dup
@@ -189,11 +209,12 @@ inline void codeComplete(std::vector<std::string>& Results,
 #include "clang/Interpreter/Interpreter.h"
 #include "clang/Interpreter/Value.h"
 
+#include "llvm/Support/DynamicLibrary.h"
 #include "llvm/Support/Error.h"
+#include "llvm/TargetParser/Host.h"
 
 #ifdef LLVM_BUILT_WITH_OOP_JIT
 #include "clang/Basic/Version.h"
-#include "llvm/TargetParser/Host.h"
 
 #include "llvm/ExecutionEngine/Orc/Debugging/DebuggerSupport.h"
 
@@ -204,29 +225,162 @@ inline void codeComplete(std::vector<std::string>& Results,
 
 namespace compat {
 
+/// Detect the CUDA installation path using clang::Driver
+/// \param args user-provided interpreter arguments (may contain --cuda-path).
+/// \param[out] CudaPath the detected CUDA installation path.
+/// \returns true on success, false if not found.
+inline bool detectCudaInstallPath(const std::vector<const char*>& args,
+                                  std::string& CudaPath) {
+  // minimal driver that runs CudaInstallationDetector internally
+  std::string TT = llvm::sys::getProcessTriple();
+  llvm::IntrusiveRefCntPtr<clang::DiagnosticIDs> DiagID(
+      new clang::DiagnosticIDs());
+  // NOLINTNEXTLINE(cppcoreguidelines-owning-memory)
+  auto* DiagsBuffer = new clang::TextDiagnosticBuffer;
+#if CLANG_VERSION_MAJOR < 21
+  llvm::IntrusiveRefCntPtr<clang::DiagnosticOptions> DiagOpts(
+      new clang::DiagnosticOptions());
+  clang::DiagnosticsEngine Diags(DiagID, DiagOpts, DiagsBuffer);
+#else
+  clang::DiagnosticOptions DiagOpts;
+  clang::DiagnosticsEngine Diags(DiagID, DiagOpts, DiagsBuffer);
+#endif
+
+  clang::driver::Driver D("clang", TT, Diags);
+  D.setCheckInputsExist(false);
+
+  // construct args: clang -x cuda -c <<< inputs >>> [args]
+  llvm::SmallVector<const char*, 16> Argv;
+  Argv.push_back("clang");
+  Argv.push_back("-xcuda");
+  Argv.push_back("-c");
+  Argv.push_back("<<< inputs >>>");
+  for (const auto* arg : args)
+    Argv.push_back(arg);
+
+  // build a compilation object, which runs the driver's CUDA installation
+  // detection logic and stores the paths
+  std::unique_ptr<clang::driver::Compilation> C(D.BuildCompilation(Argv));
+  if (!C)
+    return false;
+
+  // --cuda-path was explicitly provided in user args
+  if (auto* A =
+          C->getArgs().getLastArg(clang::driver::options::OPT_cuda_path_EQ)) {
+    std::string Candidate = A->getValue();
+    if (llvm::sys::fs::is_directory(Candidate + "/include")) {
+      CudaPath = Candidate;
+      return true;
+    }
+  }
+
+  // fallback: clang tries to auto-detect the install, CudaInstallationDetector
+  // stores the path internally but doesn't expose it, so we look for
+  // "-internal-isystem <cuda-path>/include" that the driver adds for CUDA
+  // headers.
+  for (const auto& Job : C->getJobs()) {
+    if (const auto* Cmd = llvm::dyn_cast<clang::driver::Command>(&Job)) {
+      const auto& Args = Cmd->getArguments();
+      for (size_t i = 0; i + 1 < Args.size(); ++i) {
+        if (llvm::StringRef(Args[i]) == "-internal-isystem") {
+          llvm::StringRef IncDir(Args[i + 1]);
+          if (IncDir.ends_with("/include") &&
+              llvm::sys::fs::exists(IncDir.str() + "/cuda.h")) {
+            CudaPath = IncDir.drop_back(strlen("/include")).str();
+            return true;
+          }
+        }
+      }
+    }
+  }
+  return false;
+}
+
+/// Detect GPU architecture via the CUDA Driver API, tweaked from clang's
+/// nvptx-arch tool (NVPTXArch.cpp) \param[out] Arch Set to "sm_XX" on success,
+/// or clang's default fallback. \returns true on success, false on error (no
+/// CUDA driver available).
+inline bool detectNVPTXArch(std::string& Arch) {
+  std::string Err;
+  // FIXME: Use ToolChain::getSystemGPUArchs() from a minimal driver compilation
+  // instead, and unify this function with detectCudaInstallPath. Ideally we
+  // should rely on the offload-arch/nvptx-arch tool in clang, but there is no
+  // public API or library to link against.
+  auto Lib = llvm::sys::DynamicLibrary::getPermanentLibrary(
+#ifdef _WIN32
+      "nvcuda.dll",
+#else
+      "libcuda.so.1",
+#endif
+      &Err);
+  if (!Lib.isValid())
+    return false;
+
+  using cuInit_t = int (*)(unsigned);
+  using cuDeviceGet_t = int (*)(uint32_t*, int);
+  using cuDeviceGetAttribute_t = int (*)(int*, int, uint32_t);
+
+  // NOLINTBEGIN(cppcoreguidelines-pro-type-reinterpret-cast)
+  auto cuInit = reinterpret_cast<cuInit_t>(Lib.getAddressOfSymbol("cuInit"));
+  auto cuDeviceGet =
+      reinterpret_cast<cuDeviceGet_t>(Lib.getAddressOfSymbol("cuDeviceGet"));
+  auto cuDeviceGetAttribute = reinterpret_cast<cuDeviceGetAttribute_t>(
+      Lib.getAddressOfSymbol("cuDeviceGetAttribute"));
+  // NOLINTEND(cppcoreguidelines-pro-type-reinterpret-cast)
+
+  if (!cuInit || !cuDeviceGet || !cuDeviceGetAttribute)
+    return false;
+
+  uint32_t dev;
+  int maj, min;
+  if (cuInit(0) || cuDeviceGet(&dev, 0) ||
+      cuDeviceGetAttribute(&maj, /*MAJOR*/ 75, dev) ||
+      cuDeviceGetAttribute(&min, /*MINOR*/ 76, dev)) {
+    Arch = clang::OffloadArchToString(clang::OffloadArch::CudaDefault);
+    return true;
+  }
+  Arch = "sm_" + std::to_string(maj) + std::to_string(min);
+  return true;
+}
+
 inline std::unique_ptr<clang::Interpreter>
 createClangInterpreter(std::vector<const char*>& args, int stdin_fd = -1,
                        int stdout_fd = -1, int stderr_fd = -1) {
-  auto has_arg = [](const char* x, llvm::StringRef match = "cuda") {
-    llvm::StringRef Arg = x;
-    Arg = Arg.trim().ltrim('-');
-    return Arg == match;
-  };
-  auto it = std::find_if(args.begin(), args.end(), has_arg);
-  std::vector<const char*> gpu_args = {it, args.end()};
-#ifdef __APPLE__
   bool CudaEnabled = false;
-#else
-  bool CudaEnabled = !gpu_args.empty();
+  std::string OffloadArch;
+  std::string CudaPath;
+  std::vector<const char*> CompilerArgs;
+  for (const auto* arg : args) {
+    llvm::StringRef A(arg);
+    llvm::StringRef Stripped = A.trim().ltrim('-');
+    if (Stripped == "cuda") {
+      CudaEnabled = true;
+    } else if (A.starts_with("--offload-arch=")) {
+      OffloadArch = A.substr(strlen("--offload-arch="));
+    } else if (A.starts_with("--cuda-path=")) {
+      CudaPath = A.substr(strlen("--cuda-path="));
+    } else {
+      CompilerArgs.push_back(arg);
+    }
+  }
+#ifdef __APPLE__
+  CudaEnabled = false;
 #endif
 
   clang::IncrementalCompilerBuilder CB;
-  CB.SetCompilerArgs({args.begin(), it});
+  CB.SetCompilerArgs(CompilerArgs);
 
   std::unique_ptr<clang::CompilerInstance> DeviceCI;
   if (CudaEnabled) {
-    // FIXME: Parametrize cuda-path and offload-arch.
-    CB.SetOffloadArch("sm_35");
+    if (OffloadArch.empty())
+      detectNVPTXArch(OffloadArch);
+
+    if (CudaPath.empty())
+      detectCudaInstallPath(CompilerArgs, CudaPath);
+
+    CB.SetOffloadArch(OffloadArch);
+    if (!CudaPath.empty())
+      CB.SetCudaSDK(CudaPath);
     auto devOrErr = CB.CreateCudaDevice();
     if (!devOrErr) {
       llvm::logAllUnhandledErrors(devOrErr.takeError(), llvm::errs(),

--- a/unittests/CppInterOp/CUDATest.cpp
+++ b/unittests/CppInterOp/CUDATest.cpp
@@ -3,95 +3,106 @@
 #include "CppInterOp/CppInterOp.h"
 
 #include "clang/Basic/Version.h"
+#include "llvm/Support/FileSystem.h"
 
 #include "gtest/gtest.h"
 
 #include <cstdint>
+#include <string>
+#include <vector>
 
 using namespace TestUtils;
 
-static bool HasCudaSDK() {
-  auto supportsCudaSDK = []() {
-#ifdef CPPINTEROP_USE_CLING
-    // FIXME: Enable this for cling.
-    return false;
-#endif
-    if (!Cpp::CreateInterpreter({}, {"--cuda"}))
-      return false;
-    return Cpp::Declare("__global__ void test_func() {}"
-                        "test_func<<<1,1>>>();" DFLT_FALSE) == 0;
-  };
-  static bool hasCuda = supportsCudaSDK();
-  return hasCuda;
-}
+// CUDA test fixture that runs SDK and runtime checks once for the entire suite.
+class CUDATest : public ::testing::Test {
+protected:
+  static inline bool HasSDK = false;
+  static inline bool HasRuntime = false;
 
-static bool HasCudaRuntime() {
-  auto supportsCuda = []() {
-#ifdef CPPINTEROP_USE_CLING
-    // FIXME: Enable this for cling.
-    return false;
+  static void SetUpTestSuite() {
+#if defined(CPPINTEROP_USE_CLING) || defined(_WIN32)
+    return; // FIXME: Enable for cling and Windows.
 #endif
-    if (!HasCudaSDK())
-      return false;
-
-    if (!Cpp::CreateInterpreter({}, {"--cuda"}))
-      return false;
+    auto *I = Cpp::CreateInterpreter({}, {"--cuda"});
+    if (!I)
+      return;
     if (Cpp::Declare("__global__ void test_func() {}"
-                     "test_func<<<1,1>>>();" DFLT_FALSE))
-      return false;
-    intptr_t result = Cpp::Evaluate("(bool)cudaGetLastError()" DFLT_NULLPTR);
-    return !(bool)result;
-  };
-  static bool hasCuda = supportsCuda();
-  return hasCuda;
-}
+                     "test_func<<<1,1>>>();" DFLT_FALSE) != 0)
+      return;
 
-#ifdef CPPINTEROP_USE_CLING
-TEST(DISABLED_CUDATest, Sanity) {
-#else
-TEST(CUDATest, Sanity) {
-#endif
-#ifdef _WIN32
-  GTEST_SKIP() << "Disabled on Windows. Needs fixing.";
-#endif
-  if (!HasCudaSDK())
-    GTEST_SKIP() << "Skipping CUDA tests as CUDA SDK not found";
+    HasSDK = true;
+    HasRuntime =
+        !Cpp::Declare("int __cuda_err = (int)cudaGetLastError();" DFLT_FALSE);
+    Cpp::DeleteInterpreter(I);
+  }
+
+};
+
+
+TEST_F(CUDATest, Sanity) {
+  if (!HasSDK)
+    return;
   EXPECT_TRUE(Cpp::CreateInterpreter({}, {"--cuda"}));
 }
 
-TEST(CUDATest, CUDAH) {
-#ifdef _WIN32
-  GTEST_SKIP() << "Disabled on Windows. Needs fixing.";
+// Test CUDA install path and GPU arch detection used by createClangInterpreter
+#ifndef CPPINTEROP_USE_CLING
+TEST_F(CUDATest, DetectCudaInstallAndArch) {
+  if (!HasSDK)
+    return;
+
+  std::string path;
+  std::vector<const char*> args;
+
+  // no args: rely on auto-detect
+  EXPECT_TRUE(compat::detectCudaInstallPath(args, path));
+  EXPECT_TRUE(llvm::StringRef(path).starts_with("/usr/local/cuda"));
+
+  // explicit path: returns cuda-12.3 if it exists, otherwise may auto-detect
+  args = {"--cuda-path=/usr/local/cuda-12.3"};
+  if (compat::detectCudaInstallPath(args, path)) {
+    if (llvm::sys::fs::is_directory("/usr/local/cuda-12.3/include"))
+      EXPECT_EQ(path, "/usr/local/cuda-12.3");
+    else
+      EXPECT_TRUE(llvm::StringRef(path).starts_with("/usr/local/cuda"));
+  }
+
+  // user provided path that doesn't exist should fail
+  args = {"--cuda-path=/nonexistent"};
+  EXPECT_FALSE(compat::detectCudaInstallPath(args, path));
+
+  // GPU offload arch detection
+  std::string arch;
+  EXPECT_TRUE(compat::detectNVPTXArch(arch));
+  EXPECT_TRUE(llvm::StringRef(arch).starts_with("sm_"));
+
+  EXPECT_TRUE(Cpp::CreateInterpreter(
+      {}, {"--cuda", "--cuda-path=/usr/local/cuda-12.3",
+           "--offload-arch=sm_70"}));
+}
 #endif
-  if (!HasCudaSDK())
-    GTEST_SKIP() << "Skipping CUDA tests as CUDA SDK not found";
+
+TEST_F(CUDATest, CUDAH) {
+  if (!HasSDK)
+    return;
 
   Cpp::CreateInterpreter({}, {"--cuda"});
-  bool success = !Cpp::Declare("#include <cuda.h>" DFLT_FALSE);
+  bool success = !Cpp::Declare("#include <cuda_runtime.h>" DFLT_FALSE);
   EXPECT_TRUE(success);
 }
 
-TEST(CUDATest, CUDARuntime) {
-#ifdef _WIN32
-  GTEST_SKIP() << "Disabled on Windows. Needs fixing.";
-#endif
-  if (!HasCudaRuntime())
-    GTEST_SKIP() << "Skipping CUDA tests as CUDA runtime not found";
-
-  EXPECT_TRUE(HasCudaRuntime());
+TEST_F(CUDATest, CUDARuntime) {
+  if (!HasRuntime)
+    return;
+  EXPECT_TRUE(HasRuntime);
 }
 
-TEST(CUDATest, Interpreter_GetLanguageCUDA) {
-#ifdef _WIN32
-  GTEST_SKIP() << "Disabled on Windows. Needs fixing.";
-#endif
-  if (!HasCudaRuntime())
-    GTEST_SKIP() << "Skipping CUDA tests as CUDA runtime not found";
+TEST_F(CUDATest, Interpreter_GetLanguageCUDA) {
+  if (!HasRuntime)
+    return;
 
-  auto* I =
-      Cpp::CreateInterpreter({}, {"-x", "cuda", "--cuda-path=/usr/local/cuda"});
-  if (!I) {
-    GTEST_SKIP() << "Skipping CUDA test as CUDA SDK not found";
-  }
+  auto* I = Cpp::CreateInterpreter({}, {"--cuda"});
+  if (!I)
+    GTEST_SKIP() << "CUDA interpreter creation failed";
   EXPECT_EQ(Cpp::GetLanguage(nullptr), Cpp::InterpreterLanguage::CUDA);
 }


### PR DESCRIPTION
Drop hardcoded CUDA arch provided to the `IncrementalCompilerBuilder` in `createClangInterpreter`. While debugging issues with the CUDA support that seems broken on master, after fixing the interpreter creation, I found that the second interpreter creation held an error in cudaGetLastError. CUDA and HIP reuse that option so it would not indicate whether the interpreter was CUDA enabled. All 4 CUDA tests pass locally with an `sm_89` device, LLVM 21