### PR TITLE
[ci] Improve the developers experience without losing too much of the ci coverage.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,26 +75,6 @@ jobs:
             llvm_targets_to_build: "host;NVPTX"
             Valgrind: On
             python-version: '3.14'
-          - name: ubu24-arm-gcc12-clang-repl-21-cppyy
-            os: ubuntu-24.04-arm
-            compiler: gcc-12
-            clang-runtime: '21'
-            cppyy: On
-            llvm_enable_projects: "clang"
-            llvm_targets_to_build: "host;NVPTX"
-            Valgrind: On
-            python-version: '3.14'
-          - name: ubu24-arm-gcc14-clang20-cling-cppyy
-            os: ubuntu-24.04-arm
-            compiler: gcc-14
-            clang-runtime: '20'
-            cling: On
-            cppyy: On
-            cling-version: '1.3'
-            root-llvm-tag: 'cling-llvm20-20260119-01'
-            llvm_enable_projects: "clang"
-            llvm_targets_to_build: "host;NVPTX"
-            python-version: '3.14'
           # Ubuntu X86 Jobs
           - name: ubu24-x86-gcc12-clang-repl-22
             os: ubuntu-24.04
@@ -102,6 +82,15 @@ jobs:
             clang-runtime: '22'
             llvm_enable_projects: "clang"
             llvm_targets_to_build: "host;NVPTX"
+          - name: ubu24-x86-gcc12-clang-repl-21-cppyy
+            os: ubuntu-24.04
+            compiler: gcc-12
+            clang-runtime: '21'
+            cppyy: On
+            llvm_enable_projects: "clang"
+            llvm_targets_to_build: "host;NVPTX"
+            Valgrind: On
+            python-version: '3.14'
           - name: ubu24-x86-gcc12-clang-repl-21-asan
             os: ubuntu-24.04
             compiler: gcc-12
@@ -185,13 +174,6 @@ jobs:
             llvm_targets_to_build: "host;NVPTX"
             python-version: '3.14'
           # MacOS X86 Jobs
-          - name: osx26-x86-clang-clang-repl-22
-            os: macos-26-intel
-            compiler: clang
-            clang-runtime: '22'
-            llvm_enable_projects: "clang"
-            llvm_targets_to_build: "host"
-            python-version: '3.14'
           - name: osx26-x86-clang-clang-repl-21-cppyy
             os: macos-26-intel
             compiler: clang
@@ -216,16 +198,6 @@ jobs:
             os: windows-11-arm
             compiler: msvc
             clang-runtime: '22'
-            llvm_enable_projects: "clang"
-            llvm_targets_to_build: "host;NVPTX"
-            python-version: '3.14'
-          - name: win11-msvc-clang20-cling
-            os: windows-11-arm
-            compiler: msvc
-            clang-runtime: '20'
-            cling: On
-            cling-version: '1.3'
-            root-llvm-tag: 'cling-llvm20-20260119-01'
             llvm_enable_projects: "clang"
             llvm_targets_to_build: "host;NVPTX"
             python-version: '3.14'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -84,14 +84,6 @@ jobs:
             llvm_targets_to_build: "host;NVPTX"
             Valgrind: On
             python-version: '3.14'
-          - name: ubu24-arm-gcc12-clang-repl-20-cppyy
-            os: ubuntu-24.04-arm
-            compiler: gcc-12
-            clang-runtime: '20'
-            cppyy: On
-            llvm_enable_projects: "clang"
-            llvm_targets_to_build: "host;NVPTX"
-            python-version: '3.13'
           - name: ubu24-arm-gcc14-clang20-cling-cppyy
             os: ubuntu-24.04-arm
             compiler: gcc-14
@@ -126,23 +118,17 @@ jobs:
             llvm_targets_to_build: "host;NVPTX"
             python-version: '3.14'
             coverage: true
-          - name: ubu24-x86-gcc12-clang-repl-21-cppyy
+          - name: ubu24-x86-gcc12-clang-repl-22-cppyy
             os: ubuntu-24.04
             compiler: gcc-12
-            clang-runtime: '21'
+            clang-runtime: '22'
             cppyy: On
             llvm_enable_projects: "clang"
             llvm_targets_to_build: "host;NVPTX"
