### PR TITLE
Rework the way we find builtins.

### DIFF
--- a/include/CppInterOp/CppInterOp.h
+++ b/include/CppInterOp/CppInterOp.h
@@ -38,6 +38,7 @@ using TCppIndex_t = size_t;
 using TCppScope_t = void*;
 using TCppConstScope_t = const void*;
 using TCppType_t = void*;
+using TCppConstType_t = const void*;
 using TCppFunction_t = void*;
 using TCppConstFunction_t = const void*;
 using TCppFuncAddr_t = void*;
@@ -368,7 +369,7 @@ CPPINTEROP_API bool IsComplete(TCppScope_t scope);
 CPPINTEROP_API size_t SizeOf(TCppScope_t scope);
 
 /// Checks if it is a "built-in" or a "complex" type.
-CPPINTEROP_API bool IsBuiltin(TCppType_t type);
+CPPINTEROP_API bool IsBuiltin(TCppConstType_t type);
 
 /// Checks if it is a templated class.
 CPPINTEROP_API bool IsTemplate(TCppScope_t handle);

--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -10,6 +10,7 @@
 #include "CppInterOp/CppInterOp.h"
 
 #include "Compatibility.h"
+#include "Sins.h" // for access to private members
 
 #include "clang/AST/Attrs.inc"
 #include "clang/AST/CXXInheritance.h"
