### PR TITLE
[test] Centralize Emscripten flag handling in unittest helper

### DIFF
--- a/unittests/CMakeLists.txt
+++ b/unittests/CMakeLists.txt
@@ -36,7 +36,13 @@ function(add_cppinterop_unittest name)
     ""
     ${ARGN}
   )
-  add_executable(${name} EXCLUDE_FROM_ALL ${ARG_UNPARSED_ARGUMENTS})
+  # gtest_main is dropped from the Emscripten link set, so every Emscripten
+  # test binary needs its own main.cpp entry point.
+  if(EMSCRIPTEN)
+    add_executable(${name} EXCLUDE_FROM_ALL ${ARG_UNPARSED_ARGUMENTS} main.cpp)
+  else()
+    add_executable(${name} EXCLUDE_FROM_ALL ${ARG_UNPARSED_ARGUMENTS})
+  endif()
   if(NOT LLVM_ENABLE_RTTI)
     if(MSVC)
       target_compile_options(${name} PRIVATE "/GR-")
@@ -62,6 +68,8 @@ function(add_cppinterop_unittest name)
     else()
       target_compile_definitions(${name} PRIVATE "EMSCRIPTEN_STATIC_LIBRARY")
     endif()
+    target_compile_options(${name} PRIVATE ${CPPINTEROP_COMMON_WASM_TEST_COMPILE_FLAGS})
+    target_link_options(${name} PRIVATE ${CPPINTEROP_COMMON_WASM_TEST_LINK_FLAGS})
     # Without this cmake will try and get node to run the html file.
     # This guarantees that it runs the js file, and uses emsdks node.
     add_test(NAME cppinterop-${name} COMMAND $ENV{EMSDK_NODE} ${name}.js)
@@ -82,7 +90,7 @@ function(add_cppinterop_unittest name)
   # FIXME: Enable for WASM builds
   if (NOT EMSCRIPTEN AND ARG_ENABLE_DISPATCH AND BUILD_SHARED_LIBS)
     add_cppinterop_unittest(${name}Dispatch ${ARG_UNPARSED_ARGUMENTS} DispatchTest.cpp)
