### PR TITLE
Only build Emscripten static library for nightly build (speeds up Emscripten development for PRs)

### DIFF
--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -27,7 +27,7 @@ jobs:
             llvm_enable_projects: "clang;lld"
             llvm_targets_to_build: "WebAssembly"
             emsdk_ver: "4.0.9"
-            build_static_library: On
+            build_static_library: ${{ github.event_name == 'schedule' && 'On' || 'Off' }}
             micromamba_shell_init: bash
             run-in-prs: true
           - name: osx26-arm-clang-repl-21-emscripten
@@ -36,7 +36,7 @@ jobs:
             llvm_enable_projects: "clang;lld"
             llvm_targets_to_build: "WebAssembly"
             emsdk_ver: "4.0.9"
-            build_static_library: On
+            build_static_library: ${{ github.event_name == 'schedule' && 'On' || 'Off' }}
             micromamba_shell_init: bash
           - name: ubu24-x86-clang-repl-21-emscripten
             os: ubuntu-24.04
@@ -44,7 +44,7 @@ jobs:
             llvm_enable_projects: "clang;lld"
             llvm_targets_to_build: "WebAssembly"
             emsdk_ver: "4.0.9"
-            build_static_library: On
+            build_static_library: ${{ github.event_name == 'schedule' && 'On' || 'Off' }}
             micromamba_shell_init: bash
           - name: win2025-x86-clang-repl-21-emscripten
             os: windows-2025
@@ -52,7 +52,7 @@ jobs:
             llvm_enable_projects: "clang;lld"
             llvm_targets_to_build: "WebAssembly"
             emsdk_ver: "4.0.9"
-            build_static_library: On
+            build_static_library: ${{ github.event_name == 'schedule' && 'On' || 'Off' }}
             micromamba_shell_init: powershell
 
     steps:


### PR DESCRIPTION
If it works, this should mean that the Emscripten static library is only tested for nightly builds. This feels likely to be ok, since we only have one test failing for the static build which passes for the shared library build. The static library build is much more compute intensive, since linking the static library to the test executables takes a long time. This should help further alleviate the bottleneck the Emscripten ci has posed on development.