### PR TITLE
[win] Fix compilation of `clang::driver::options::OPT_` for CUDA

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -380,6 +380,8 @@ endif ()
 # Fixes "C++ exception handler used, but unwind semantics are not enabled" warning Windows
 if (MSVC)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /EHsc")
+  # Required for clang::driver::options::OPT_ see https://github.com/llvm/llvm-project/issues/86028
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Zc:preprocessor")
 endif ()
 
 if (APPLE)


### PR DESCRIPTION
https://github.com/compiler-research/CppInterOp/commit/6ab18fdf3faa6c70bbe8b34d657d13dda4507b1c introduced the usage of `clang::driver::options::OPT_` to detect GPU compute capability using `clang::Driver` but this does not  compile on windows without `-Zc:preprocessor` see https://github.com/llvm/llvm-project/issues/86028
I'm confused why we didn't catch this on our CI, but this was caught on ROOT