@@ -128,6 +129,9 @@ using namespace llvm;
 struct InterpreterInfo {
   compat::Interpreter* Interpreter = nullptr;
   bool isOwned = true;
+  // Store the list of builtin types.
+  llvm::StringMap<QualType> BuiltinMap;
+
   InterpreterInfo(compat::Interpreter* I, bool Owned)
       : Interpreter(I), isOwned(Owned) {}
 
@@ -408,7 +412,7 @@ size_t SizeOf(TCppScope_t scope) {
   return 0;
 }
 
-bool IsBuiltin(TCppType_t type) {
+bool IsBuiltin(TCppConstType_t type) {
   QualType Ty = QualType::getFromOpaquePtr(type);
   if (Ty->isBuiltinType() || Ty->isAnyComplexType())
     return true;
@@ -1887,69 +1891,109 @@ TCppType_t AddTypeQualifier(TCppType_t type, QualKind qual) {
   return QT.getAsOpaquePtr();
 }
 
-// Internal functions that are not needed outside the library are
-// encompassed in an anonymous namespace as follows. This function converts
-// from a string to the actual type. It is used in the GetType() function.
-namespace {
-static QualType findBuiltinType(llvm::StringRef typeName, ASTContext& Context) {
-  bool issigned = false;
-  bool isunsigned = false;
-  if (typeName.starts_with("signed ")) {
-    issigned = true;
-    typeName = StringRef(typeName.data() + 7, typeName.size() - 7);
-  }
-  if (!issigned && typeName.starts_with("unsigned ")) {
-    isunsigned = true;
-    typeName = StringRef(typeName.data() + 9, typeName.size() - 9);
-  }
-  if (typeName == "char") {
-    if (isunsigned)
-      return Context.UnsignedCharTy;
-    return Context.SignedCharTy;
-  }
-  if (typeName == "short") {
-    if (isunsigned)
-      return Context.UnsignedShortTy;
-    return Context.ShortTy;
-  }
-  if (typeName == "int") {
-    if (isunsigned)
-      return Context.UnsignedIntTy;
-    return Context.IntTy;
-  }
-  if (typeName == "long") {
-    if (isunsigned)
-      return Context.UnsignedLongTy;
-    return Context.LongTy;
-  }
-  if (typeName == "long long") {
-    if (isunsigned)
-      return Context.UnsignedLongLongTy;
-    return Context.LongLongTy;
-  }
-  if (!issigned && !isunsigned) {
-    if (typeName == "bool")
-      return Context.BoolTy;
-    if (typeName == "float")
-      return Context.FloatTy;
-    if (typeName == "double")
-      return Context.DoubleTy;
-    if (typeName == "long double")
-      return Context.LongDoubleTy;
+// Registers all permutations of a word set
+static void RegisterPerms(llvm::StringMap<QualType>& Map, QualType QT,
+                          llvm::SmallVectorImpl<llvm::StringRef>& Words) {
+  std::sort(Words.begin(), Words.end());
+  do {
+    std::string Key;
+    for (size_t i = 0; i < Words.size(); ++i) {
+      if (i > 0)
+        Key += ' ';
+      Key += Words[i].str();
+    }
+    Map[Key] = QT;
+  } while (std::next_permutation(Words.begin(), Words.end()));
+}
+ALLOW_ACCESS(ASTContext, Types, llvm::SmallVector<clang::Type*, 0>);
+static void PopulateBuiltinMap(ASTContext& Context) {
+  const PrintingPolicy Policy(Context.getLangOpts());
+  auto& BuiltinMap = sInterpreters->back().BuiltinMap;
+  const auto& Types = ACCESS(Context, Types);
 
-    if (typeName == "wchar_t")
-      return Context.WCharTy;
-    if (typeName == "char16_t")
-      return Context.Char16Ty;
-    if (typeName == "char32_t")
-      return Context.Char32Ty;
+  for (clang::Type* T : Types) {
+    auto* BT = llvm::dyn_cast<BuiltinType>(T);
+    if (!BT || BT->isPlaceholderType())
+      continue;
+
+    QualType QT(BT, 0);
+    std::string Name = QT.getAsString(Policy);
+    if (Name.empty() || Name[0] == '<')
+      continue;
+
+    // Initial entry (e.g., "int", "unsigned long")
+    BuiltinMap[Name] = QT;
+
+    llvm::SmallVector<llvm::StringRef, 4> Words;
+    llvm::StringRef(Name).split(Words, ' ', -1, false);
+
+    bool hasInt = false;
+    bool hasSigned = false;
+    bool hasUnsigned = false;
+    bool hasChar = false;
+    bool isModifiable = false;
+
+    for (auto W : Words) {
+      if (W == "int")
+        hasInt = true;
+      else if (W == "signed")
+        hasSigned = true;
+      else if (W == "unsigned")
+        hasUnsigned = true;
+      else if (W == "char")
+        hasChar = true;
+
+      if (W == "long" || W == "short" || hasInt)
+        isModifiable = true;
+    }
+
+    // Skip things like 'float' or 'double' that aren't combined
+    if (!isModifiable && !hasUnsigned && !hasSigned)
+      continue;
+
+    // Register base permutations (e.g., "long long" or "unsigned int")
+    if (Words.size() > 1)
+      RegisterPerms(BuiltinMap, QT, Words);
+
+    // Expansion: Add "int" suffix where missing (e.g., "short" -> "short int")
+    if (!hasInt && !hasChar) {
+      auto WithInt = Words;
+      WithInt.push_back("int");
+      RegisterPerms(BuiltinMap, QT, WithInt);
+
+      // If we are adding 'int', we should also try adding 'signed'
+      // to cover cases like "short" -> "signed short int"
+      if (!hasSigned && !hasUnsigned) {
+        auto WithBoth = WithInt;
+        WithBoth.push_back("signed");
+        RegisterPerms(BuiltinMap, QT, WithBoth);
+      }
+    }
+
+    // Expansion: Add "signed" prefix
+    // (e.g., "int" -> "signed int", "long" -> "signed long")
+    if (!hasSigned && !hasUnsigned) {
+      auto WithSigned = Words;
+      WithSigned.push_back("signed");
+      RegisterPerms(BuiltinMap, QT, WithSigned);
+    }
   }
-  /* Missing
- CanQualType WideCharTy; // Same as WCharTy in C++, integer type in C99.
- CanQualType WIntTy;   // [C99 7.24.1], integer type unchanged by default
- promotions.
-   */
-  return QualType();
+
+  // Explicit global synonym
+  BuiltinMap["signed"] = Context.IntTy;
+  BuiltinMap["unsigned"] = Context.UnsignedIntTy;
+}
+static QualType findBuiltinType(llvm::StringRef typeName, ASTContext& Context) {
+  llvm::StringMap<QualType>& BuiltinMap = sInterpreters->back().BuiltinMap;
+  if (BuiltinMap.empty())
+    PopulateBuiltinMap(Context);
+
+  // Fast Lookup
+  auto It = BuiltinMap.find(typeName);
+  if (It != BuiltinMap.end())
+    return It->second;
+
+  return QualType(); // Return null if not a builtin
 }
 static std::optional<QualType> GetTypeInternal(Decl* D) {
   if (!D)
@@ -1967,7 +2011,6 @@ static std::optional<QualType> GetTypeInternal(Decl* D) {
 
   return {};
 }
-} // namespace
 
 TCppType_t GetType(const std::string& name) {
   QualType builtin = findBuiltinType(name, getASTContext());

--- a/lib/CppInterOp/Sins.h
+++ b/lib/CppInterOp/Sins.h
@@ -1,0 +1,28 @@
+#ifndef LIB_CPPINTEROP_SINS_H
+#define LIB_CPPINTEROP_SINS_H
+
+/// Standard-protected facility allowing access into private members in C++.
+/// Use with caution!
+// NOLINTBEGIN(cppcoreguidelines-macro-usage)
+#define CONCATE_(X, Y) X##Y
+#define CONCATE(X, Y) CONCATE_(X, Y)
+#define ALLOW_ACCESS(CLASS, MEMBER, ...)                                       \
+  template <typename Only, __VA_ARGS__ CLASS::*Member>                         \
+  struct CONCATE(MEMBER, __LINE__) {                                           \
+    friend __VA_ARGS__ CLASS::*Access(Only*) { return Member; }                \
+  };                                                                           \
+  template <typename> struct Only_##MEMBER;                                    \
+  template <> struct Only_##MEMBER<CLASS> {                                    \
+    friend __VA_ARGS__ CLASS::*Access(Only_##MEMBER<CLASS>*);                  \
+  };                                                                           \
+  template struct CONCATE(MEMBER,                                              \
+                          __LINE__)<Only_##MEMBER<CLASS>, &CLASS::MEMBER>
+
+#define ACCESS(OBJECT, MEMBER)                                                 \
+  (OBJECT).*                                                                   \
+      Access(                                                                  \
+          (Only_##MEMBER<std::remove_reference_t<decltype(OBJECT)>>*)nullptr)
+
+// NOLINTEND(cppcoreguidelines-macro-usage)
+
+#endif // LIB_CPPINTEROP_SINS_H

--- a/lib/CppInterOp/exports.ld
+++ b/lib/CppInterOp/exports.ld
@@ -54,3 +54,4 @@
 -Wl,--export=_ZN4llvm15SmallVectorBaseIjE8set_sizeEm
 -Wl,--export=_ZN5clang11Interpreter6createENSt3__210unique_ptrINS_16CompilerInstanceENS1_14default_deleteIS3_EEEENS2_IN4llvm3orc12LLJITBuilderENS4_IS9_EEEE
 -Wl,--export=_ZNK5clang13CXXRecordDecl19isInjectedClassNameEv
+-Wl,--export=_ZNK5clang8QualType11getAsStringERKNS_14PrintingPolicyE

--- a/unittests/CppInterOp/ScopeReflectionTest.cpp
+++ b/unittests/CppInterOp/ScopeReflectionTest.cpp
@@ -4,18 +4,16 @@
 #include "clang-c/CXCppInterOp.h"
 
 #include "clang/AST/ASTContext.h"
-#include "clang/Basic/Version.h"
-#include "clang/Frontend/CompilerInstance.h"
-#include "clang/Sema/Sema.h"
-
 #include "clang/AST/ASTDumper.h"
 #include "clang/AST/Decl.h"
 #include "clang/AST/DeclBase.h"
 #include "clang/AST/GlobalDecl.h"
+#include "clang/AST/Type.h"
+#include "clang/Basic/Version.h"
+#include "clang/Frontend/CompilerInstance.h"
+#include "clang/Sema/Sema.h"
 
 #include "llvm/Support/Valgrind.h"
-
-#include "clang-c/CXCppInterOp.h"
 
 #include "gtest/gtest.h"
 
@@ -24,6 +22,98 @@
 using namespace TestUtils;
 using namespace llvm;
 using namespace clang;
+
+TYPED_TEST(CPPINTEROP_TEST_MODE, ScopeReflection_GetTypeOfBuiltins) {
+  // Structural check: Ensure every valid BuiltinType kind can be resolved
+  TestFixture::CreateInterpreter();
+  ASTContext& C = Interp->getCI()->getASTContext(); // for brevity
+
+#define BUILTIN_TYPE(Id, SingletonId)                                          \
+  {                                                                            \
+    QualType QT = C.SingletonId;                                               \
+    if (!QT.isNull()) {                                                        \
+      std::string name = QT.getAsString(C.getPrintingPolicy());                \
+      if (name[0] != '<' && !QT->isPlaceholderType()) {                        \
+        const auto* FoundTy = Cpp::GetType(name);                              \
+        EXPECT_TRUE(FoundTy) << "Failed to find builtin: '" << name << "'";    \
+        if (FoundTy) {                                                         \
+          EXPECT_EQ(FoundTy, QT.getAsOpaquePtr())                              \
+              << "Type mismatch for '" << name << "'";                         \
+          EXPECT_TRUE(Cpp::IsBuiltin(FoundTy));                                \
+        }                                                                      \
+      }                                                                        \
+    }                                                                          \
+  }
+#include "clang/AST/BuiltinTypes.def"
+#undef BUILTIN_TYPE
+
+  auto Verify = [&](const char* Name, QualType Expected) {
+    void* Found = Cpp::GetType(Name);
+    EXPECT_EQ(Found, Expected.getAsOpaquePtr()) << "Failed for: " << Name;
+  };
+
+  // --- Integer Variations ---
+  Verify("int", C.IntTy);
+  Verify("signed int", C.IntTy);
+  Verify("signed", C.IntTy);
+  Verify("int signed", C.IntTy);
+
+  // --- Short Variations ---
+  Verify("short", C.ShortTy);
+  Verify("short int", C.ShortTy);
+  Verify("signed short", C.ShortTy);
+  Verify("signed short int", C.ShortTy);
+  Verify("int short signed", C.ShortTy);
+
+  // --- Long Variations ---
+  Verify("long", C.LongTy);
+  Verify("long int", C.LongTy);
+  Verify("signed long", C.LongTy);
+  Verify("signed long int", C.LongTy);
+  Verify("int long", C.LongTy);
+
+  // --- Long Long Variations ---
+  Verify("long long", C.LongLongTy);
+  Verify("long long int", C.LongLongTy);
+  Verify("signed long long", C.LongLongTy);
+  Verify("signed long long int", C.LongLongTy);
+  Verify("int long long signed", C.LongLongTy);
+
+  // --- Unsigned Variations ---
+  Verify("unsigned", C.UnsignedIntTy);
+  Verify("unsigned int", C.UnsignedIntTy);
+  Verify("int unsigned", C.UnsignedIntTy);
+
+  Verify("unsigned short", C.UnsignedShortTy);
+  Verify("unsigned short int", C.UnsignedShortTy);
+  Verify("int short unsigned", C.UnsignedShortTy);
+
+  Verify("unsigned long", C.UnsignedLongTy);
+  Verify("unsigned long int", C.UnsignedLongTy);
+
+  Verify("unsigned long long", C.UnsignedLongLongTy);
+  Verify("unsigned long long int", C.UnsignedLongLongTy);
+
+  // --- Character Variations (No 'int' suffix allowed) ---
+  Verify("char", C.CharTy);
+  Verify("signed char", C.SignedCharTy);
+  Verify("unsigned char", C.UnsignedCharTy);
+
+  // Negative check: signed char int is NOT a valid builtin
+  EXPECT_EQ(Cpp::GetType("signed char int"), nullptr);
+
+  // Maybe these should be considered builtins?
+  // EXPECT_EQ(Cpp::GetType("size_t"), C.getSizeType().getAsOpaquePtr());
+  // EXPECT_EQ(Cpp::GetType("ptrdiff_t"),
+  // C.getPointerDiffType().getAsOpaquePtr());
+  // EXPECT_EQ(Cpp::GetType("intptr_t"), C.getIntPtrType().getAsOpaquePtr());
+  // EXPECT_EQ(Cpp::GetType("uintptr_t"), C.getUIntPtrType().getAsOpaquePtr());
+  // EXPECT_EQ(Cpp::GetType("size_t"), C.getSizeType().getAsOpaquePtr());
+  // EXPECT_EQ(Cpp::GetType("size_t"), C.getSizeType().getAsOpaquePtr());
+
+  // EXPECT_EQ(Cpp::GetType("wint_t"), C.WIntTy.getAsOpaquePtr());
+  // EXPECT_EQ(Cpp::GetType("wchar_t"), C.WCharTy.getAsOpaquePtr());
+}
 
 TYPED_TEST(CPPINTEROP_TEST_MODE, ScopeReflection_GetTypeOfTypedef) {
   std::string code = R"(


### PR DESCRIPTION
The builtin types can be platform- and target-dependent (see ASTContext::InitBuiltinTypes). The new approach iterates over all registered builtin types and adds their string representation to a map which can be searched efficiently.
