### PR TITLE
[ci] Improve cppyy testing with requirements.txt and pytest-xdist

### DIFF
--- a/.github/actions/Build_and_Test_cppyy/action.yml
+++ b/.github/actions/Build_and_Test_cppyy/action.yml
@@ -52,7 +52,9 @@ runs:
         # Install cppyy
         git clone --depth=1 https://github.com/compiler-research/cppyy.git
         cd cppyy
+        python -m pip install --upgrade pip
         python -m pip install uv
+        python -m pip install -r requirements.txt
         python -m pip install --upgrade . --no-deps
         cd ..
 
@@ -74,14 +76,8 @@ runs:
         # Run the tests
         source .venv/bin/activate
         cd cppyy/test
-        echo ::group::Prepare For Testing
+        echo ::group::Build test dictionaries
         make all
-        python -m pip install --upgrade pip
-        python -m pip install pytest
-        python -m pip install pytest-xdist
-        if [[ "${{ matrix.python-version }}" != "3.14" ]]; then
-          python -m uv pip install numba==0.61.2
-        fi
         echo ::endgroup::
         echo ::group::Run complete test suite
         set -o pipefail


### PR DESCRIPTION
If the multithreaded pytest fails on OS X, that's a bug in our test setup. Tests should work in a standalone isolated fashion (`-k test_name`)