### PR TITLE
Fix silencing of diagnostics in Declare() swallowing error status.

### DIFF
--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -31,6 +31,7 @@
 #include "clang/AST/RecordLayout.h"
 #include "clang/AST/Stmt.h"
 #include "clang/AST/Type.h"
+#include "clang/Basic/Diagnostic.h"
 #include "clang/Basic/DiagnosticSema.h"
 #include "clang/Basic/LangStandard.h"
 #include "clang/Basic/Linkage.h"
@@ -3966,8 +3967,13 @@ protected:
 
 int Declare(compat::Interpreter& I, const char* code, bool silent) {
   if (silent) {
-    clangSilent diagSuppr(I.getSema().getDiagnostics());
-    return I.declare(code);
+    clang::DiagnosticsEngine& Diag = I.getSema().getDiagnostics();
+    clangSilent diagSuppr(Diag);
+    clang::DiagnosticErrorTrap Trap(Diag);
+    auto result = I.declare(code);
+    if (Trap.hasErrorOccurred())
+      return 1;
+    return result;
   }
 
   return I.declare(code);

--- a/unittests/CppInterOp/InterpreterTest.cpp
+++ b/unittests/CppInterOp/InterpreterTest.cpp
@@ -177,6 +177,19 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, Interpreter_Process) {
   clang_Interpreter_dispose(CXI);
 }
 
+TYPED_TEST(CPPINTEROP_TEST_MODE, Interpreter_DeclareSilent) {
+  TestFixture::CreateInterpreter();
+
+  // Valid code with silent=true should succeed.
+  EXPECT_EQ(0, Cpp::Declare("int x = 42;", /*silent=*/true));
+
+  // Invalid code with silent=true should still report failure.
+  EXPECT_NE(0, Cpp::Declare("invalid_syntax!!!;", /*silent=*/true));
+
+  // The interpreter should remain usable after a silent failure.
+  EXPECT_EQ(0, Cpp::Declare("int y = 123;", /*silent=*/false));
+}
+
 TYPED_TEST(CPPINTEROP_TEST_MODE, Interpreter_EmscriptenExceptionHandling) {
 #ifndef EMSCRIPTEN
   GTEST_SKIP() << "This test is intended to check exception handling for Emscripten builds.";


### PR DESCRIPTION
Before this patch, calling Declare() with silent=true suppressed diagnostic output but also prevented DiagnosticsEngine::ErrorOccurred from being set. This caused IncrementalParser::ParseOrWrapTopLevelDecl() to miss the error check, returning a broken PTU as if parsing succeeded. As a result, Declare() returned 0 (success) for invalid code, and the interpreter state could be left with partially parsed AST nodes.

This patch adds a DiagnosticErrorTrap around the silent declare() call. The trap checks TrapNumErrorsOccurred, which is incremented before the SuppressAllDiagnostics early return in ProcessDiag(), so it correctly detects errors even when output is suppressed. A new test exercises valid code, invalid code, and post-failure interpreter health under silent mode.