-    target_compile_definitions(${name}Dispatch PRIVATE 
+    target_compile_definitions(${name}Dispatch PRIVATE
       ENABLE_DISPATCH_TESTS
       CPPINTEROP_LIB_PATH="${CMAKE_BINARY_DIR}/lib/libclangCppInterOp${CMAKE_SHARED_LIBRARY_SUFFIX}"
     )

--- a/unittests/CppInterOp/CMakeLists.txt
+++ b/unittests/CppInterOp/CMakeLists.txt
@@ -1,43 +1,35 @@
 if (EMSCRIPTEN)
-  # So we create a html file, as well as the javascript file
+  # Build a .html shell alongside the .js main module.
   set(CMAKE_EXECUTABLE_SUFFIX ".html")
-  # Omitting CUDATest.cpp since Emscripten build currently has no GPU support
-  # For Emscripten builds linking to gtest_main will not suffice for gtest to run
-  # the tests and an explicitly main.cpp is needed
-  set(EXTRA_TEST_SOURCE_FILES main.cpp)
 
   string(REPLACE "@" "@@" ESCAPED_SYSROOT_PATH "${SYSROOT_PATH}")
-  # Explanation of Emscripten-specific link flags for CppInterOpTests:
+  # Explanation of Emscripten-specific link flags for CppInterOp tests:
   #
   # MAIN_MODULE=1:
-  # Enables building CppInterOpTests.js as the main WebAssembly module, allowing dynamic linking of side modules.
+  # Enables the test binary as the main WebAssembly module, allowing dynamic
+  # linking of side modules (TestSharedLib).
   #
   # WASM_BIGINT:
-  # Ensures support for 64-bit integer types by enabling JavaScript BigInt integration in WASM.
+  # Enables JS BigInt integration in WASM so 64-bit integer types round-trip.
   #
   # ALLOW_MEMORY_GROWTH=1:
-  # Allows the WebAssembly memory to grow dynamically at runtime to accommodate increasing memory needs.
-  # Would lead to an abortOnCannotGrowMemory error if memory cannot be grown while running the tests.
+  # Lets the WebAssembly linear memory grow at runtime. Without it we hit
+  # abortOnCannotGrowMemory during the tests.
   #
-  # STACK_SIZE=32mb: Allocates 32MB of stack space to handle deep recursion or large stack-allocated objects safely.
-  # INITIAL_MEMORY=128mb: Sets the initial linear memory size to 128MB to reduce the likelihood of early memory expansion and improve performance.
-  # The STACK_SIZE and INITIAL_MEMORY values are chosen based on what has been put to use for running xeus-cpp-lite.
-  # Check https://github.com/jupyter-xeus/xeus/blob/main/cmake/WasmBuildOptions.cmake#L35-L36 for more details.
-  # Not setting these flags would lead to a memory access out of bounds error while running the tests.
+  # STACK_SIZE=32mb / INITIAL_MEMORY=64mb:
+  # Chosen to match xeus-cpp-lite
+  # (https://github.com/jupyter-xeus/xeus/blob/main/cmake/WasmBuildOptions.cmake#L35-L36).
+  # Smaller values trigger out-of-bounds memory accesses while running the tests.
   #
   # --preload-file ${SYSROOT_PATH}/include@/include:
-  # Preloads the system include directory into the Emscripten virtual filesystem to make headers accessible at runtime.
+  # Preloads the system include directory into the Emscripten VFS so headers
+  # are available at runtime.
   #
-  # --emrun
-  # Makes it so that we run the html file created by this target, that we can capture the standard output
-  # and output to the terminal
-
-  # Common compile flags for WASM tests
+  # --emrun:
+  # Makes emrun drive the .html shell and pipe stdout back to the terminal.
   set(CPPINTEROP_COMMON_WASM_TEST_COMPILE_FLAGS
     "SHELL:${CPPINTEROP_EXTRA_WASM_FLAGS}"
   )
-
-  # Common link flags for WASM tests
   set(CPPINTEROP_COMMON_WASM_TEST_LINK_FLAGS
     "SHELL:${CPPINTEROP_EXTRA_WASM_FLAGS}"
     "SHELL:-s MAIN_MODULE=1"
@@ -48,9 +40,6 @@ if (EMSCRIPTEN)
     "SHELL:--preload-file ${ESCAPED_SYSROOT_PATH}/include@/include"
     "SHELL:--emrun"
   )
-else()
-  # Do not need main.cpp for native builds, but we do have GPU support for native builds
-  set(EXTRA_TEST_SOURCE_FILES CUDATest.cpp)
 endif()
 
 add_cppinterop_unittest(CppInterOpTests
@@ -64,69 +53,41 @@ add_cppinterop_unittest(CppInterOpTests
   TypeReflectionTest.cpp
   Utils.cpp
   VariableReflectionTest.cpp
-  ${EXTRA_TEST_SOURCE_FILES}
 )
+if (NOT EMSCRIPTEN)
+  # Emscripten has no GPU; CUDA tests are native-only.
+  target_sources(CppInterOpTests PRIVATE CUDATest.cpp)
+endif()
 
 if(NOT WIN32)
   set_source_files_properties(VariableReflectionTest.cpp PROPERTIES COMPILE_FLAGS
     "-Wno-pedantic"
-)
-endif ()
+  )
+endif()
 
 set_source_files_properties(InterpreterTest.cpp PROPERTIES COMPILE_DEFINITIONS
   "LLVM_BINARY_DIR=\"${LLVM_BINARY_DIR}\""
 )
 
-if(EMSCRIPTEN)
-  target_compile_options(CppInterOpTests
-    PUBLIC ${CPPINTEROP_COMMON_WASM_TEST_COMPILE_FLAGS}
-  )
-  target_link_options(CppInterOpTests
-    PUBLIC ${CPPINTEROP_COMMON_WASM_TEST_LINK_FLAGS}
-  )
-endif()
-
-if (NOT EMSCRIPTEN)
-  set(EXTRA_TEST_SOURCE_FILES "")
-endif()
-
-add_cppinterop_unittest(DynamicLibraryManagerTests 
-  DynamicLibraryManagerTest.cpp 
-  Utils.cpp 
-  ${EXTRA_TEST_SOURCE_FILES}
+add_cppinterop_unittest(DynamicLibraryManagerTests
+  DynamicLibraryManagerTest.cpp
+  Utils.cpp
 )
+if(EMSCRIPTEN)
+  set(TEST_SHARED_LIBRARY_PATH "${CMAKE_CURRENT_BINARY_DIR}/bin/$<CONFIG>/")
+  string(REPLACE "@" "@@" ESCAPED_TEST_SHARED_LIBRARY_PATH "${TEST_SHARED_LIBRARY_PATH}")
+  target_link_options(DynamicLibraryManagerTests PRIVATE
+    "SHELL:--preload-file ${ESCAPED_TEST_SHARED_LIBRARY_PATH}/libTestSharedLib.so@/libTestSharedLib.so"
+  )
+endif()
 
 add_cppinterop_unittest(TracingTests
   TracingTests.cpp
   Utils.cpp
-  ${EXTRA_TEST_SOURCE_FILES}
 )
 target_compile_definitions(TracingTests PRIVATE
   "CPPINTEROP_DIR=\"${CMAKE_SOURCE_DIR}\""
 )
 
-if(EMSCRIPTEN)
-  target_compile_options(TracingTests
-    PUBLIC ${CPPINTEROP_COMMON_WASM_TEST_COMPILE_FLAGS}
-  )
-  target_link_options(TracingTests
-    PUBLIC ${CPPINTEROP_COMMON_WASM_TEST_LINK_FLAGS}
-  )
-endif()
-
-if(EMSCRIPTEN)
-  set(TEST_SHARED_LIBRARY_PATH "${CMAKE_CURRENT_BINARY_DIR}/bin/$<CONFIG>/")
-  string(REPLACE "@" "@@" ESCAPED_TEST_SHARED_LIBRARY_PATH "${TEST_SHARED_LIBRARY_PATH}")
-  target_compile_options(DynamicLibraryManagerTests
-    PUBLIC ${CPPINTEROP_COMMON_WASM_TEST_COMPILE_FLAGS}
-  )
-  target_link_options(DynamicLibraryManagerTests
-    PUBLIC
-      ${CPPINTEROP_COMMON_WASM_TEST_LINK_FLAGS}
-      "SHELL:--preload-file ${ESCAPED_TEST_SHARED_LIBRARY_PATH}/libTestSharedLib.so@/libTestSharedLib.so"
-  )
-endif()
-
 add_subdirectory(TestSharedLib)
 add_dependencies(DynamicLibraryManagerTests TestSharedLib)
-


### PR DESCRIPTION
Before this change, unittests/CppInterOp/CMakeLists.txt juggled a variable named EXTRA_TEST_SOURCE_FILES that meant two different things depending on the platform: main.cpp under Emscripten (appended to every test binary) and CUDATest.cpp on native (appended only to CppInterOpTests, then cleared mid-file). The per-target Emscripten compile/link option blocks were also duplicated three times with the same CPPINTEROP_COMMON_WASM_TEST_* inputs.

Move the common Emscripten setup into add_cppinterop_unittest:

- The helper injects main.cpp into the source list on Emscripten, since the Emscripten link set drops gtest_main and every test binary needs its own entry point.

- The helper applies CPPINTEROP_COMMON_WASM_TEST_COMPILE_FLAGS and CPPINTEROP_COMMON_WASM_TEST_LINK_FLAGS unconditionally for Emscripten test binaries.

With that in place, drop EXTRA_TEST_SOURCE_FILES and the three duplicate target_compile_options / target_link_options blocks. CUDATest.cpp is now attached explicitly via target_sources on the NOT EMSCRIPTEN branch, and the DynamicLibraryManagerTests preload-file becomes a single follow-up target_link_options call since the common flags are already in place.

While there, tighten up the (lengthy) Emscripten link-flag rationale comment for readability.

No behavior change: every test binary still receives the same sources, defines, compile options and link options as before, on both native and Emscripten.

# Description

Please include a summary of changes, motivation and context for this PR.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [ ] I have read the contribution guide recently
