### PR TITLE
[test] Tidy up unittests CMake helper

### DIFF
--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -45,15 +45,15 @@ function(add_cppinterop_unittest name)
     endif()
   endif()
   add_dependencies(CppInterOpUnitTests ${name})
-  target_include_directories(${name} PUBLIC ${CMAKE_CURRENT_BINARY_DIR} ${GTEST_INCLUDE_DIR})
+  target_include_directories(${name} PRIVATE ${CMAKE_CURRENT_BINARY_DIR} ${GTEST_INCLUDE_DIR})
   set_property(TARGET ${name} PROPERTY RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
   export_executable_symbols(${name})
 
   if(WIN32)
-    target_link_libraries(${name} PUBLIC ${ARG_LIBRARIES} ${gtest_libs})
+    target_link_libraries(${name} PRIVATE ${gtest_libs})
     set_property(TARGET ${name} APPEND_STRING PROPERTY LINK_FLAGS "${MSVC_EXPORTS}")
   else()
-    target_link_libraries(${name} PRIVATE ${ARG_LIBRARIES} ${gtest_libs} ${link_pthreads_lib})
+    target_link_libraries(${name} PRIVATE ${gtest_libs} ${link_pthreads_lib})
   endif()
   target_link_libraries(${name} PRIVATE clangCppInterOp)
   if(EMSCRIPTEN)
@@ -76,9 +76,7 @@ function(add_cppinterop_unittest name)
 
   set_tests_properties(cppinterop-${name} PROPERTIES
                         TIMEOUT "${TIMEOUT_VALUE}"
-                        ENVIRONMENT "CPLUS_INCLUDE_PATH=${CMAKE_BINARY_DIR}/etc"
-                        LABELS
-                        DEPENDS)
+                        ENVIRONMENT "CPLUS_INCLUDE_PATH=${CMAKE_BINARY_DIR}/etc")
   # Auto-generate the dispatch version if shared libs are built by recursively calling
   # add_cppinterop_unittest with the necessary compile definitions
   # FIXME: Enable for WASM builds

--- a/unittests/CppInterOp/CMakeLists.txt
+++ b/unittests/CppInterOp/CMakeLists.txt
@@ -86,8 +86,6 @@ if(EMSCRIPTEN)
   )
 endif()
 
-unset(LLVM_LINK_COMPONENTS)
-
 if (NOT EMSCRIPTEN)
   set(EXTRA_TEST_SOURCE_FILES "")
 endif()
@@ -129,8 +127,6 @@ if(EMSCRIPTEN)
   )
 endif()
 
-add_dependencies(DynamicLibraryManagerTests TestSharedLib)
-
-#export_executable_symbols_for_plugins(TestSharedLib)
 add_subdirectory(TestSharedLib)
+add_dependencies(DynamicLibraryManagerTests TestSharedLib)
 


### PR DESCRIPTION
A handful of small, unrelated hygiene fixes in the unittest CMake, none of
which change what gets built on any platform.