### PR TITLE
[ci] Rely on setup compiler step for gcc12, add apt-get update

### DIFF
--- a/.github/actions/Miscellaneous/Setup_Compiler/action.yml
+++ b/.github/actions/Miscellaneous/Setup_Compiler/action.yml
@@ -35,8 +35,9 @@ runs:
         # https://www.gnu.org/software/bash/manual/html_node/Shell-Parameter-Expansion.html
         vers="${compiler#*-}"
         os_codename="`cat /etc/os-release | grep UBUNTU_CODENAME | cut -d = -f 2`"
+        sudo apt-get update
         if [[ "${{ matrix.compiler }}" == *"gcc"* ]]; then
-          sudo apt install -y gcc-${vers} g++-${vers} lld
+          sudo apt-get install -y gcc-${vers} g++-${vers} lld
           echo "CC=gcc-${vers}" >> $GITHUB_ENV
           echo "CXX=g++-${vers}" >> $GITHUB_ENV
         else

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -319,8 +319,11 @@ jobs:
       if: ${{ runner.environment == 'self-hosted' }}
       shell: bash
       run: |
+        wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
+        codename="$(. /etc/os-release && echo $UBUNTU_CODENAME)"
+        echo "deb http://apt.llvm.org/${codename}/ llvm-toolchain-${codename}-${{ matrix.clang-runtime }} main" | sudo tee /etc/apt/sources.list.d/llvm.list
         sudo apt-get update
-        sudo apt-get install -y llvm-${{ matrix.clang-runtime }}-dev libclang-${{ matrix.clang-runtime }}-dev clang-${{ matrix.clang-runtime }} libzstd-dev gcc-12 g++-12
+        sudo apt-get install -y llvm-${{ matrix.clang-runtime }}-dev libclang-${{ matrix.clang-runtime }}-dev clang-${{ matrix.clang-runtime }} libpolly-${{ matrix.clang-runtime }}-dev libzstd-dev
 
     - name: Build LLVM-${{ matrix.clang-runtime }} and ${{ matrix.cling == 'On' && 'Cling' || 'Clang-REPL' }}
       if: ${{ runner.environment != 'self-hosted' }}


### PR DESCRIPTION
#864 passed the jobs on the CI but a fresh run on main hit an error with the apt installation of gcc in "Setup Compiler". This indicates that the setup is in fact stateless based on how github configures the runner, and we require the setup steps without assuming dependencies are installed. Which is more ideal.
This PR should resolve the seen issue, and drops redundant steps (update, gcc install) for the self hosted runner block (only checks llvm21) and installs dependencies.