### PR TITLE
Suppress llvm_shutdown for external-interpreter clients.

### DIFF
--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -65,6 +65,7 @@
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/FileSystem.h"
+#include "llvm/Support/InitLLVM.h"
 #include "llvm/Support/ManagedStatic.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/Process.h"
@@ -174,18 +175,43 @@ struct InterpreterInfo {
 };
 
 static void DefaultProcessCrashHandler(void*);
+
+/// True if an external (unowned) interpreter has been registered.
+/// When set, CppInterOp must not call llvm_shutdown — the client owns LLVM.
+static bool HasExternalInterpreter = false;
+
+/// RAII guard that destroys all owned interpreters and optionally calls
+/// llvm_shutdown at process exit. Constructed as a function-local static
+/// inside GetInterpreters().
+struct InterpreterCleanup {
+  std::deque<InterpreterInfo>* Interps;
+  explicit InterpreterCleanup(std::deque<InterpreterInfo>* I) : Interps(I) {}
+  ~InterpreterCleanup() {
+    if (!Interps)
+      return;
+    // Destroy owned interpreters in reverse order. External (unowned)
+    // interpreters are the client's responsibility.
+    while (!Interps->empty()) {
+      if (!Interps->back().isOwned) {
+        Interps->pop_back();
+        continue;
+      }
+      Interps->pop_back(); // ~InterpreterInfo deletes owned interpreters
+    }
+    CppInterOp::Tracing::TraceInfo::TheTraceInfo = nullptr;
+
+    // Only shut down LLVM if we own it (no external interpreter).
+    if (!HasExternalInterpreter)
+      llvm::llvm_shutdown();
+  }
+};
+
 // Function-static storage for interpreters
 static std::deque<InterpreterInfo>& GetInterpreters() {
-  // static int FakeArgc = 1;
-  // static const std::string VersionStr = GetVersion();
-  // static const char* ArgvBuffer[] = {VersionStr.c_str(), nullptr};
-  // static const char** FakeArgv = ArgvBuffer;
-  // static llvm::InitLLVM X(FakeArgc, FakeArgv);
-  // Cannot be a llvm::ManagedStatic because X will call shutdown which will
-  // trigger destruction on llvm::ManagedStatics and the destruction of the
-  // InterpreterInfos require to have llvm around.
-  // FIXME: Currently we never call llvm::llvm_shutdown and sInterpreters leaks.
-  static llvm::ManagedStatic<std::deque<InterpreterInfo>> sInterpreters;
+  // Intentionally heap-allocated so it outlives the cleanup guard.
+  // The guard drains it; the pointer itself leaks (harmless).
+  static auto sInterpreters = new std::deque<InterpreterInfo>();
+  static InterpreterCleanup Cleanup(sInterpreters);
   static std::once_flag ProcessInitialized;
   std::call_once(ProcessInitialized, []() {
     llvm::sys::PrintStackTraceOnErrorSignal("CppInterOp");
@@ -200,9 +226,10 @@ static std::deque<InterpreterInfo>& GetInterpreters() {
     llvm::InitializeAllAsmParsers();
     llvm::InitializeAllAsmPrinters();
 
+    llvm::sys::SetOneShotPipeSignalFunction(
+        llvm::sys::DefaultOneShotPipeSignalHandler);
     llvm::sys::AddSignalHandler(DefaultProcessCrashHandler, /*Cookie=*/nullptr);
-
-    // std::atexit(llvm::llvm_shutdown);
+    llvm::install_out_of_memory_new_handler();
   });
 
   return *sInterpreters;
@@ -250,6 +277,21 @@ static void DefaultProcessCrashHandler(void*) {
 
 static void RegisterInterpreter(compat::Interpreter* I, bool Owned) {
   std::deque<InterpreterInfo>& Interps = GetInterpreters();
+
+  // When adding a second (or later) interpreter, eagerly materialize the
+  // deinit runtime symbols (__lljit_run_atexits) for all existing ones.
+  // This ensures that deinitialize() during shutdown does not trigger lazy
+  // JIT compilation — by that point LLVM globals (e.g. TargetLibraryInfoImpl)
+  // may already be destroyed.
+#if !defined(CPPINTEROP_USE_CLING) && !defined(EMSCRIPTEN)
+  if (!Interps.empty()) {
+    for (auto& Info : Interps) {
+      if (Info.Interpreter)
+        (void)Info.Interpreter->getAddressOfGlobal("__lljit_run_atexits");
+    }
+  }
+#endif
+
   Interps.emplace_back(I, Owned);
 }
 
@@ -273,6 +315,7 @@ TInterp_t GetInterpreter() {
 void UseExternalInterpreter(TInterp_t I) {
   INTEROP_TRACE(I);
   assert(GetInterpreters().empty() && "sInterpreter already in use!");
+  HasExternalInterpreter = true;
   RegisterInterpreter(static_cast<compat::Interpreter*>(I), /*Owned=*/false);
   return INTEROP_VOID_RETURN();
 }

--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -187,18 +187,33 @@ struct InterpreterInfo {
 };
 
 static void DefaultProcessCrashHandler(void*);
+
+/// Set by UseExternalInterpreter to suppress llvm_shutdown at process exit
+/// -- the client owns LLVM in that case.
+static bool SkipShutDown = false;
+
+/// RAII guard whose dtor calls llvm_shutdown for the owned-interpreter case.
+/// Constructed as a function-local static AFTER sInterpreters, so its dtor
+/// fires FIRST (reverse-of-construction); llvm_shutdown then drains the
+/// ManagedStatic registry, including sInterpreters, deterministically.
+/// The llvm_shutdown call itself is gated on LLVM 23+, where
+/// Platform::lookupResolvedInitSymbols (llvm/llvm-project#196874) makes
+/// ~Interpreter's JIT deinit skip lazy materialization. On older LLVM
+/// the same chain SEGFAULTs in cleanUp against destroyed function-local
+/// statics, so the dtor is a no-op and sInterpreters leaks instead.
+struct InterpreterShutdown {
+  ~InterpreterShutdown() {
+    if (!SkipShutDown) {
+#if LLVM_VERSION_MAJOR > 22
+      llvm::llvm_shutdown();
+#endif
+    }
+  }
+};
+
 // Function-static storage for interpreters
 static std::deque<InterpreterInfo>&
 GetInterpreters(bool SetCrashHandler = true) {
-  // static int FakeArgc = 1;
-  // static const std::string VersionStr = GetVersion();
-  // static const char* ArgvBuffer[] = {VersionStr.c_str(), nullptr};
-  // static const char** FakeArgv = ArgvBuffer;
-  // static llvm::InitLLVM X(FakeArgc, FakeArgv);
-  // Cannot be a llvm::ManagedStatic because X will call shutdown which will
-  // trigger destruction on llvm::ManagedStatics and the destruction of the
-  // InterpreterInfos require to have llvm around.
-  // FIXME: Currently we never call llvm::llvm_shutdown and sInterpreters leaks.
   static llvm::ManagedStatic<std::deque<InterpreterInfo>> sInterpreters;
   static std::once_flag ProcessInitialized;
   std::call_once(ProcessInitialized, [SetCrashHandler]() {
@@ -215,12 +230,20 @@ GetInterpreters(bool SetCrashHandler = true) {
     llvm::InitializeAllAsmParsers();
     llvm::InitializeAllAsmPrinters();
 
-    if (SetCrashHandler)
+    // Pipe / OOM / crash handlers replicate what InitLLVM did before it was
+    // dropped. Skipped when the host owns LLVM -- they're its decision.
+    if (SetCrashHandler) {
+      llvm::sys::SetOneShotPipeSignalFunction(
+          llvm::sys::DefaultOneShotPipeSignalHandler);
       llvm::sys::AddSignalHandler(DefaultProcessCrashHandler,
                                   /*Cookie=*/nullptr);
-
-    // std::atexit(llvm::llvm_shutdown);
+      llvm::install_out_of_memory_new_handler();
+    }
   });
+
+  // Constructed after sInterpreters above, so its dtor fires first at
+  // process exit; see InterpreterShutdown.
+  static InterpreterShutdown Shutdown;
 
   return *sInterpreters;
 }
@@ -299,6 +322,7 @@ TInterp_t GetInterpreter() {
 void UseExternalInterpreter(TInterp_t I) {
   INTEROP_TRACE(I);
   assert(GetInterpreters(false).empty() && "sInterpreter already in use!");
+  SkipShutDown = true;
   RegisterInterpreter(static_cast<compat::Interpreter*>(I), /*Owned=*/false);
   return INTEROP_VOID_RETURN();
 }

--- a/unittests/CppInterOp/InterpreterTest.cpp
+++ b/unittests/CppInterOp/InterpreterTest.cpp
@@ -119,6 +119,51 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, Interpreter_DeleteInterpreter) {
   EXPECT_EQ(I2, Cpp::GetInterpreter()) << "I2 is not active";
 }
 
+TYPED_TEST(CPPINTEROP_TEST_MODE, Interpreter_StaticDtorsRunOnDelete) {
+#ifdef EMSCRIPTEN
+  GTEST_SKIP() << "Test fails for Emscripten builds";
+#endif
+  if (TypeParam::isOutOfProcess)
+    GTEST_SKIP() << "Test fails for OOP JIT builds";
+
+  auto* I = TestFixture::CreateInterpreter();
+  ASSERT_NE(I, nullptr);
+
+  // Declare a flag and a struct whose destructor sets it.
+  Cpp::Declare(R"(
+    int dtor_flag = 0;
+    struct DtorProbe { ~DtorProbe() { dtor_flag = 1; } };
+  )",
+               I);
+
+  // Create a static instance so its destructor is registered with atexit.
+  Cpp::Process("static DtorProbe probe;");
+
+  // Use a host-side flag that survives interpreter deletion.
+  // The JIT code writes to this address via a pointer we inject.
+  static int HostFlag = 0;
+  std::string inject = "extern \"C\" void* dtor_sink = (void*)" +
+                       std::to_string(reinterpret_cast<uintptr_t>(&HostFlag)) +
+                       ";";
+  Cpp::Declare(inject.c_str(), I);
+  Cpp::Declare(R"(
+    struct DtorNotify {
+      ~DtorNotify() { *static_cast<int*>(dtor_sink) = 1; }
+    };
+  )",
+               I);
+  Cpp::Process("static DtorNotify notify;");
+
+  EXPECT_EQ(HostFlag, 0) << "Flag should be 0 before destructor runs";
+
+  // Delete the interpreter — this should run JIT static destructors.
+  Cpp::DeleteInterpreter(I);
+
+  EXPECT_EQ(HostFlag, 1)
+      << "Static destructor did not run during DeleteInterpreter. "
+         "JIT atexit handlers are likely not being executed.";
+}
+
 TYPED_TEST(CPPINTEROP_TEST_MODE, Interpreter_ActivateInterpreter) {
 #ifdef EMSCRIPTEN_STATIC_LIBRARY
   GTEST_SKIP() << "Test fails for Emscipten static library build";
@@ -407,6 +452,12 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, Interpreter_GetLanguageStandardGNU) {
   EXPECT_EQ(Cpp::GetLanguageStandard(nullptr),
             Cpp::InterpreterLanguageStandard::gnucxx17);
 }
+
+// Note: UseExternalInterpreter's effect on llvm_shutdown is tested
+// indirectly by the existing Interpreter_ExternalInterpreter test.
+// UseExternalInterpreter sets an internal flag that prevents
+// llvm_shutdown from being called at process exit, ensuring the
+// client's LLVM infrastructure remains intact.
 
 TYPED_TEST(CPPINTEROP_TEST_MODE, Interpreter_ExternalInterpreter) {
 

--- a/unittests/CppInterOp/InterpreterTest.cpp
+++ b/unittests/CppInterOp/InterpreterTest.cpp
@@ -27,6 +27,7 @@
 
 #include <algorithm>
 #include <csignal>
+#include <cstdlib>
 
 using ::testing::StartsWith;
 
@@ -147,6 +148,74 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, Interpreter_DeleteInterpreter) {
 
   EXPECT_TRUE(Cpp::DeleteInterpreter(I1));
   EXPECT_EQ(I2, Cpp::GetInterpreter()) << "I2 is not active";
+}
+
+TYPED_TEST(CPPINTEROP_TEST_MODE, Interpreter_StaticDtorsRunOnDelete) {
+#ifdef EMSCRIPTEN
+  GTEST_SKIP() << "Test fails for Emscripten builds";
+#endif
+  if (TypeParam::isOutOfProcess)
+    GTEST_SKIP() << "Test fails for OOP JIT builds";
+
+  auto* I = TestFixture::CreateInterpreter();
+  ASSERT_NE(I, nullptr);
+
+  // Host-side flag the JIT writes to; survives the interpreter deletion
+  // that frees JIT memory. Reset explicitly for --gtest_repeat.
+  static int HostFlag;
+  HostFlag = 0;
+  std::string Inject = "extern \"C\" void* dtor_sink = (void*)" +
+                       std::to_string(reinterpret_cast<uintptr_t>(&HostFlag)) +
+                       ";";
+  Cpp::Declare(Inject.c_str(), I);
+  Cpp::Declare(R"(
+    struct DtorNotify { ~DtorNotify() { *static_cast<int*>(dtor_sink) = 1; } };
+  )",
+               I);
+  Cpp::Process("static DtorNotify notify;");
+
+  EXPECT_EQ(HostFlag, 0);
+  Cpp::DeleteInterpreter(I);
+  EXPECT_EQ(HostFlag, 1) << "JIT static dtor did not run on DeleteInterpreter";
+}
+
+// Mirrors clang/unittests/Interpreter/InterpreterTest.cpp's
+// ShutdownDoesNotMaterializeAgainstDestroyedGlobals at the CppInterOp
+// wrapper level: two interpreters each register a static with a
+// non-trivial dtor, then std::exit drives the C++ static-dtor phase.
+// On LLVM 23+ our InterpreterShutdown calls llvm_shutdown which fires
+// ~InterpreterInfo -> ~Interpreter -> JIT deinit; the deinit lookup
+// skips lazy materialization (Platform::lookupResolvedInitSymbols,
+// llvm/llvm-project#196874) and the process exits cleanly.
+//
+// Skipped on older LLVM: InterpreterShutdown's llvm_shutdown call is
+// gated out (we leak instead of risking the JIT cleanUp crash), and
+// driving the chain manually from the test deadlocks rather than
+// crashing cleanly through the compat layer. The crash contract is
+// pinned upstream by clang's
+// ShutdownDoesNotMaterializeAgainstDestroyedGlobals test.
+TYPED_TEST(CPPINTEROP_TEST_MODE,
+           Interpreter_ShutdownDoesNotMaterializeAgainstDestroyedGlobals) {
+#ifdef EMSCRIPTEN
+  GTEST_SKIP() << "Test fails for Emscripten builds";
+#endif
+  if (TypeParam::isOutOfProcess)
+    GTEST_SKIP() << "Test fails for OOP JIT builds";
+#if LLVM_VERSION_MAJOR <= 22
+  GTEST_SKIP() << "Requires LLVM 23+ (lookupResolvedInitSymbols)";
+#else
+  EXPECT_EXIT(
+      {
+        auto* I1 = TestFixture::CreateInterpreter();
+        auto* I2 = TestFixture::CreateInterpreter();
+        Cpp::ActivateInterpreter(I1);
+        Cpp::Process("struct S1 { S1() {} ~S1() {} }; static S1 s1;");
+        Cpp::ActivateInterpreter(I2);
+        Cpp::Process("struct S2 { S2() {} ~S2() {} }; static S2 s2;");
+        std::exit(0);
+      },
+      ::testing::ExitedWithCode(0), "");
+#endif
 }
 
 TYPED_TEST(CPPINTEROP_TEST_MODE, Interpreter_ActivateInterpreter) {


### PR DESCRIPTION
sInterpreters used to leak across process exit (FIXME-documented). Add an InterpreterShutdown RAII guard that drains it via `llvm_shutdown`, and a `SkipShutDown` flag that `UseExternalInterpreter` sets to suppress the call -- otherwise a CppInterOp-managed exit would tear down the host's LLVM. The guard is declared after `sInterpreters` in `GetInterpreters` so its dtor fires first in the static-dtor phase (LIFO), giving llvm_shutdown live LLVM globals to work against.

The `llvm_shutdown` call itself is gated on LLVM_VERSION_MAJOR > 22. That is the version with `Platform::lookupResolvedInitSymbols` (https://github.com/llvm/llvm-project/pull/196874), which makes ~Interpreter's JIT deinit skip lazy materialization; older LLVM SEGFAULTs in cleanUp against destroyed function-local statics, so the dtor stays a no-op and `sInterpreters` keeps leaking instead.

Also restore the pipe / OOM / crash handlers lost when InitLLVM was dropped (skipped for external interpreters -- those decisions belong to the host). Tests pin JIT static dtors fire on `Cpp::DeleteInterpreter`, and mirror clang's `ShutdownDoesNotMaterializeAgainstDestroyedGlobals` gated on LLVM 23+.