### PR TITLE
Move wrapper caches from function-local statics to per-interpreter storage

### DIFF
--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -138,6 +138,10 @@ struct InterpreterInfo {
   bool isOwned = true;
   // Store the list of builtin types.
   llvm::StringMap<QualType> BuiltinMap;
+  // Per-interpreter wrapper caches. Keyed on AST nodes that belong to this
+  // interpreter, so the caches must be destroyed together with it.
+  std::map<const FunctionDecl*, void*> WrapperStore;
+  std::map<const Decl*, void*> DtorWrapperStore;
 
   InterpreterInfo(compat::Interpreter* I, bool Owned)
       : Interpreter(I), isOwned(Owned) {}
@@ -253,13 +257,22 @@ static void RegisterInterpreter(compat::Interpreter* I, bool Owned) {
   Interps.emplace_back(I, Owned);
 }
 
-static compat::Interpreter& getInterp(TInterp_t I = nullptr) {
-  if (I)
-    return *static_cast<compat::Interpreter*>(I);
+static InterpreterInfo& getInterpInfo(compat::Interpreter* I = nullptr) {
   auto& Interps = GetInterpreters();
   assert(!Interps.empty() &&
          "Interpreter instance must be set before calling this!");
-  return *Interps.back().Interpreter;
+  if (I) {
+    for (auto& Info : Interps)
+      if (Info.Interpreter == I)
+        return Info;
+  }
+  return Interps.back();
+}
+
+static compat::Interpreter& getInterp(TInterp_t I = nullptr) {
+  if (I)
+    return *static_cast<compat::Interpreter*>(I);
+  return *getInterpInfo().Interpreter;
 }
 
 TInterp_t GetInterpreter() {
@@ -3335,10 +3348,10 @@ int get_wrapper_code(compat::Interpreter& I, const FunctionDecl* FD,
 
 JitCall::GenericCall make_wrapper(compat::Interpreter& I,
                                   const FunctionDecl* FD) {
-  static std::map<const FunctionDecl*, void*> gWrapperStore;
+  auto& WrapperStore = getInterpInfo(&I).WrapperStore;
 
-  auto R = gWrapperStore.find(FD);
-  if (R != gWrapperStore.end())
+  auto R = WrapperStore.find(FD);
+  if (R != WrapperStore.end())
     return (JitCall::GenericCall)R->second;
 
   std::string wrapper_name;
@@ -3375,7 +3388,7 @@ JitCall::GenericCall make_wrapper(compat::Interpreter& I,
   void* wrapper =
       compile_wrapper(I, wrapper_name, wrapper_code, withAccessControl);
   if (wrapper) {
-    gWrapperStore.insert(std::make_pair(FD, wrapper));
+    WrapperStore.insert(std::make_pair(FD, wrapper));
   } else {
     llvm::errs() << "TClingCallFunc::make_wrapper"
                  << ":"
@@ -3445,10 +3458,10 @@ static JitCall::DestructorCall make_dtor_wrapper(compat::Interpreter& interp,
   //
   //--
 
-  static std::map<const Decl*, void*> gDtorWrapperStore;
+  auto& DtorWrapperStore = getInterpInfo(&interp).DtorWrapperStore;
 
-  auto I = gDtorWrapperStore.find(D);
-  if (I != gDtorWrapperStore.end())
+  auto I = DtorWrapperStore.find(D);
+  if (I != DtorWrapperStore.end())
     return (JitCall::DestructorCall)I->second;
 
   //
@@ -3549,7 +3562,7 @@ static JitCall::DestructorCall make_dtor_wrapper(compat::Interpreter& interp,
   void* F = compile_wrapper(interp, wrapper_name, wrapper,
                             /*withAccessControl=*/false);
   if (F) {
-    gDtorWrapperStore.insert(std::make_pair(D, F));
+    DtorWrapperStore.insert(std::make_pair(D, F));
   } else {
     llvm::errs() << "make_dtor_wrapper"
                  << "Failed to compile\n"

--- a/unittests/CppInterOp/InterpreterTest.cpp
+++ b/unittests/CppInterOp/InterpreterTest.cpp
@@ -508,3 +508,50 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, SignalHandler_MultipleInterpreters) {
   EXPECT_DEATH({ raise(SIGSEGV); }, ExpectedMsg);
 }
 #endif // GTEST_HAS_DEATH_TEST
+
+#ifndef EMSCRIPTEN
+TYPED_TEST(CPPINTEROP_TEST_MODE, Interpreter_WrapperCacheIsPerInterpreter) {
+  if (TypeParam::isOutOfProcess)
+    GTEST_SKIP() << "Test fails for OOP JIT builds";
+
+  // Create first interpreter: add(a,b) returns a + b.
+  auto* I1 = TestFixture::CreateInterpreter();
+  ASSERT_NE(I1, nullptr);
+  Cpp::ActivateInterpreter(I1);
+  Cpp::Declare("int add(int a, int b) { return a + b; }" DFLT_FALSE);
+  auto* AddDecl1 = Cpp::GetNamed("add" DFLT_NULLPTR);
+  ASSERT_NE(AddDecl1, nullptr);
+
+  Cpp::Declare("#include <new>" DFLT_FALSE); // Needed by JitCall
+  auto JC1 = Cpp::MakeFunctionCallable(AddDecl1);
+  ASSERT_TRUE(JC1.isValid());
+
+  int a1 = 3, b1 = 4, r1 = 0;
+  void* args1[] = {&a1, &b1};
+  JC1.Invoke(&r1, {args1, 2});
+  EXPECT_EQ(r1, 7);
+
+  // Create second interpreter: add(a,b) returns a * b.
+  auto* I2 = TestFixture::CreateInterpreter();
+  ASSERT_NE(I2, nullptr);
+  Cpp::ActivateInterpreter(I2);
+  Cpp::Declare("int add(int a, int b) { return a * b; }" DFLT_FALSE);
+  auto* AddDecl2 = Cpp::GetNamed("add" DFLT_NULLPTR);
+  ASSERT_NE(AddDecl2, nullptr);
+
+  Cpp::Declare("#include <new>" DFLT_FALSE); // Needed by JitCall
+  auto JC2 = Cpp::MakeFunctionCallable(AddDecl2);
+  ASSERT_TRUE(JC2.isValid());
+
+  // Delete the first interpreter.
+  EXPECT_TRUE(Cpp::DeleteInterpreter(I1));
+
+  // The second interpreter's wrapper must still work and must use its own
+  // implementation (multiply), not a stale cache entry from deleted I1.
+  int a2 = 3, b2 = 4, r2 = 0;
+  void* args2[] = {&a2, &b2};
+  JC2.Invoke(&r2, {args2, 2});
+  EXPECT_EQ(r2, 12) << "Wrapper should use I2's implementation (multiply), "
+                       "not a stale cache from deleted I1";
+}
+#endif // !EMSCRIPTEN


### PR DESCRIPTION
The WrapperStore and DtorWrapperStore maps are keyed on AST nodes that belong to a specific interpreter. Storing them as function-local statics meant they outlived the interpreter that owned the AST, leaving dangling keys after DeleteInterpreter. Move them into InterpreterInfo so each interpreter owns its cache and destruction is automatic.

Add getInterpInfo() helper to look up the InterpreterInfo for a given compat::Interpreter pointer and a test that creates two interpreters with identically-named but differently-implemented functions, deletes the first, and verifies the second wrapper still executes its own implementation.
