### PR TITLE
Drop the broken suppression mechanism.

### DIFF
--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -3606,26 +3606,9 @@ void GetIncludePaths(std::vector<std::string>& IncludePaths, bool withSystem,
     IncludePaths.push_back(i);
 }
 
-namespace {
-
-class clangSilent {
-public:
-  clangSilent(clang::DiagnosticsEngine& diag) : fDiagEngine(diag) {
-    fOldDiagValue = fDiagEngine.getSuppressAllDiagnostics();
-    fDiagEngine.setSuppressAllDiagnostics(true);
-  }
-
-  ~clangSilent() { fDiagEngine.setSuppressAllDiagnostics(fOldDiagValue); }
-
-protected:
-  clang::DiagnosticsEngine& fDiagEngine;
-  bool fOldDiagValue;
-};
-} // namespace
-
 int Declare(compat::Interpreter& I, const char* code, bool silent) {
   if (silent) {
-    clangSilent diagSuppr(I.getSema().getDiagnostics());
+    // FIXME: Add a proper RAII object
     return I.declare(code);
   }
 


### PR DESCRIPTION
This suppression file tells the diagnostics engine to discard all diagnostics. Then the incremental infrastructure has no way to understand if something was ill-formed. That leads to even more subtle issues because the broken AST is not reverted but sent to CodeGen.

A proper solution should use a DiagnosticConsumer which discards the errors on the screen but does not keep the underlying infrastructure blind.
