### PR TITLE
Move DynamicLibraryManager from function-local static to per-interpreter member.

### DIFF
--- a/lib/CppInterOp/CppInterOpInterpreter.h
+++ b/lib/CppInterOp/CppInterOpInterpreter.h
@@ -44,6 +44,7 @@
 #include <algorithm>
 #include <cstdio>
 #include <memory>
+#include <mutex>
 #include <tuple>
 #include <utility>
 #include <vector>
@@ -195,6 +196,8 @@ private:
 
   std::unique_ptr<clang::Interpreter> inner;
   std::unique_ptr<IOContext> io_context;
+  mutable std::unique_ptr<DynamicLibraryManager> sDLM;
+  mutable std::once_flag sDLMInit;
   bool outOfProcess;
 
 public:
@@ -447,14 +450,13 @@ public:
 
   const DynamicLibraryManager* getDynamicLibraryManager() const {
     assert(compat::getExecutionEngine(*inner) && "We must have an executor");
-    static std::unique_ptr<DynamicLibraryManager> DLM = nullptr;
-    if (!DLM) {
-      DLM.reset(new DynamicLibraryManager());
-      DLM->initializeDyld([](llvm::StringRef) { /*ignore*/ return false; });
-    }
-    return DLM.get();
-    // TODO: Add DLM to InternalExecutor and use executor->getDML()
-    //      return inner->getExecutionEngine()->getDynamicLibraryManager();
+    // Replaces the C++11 magic-static thread-safe init the previous
+    // function-local DLM had for free.
+    std::call_once(sDLMInit, [this] {
+      sDLM = std::make_unique<DynamicLibraryManager>();
+      sDLM->initializeDyld([](llvm::StringRef) { /*ignore*/ return false; });
+    });
+    return sDLM.get();
   }
 
   DynamicLibraryManager* getDynamicLibraryManager() {

--- a/unittests/CppInterOp/InterpreterTest.cpp
+++ b/unittests/CppInterOp/InterpreterTest.cpp
@@ -693,4 +693,44 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, Interpreter_WrapperCacheIsPerInterpreter) {
   EXPECT_EQ(r2, 12) << "Wrapper should use I2's implementation (multiply), "
                        "not a stale cache from deleted I1";
 }
+
+TYPED_TEST(CPPINTEROP_TEST_MODE, Interpreter_DLMIsPerInterpreter) {
+  if (TypeParam::isOutOfProcess)
+    GTEST_SKIP() << "Test fails for OOP JIT builds";
+#ifdef _WIN32
+  GTEST_SKIP() << "Disabled on Windows: DLM symbol-table walk crashes "
+                  "(RVA 0x0 in export table).";
+#endif
+
+#ifdef __APPLE__
+  static constexpr const char* kSym = "_ret_zero";
+#else
+  static constexpr const char* kSym = "ret_zero";
+#endif
+
+  std::string BinaryPath =
+      llvm::sys::fs::getMainExecutable(/*Argv0=*/nullptr, /*MainAddr=*/nullptr);
+  ASSERT_FALSE(BinaryPath.empty());
+  llvm::StringRef BinDir = llvm::sys::path::parent_path(BinaryPath);
+
+  auto* I1 = TestFixture::CreateInterpreter();
+  ASSERT_NE(I1, nullptr);
+  Cpp::ActivateInterpreter(I1);
+  Cpp::AddSearchPath(BinDir.str().c_str());
+
+  std::string R1 = Cpp::SearchLibrariesForSymbol(kSym, /*system_search=*/false);
+  if (R1.empty())
+    GTEST_SKIP() << "TestSharedLib not found — cannot test DLM isolation";
+
+  // With a single function-local-static DLM, the path added on I1
+  // would reach I2 and the lookup below would succeed; the per-
+  // interpreter DLM means I2 starts with a fresh path set.
+  auto* I2 = TestFixture::CreateInterpreter();
+  ASSERT_NE(I2, nullptr);
+  Cpp::ActivateInterpreter(I2);
+
+  std::string R2 = Cpp::SearchLibrariesForSymbol(kSym, /*system_search=*/false);
+  EXPECT_TRUE(R2.empty()) << "I2 must not see search paths added on I1; found: "
+                          << R2;
+}
 #endif // !EMSCRIPTEN


### PR DESCRIPTION
The DLM was a function-local static shared across all interpreter instances, causing search paths added in one interpreter to leak into all others. Move it to a mutable unique_ptr member of CppInternal::Interpreter so each instance owns its DLM and search path state is properly isolated.

Add a test that creates two interpreters, adds a search path to the first, and verifies the second cannot find a library through that path.
