### PR TITLE
Fix `GetLanguage` for CUDA/HIP where CXX standard was returned

### DIFF
--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -3497,6 +3497,13 @@ TInterp_t GetInterpreter() {
 InterpreterLanguage GetLanguage(TInterp_t I /*=nullptr*/) {
   compat::Interpreter* interp = &getInterp(I);
   const auto& LO = interp->getCI()->getLangOpts();
+
+  // CUDA and HIP reuse C++ language standards, so LangStd alone reports CXX.
+  if (LO.CUDA)
+    return InterpreterLanguage::CUDA;
+  if (LO.HIP)
+    return InterpreterLanguage::HIP;
+
   auto standard = clang::LangStandard::getLangStandardForKind(LO.LangStd);
   auto lang = static_cast<InterpreterLanguage>(standard.getLanguage());
   assert(lang != InterpreterLanguage::Unknown && "Unknown language");


### PR DESCRIPTION
Originally part of #866, can land as an independent change after it is merged, and should fix the test

Edit: The `GetLanguage` interface failed for CUDA/HIP where the CXX standard was returned instead because we only check `LangStd`, we should check `LangOpts` for this