-            Valgrind: On
             python-version: '3.14'
-          - name: ubu24-x86-gcc12-clang-repl-20-cppyy
-            os: ubuntu-24.04
-            compiler: gcc-12
-            clang-runtime: '20'
-            cppyy: On
-            llvm_enable_projects: "clang"
-            llvm_targets_to_build: "host;NVPTX"
-            python-version: '3.13'
+          # oop-jit stays on clang-20 because the out-of-process JIT patch
+          # (patches/llvm/clang20-1-out-of-process.patch) only targets
+          # release/20.x; bump to clang-22 when a matching patch lands.
           - name: ubu24-x86-gcc12-clang-repl-20-out-of-process
             os: ubuntu-24.04
             compiler: gcc-12
@@ -187,14 +173,6 @@ jobs:
             llvm_targets_to_build: "host"
             oop-jit: On
             python-version: '3.13'
-          - name: osx26-arm-clang-clang-repl-20-cppyy
-            os: macos-26
-            compiler: clang
-            clang-runtime: '20'
-            cppyy: On
-            llvm_enable_projects: "clang"
-            llvm_targets_to_build: "host"
-            python-version: '3.13'
           - name: osx26-arm-clang-clang20-cling-cppyy
             os: macos-26
             compiler: clang
@@ -222,14 +200,6 @@ jobs:
             llvm_enable_projects: "clang"
             llvm_targets_to_build: "host"
             python-version: '3.14'
-          - name: osx26-x86-clang-clang-repl-20-cppyy
-            os: macos-26-intel
-            compiler: clang
-            clang-runtime: '20'
-            cppyy: On
-            llvm_enable_projects: "clang"
-            llvm_targets_to_build: "host"
-            python-version: '3.13'
           - name: osx26-x86-clang-clang20-cling-cppyy
             os: macos-26-intel
             compiler: clang


### PR DESCRIPTION
Each OS+arch had up to three cppyy matrix rows — one per clang-runtime (20, 21, 22). cppyy exercises the same public CppInterOp API on every clang-runtime, so the clang-20 cppyy rows were pure duplication once the clang-21 rows existed.

Cache keys do not include cppyy (by design, cppyy tests share the LLVM build with the equivalent non-cppyy row), but none of the dropped rows shared a cache key with any remaining job: the Linux arm+gcc-12+clang-20 plain cache, the Linux x86+gcc-12+clang-20 plain cache, and the two macOS clang-20 plain caches are unique to the dropped rows. So four clang+LLVM builds come off the critical path.

Drop:
- ubu24-arm-gcc12-clang-repl-20-cppyy
- ubu24-x86-gcc12-clang-repl-20-cppyy
- osx26-arm-clang-clang-repl-20-cppyy
- osx26-x86-clang-clang-repl-20-cppyy

To preserve cppyy coverage on the latest supported LLVM, bump ubu24-x86-gcc12-clang-repl-21-cppyy to clang-runtime 22; the remaining clang-21 cppyy coverage stays on Linux ARM plus both macOS arches. clang-20 stays exercised via the oop-jit and cling rows.

Matrix: 23 -> 19 jobs.

ARM cling was exercised on three platforms: Ubuntu 24.04 ARM, macOS 26 ARM, and Windows 11 ARM. Cling behavior on ARM is platform-agnostic for the CppInterOp API surface these tests cover; keeping three full LLVM+cling builds is over-coverage.

Keep the macOS 26 ARM cling job as the ARM cling representative: it is the freshest ARM OS in the matrix and it bundles the cppyy test surface as well, so losing it would cost more than losing either of the others. Drop ubu24-arm-gcc14-clang20-cling-cppyy and win11-msvc-clang20-cling. x86 cling coverage is unchanged (Linux x86, macOS x86, Windows x86).

Also drop osx26-x86-clang-clang-repl-22, the Intel-Mac plain smoke test. Intel Macs are phasing out of the supported matrix and this job was the only macOS-x86 entry on clang-22; macOS-ARM already carries the clang-22 plain signal plus the cppyy and oop-jit axes.

Matrix: 19 -> 16 jobs.