### PR TITLE
Add various type reflection interfaces for cppyy/numba

### DIFF
--- a/include/CppInterOp/CppInterOp.h
+++ b/include/CppInterOp/CppInterOp.h
@@ -95,12 +95,14 @@ enum Operator : unsigned char {
 };
 
 enum OperatorArity : unsigned char { kUnary = 1, kBinary, kBoth };
+enum Signedness : unsigned char { kSigned = 1, kUnsigned };
 
 /// Enum modelling CVR qualifiers.
 enum QualKind : unsigned char {
   Const = 1 << 0,
   Volatile = 1 << 1,
-  Restrict = 1 << 2
+  Restrict = 1 << 2,
+  All = Const | Volatile | Restrict
 };
 
 /// Enum modelling programming languages.
@@ -686,6 +688,20 @@ CPPINTEROP_API bool IsRecordType(TCppType_t type);
 
 /// Checks if the provided parameter is a Plain Old Data Type (POD).
 CPPINTEROP_API bool IsPODType(TCppType_t type);
+
+/// Checks if type has an integer representation.
+/// If \p s is non-null, it is set to the signedness of the type.
+CPPINTEROP_API bool IsIntegerType(TCppType_t type, Signedness* s = nullptr);
+
+/// Checks if type has a floating representation
+CPPINTEROP_API bool IsFloatingType(TCppType_t type);
+
+/// Checks if two types are the equivalent
+/// i.e. have the same canonical type
+CPPINTEROP_API bool IsSameType(TCppType_t type_a, TCppType_t type_b);
+
+/// Checks if type is a void pointer
+CPPINTEROP_API bool IsVoidPointerType(TCppType_t type);
 
 /// Checks if type is a pointer
 CPPINTEROP_API bool IsPointerType(TCppType_t type);

--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -2063,10 +2063,49 @@ bool IsPODType(TCppType_t type) {
   return INTEROP_RETURN(QT.isPODType(getASTContext()));
 }
 
+bool IsIntegerType(TCppType_t type, Signedness* s) {
+  INTEROP_TRACE(type, s);
+  if (!type)
+    return INTEROP_RETURN(false);
+  QualType QT = QualType::getFromOpaquePtr(type);
+  if (!QT->hasIntegerRepresentation())
+    return INTEROP_RETURN(false);
+  if (s) {
+    *s = QT->hasSignedIntegerRepresentation() ? Signedness::kSigned
+                                              : Signedness::kUnsigned;
+  }
+  return INTEROP_RETURN(true);
+}
+
+bool IsFloatingType(TCppType_t type) {
+  INTEROP_TRACE(type);
+  if (!type)
+    return INTEROP_RETURN(false);
+  QualType QT = QualType::getFromOpaquePtr(type);
+  return INTEROP_RETURN(QT->hasFloatingRepresentation());
+}
+
+bool IsSameType(TCppType_t type_a, TCppType_t type_b) {
+  INTEROP_TRACE(type_a, type_b);
+  if (!type_a || !type_b)
+    return INTEROP_RETURN(false);
+  QualType QT1 = QualType::getFromOpaquePtr(type_a);
+  QualType QT2 = QualType::getFromOpaquePtr(type_b);
+  return INTEROP_RETURN(getASTContext().hasSameType(QT1, QT2));
+}
+
 bool IsPointerType(TCppType_t type) {
   INTEROP_TRACE(type);
   QualType QT = QualType::getFromOpaquePtr(type);
   return INTEROP_RETURN(QT->isPointerType());
+}
+
+bool IsVoidPointerType(TCppType_t type) {
+  INTEROP_TRACE(type);
+  if (!type)
+    return INTEROP_RETURN(false);
+  QualType QT = QualType::getFromOpaquePtr(type);
+  return INTEROP_RETURN(QT->isVoidPointerType());
 }
 
 TCppType_t GetPointeeType(TCppType_t type) {
@@ -2119,6 +2158,8 @@ TCppType_t GetNonReferenceType(TCppType_t type) {
 
 TCppType_t GetUnderlyingType(TCppType_t type) {
   INTEROP_TRACE(type);
+  if (!type)
+    return INTEROP_RETURN(nullptr);
   QualType QT = QualType::getFromOpaquePtr(type);
   QT = QT->getCanonicalTypeUnqualified();
 

--- a/unittests/CppInterOp/TypeReflectionTest.cpp
+++ b/unittests/CppInterOp/TypeReflectionTest.cpp
@@ -682,10 +682,138 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, TypeReflection_TypeQualifiers) {
   EXPECT_EQ(b, Cpp::RemoveTypeQualifier(h, Cpp::QualKind::Const |
                                                Cpp::QualKind::Volatile));
 
+  // QualKind::All removes all qualifiers at once
+  EXPECT_EQ(a, Cpp::RemoveTypeQualifier(h, Cpp::QualKind::All));
+  EXPECT_EQ(a, Cpp::RemoveTypeQualifier(e, Cpp::QualKind::All));
+  EXPECT_EQ(a, Cpp::RemoveTypeQualifier(b, Cpp::QualKind::All));
+  // Already unqualified type is unchanged
+  EXPECT_EQ(a, Cpp::RemoveTypeQualifier(a, Cpp::QualKind::All));
+
   EXPECT_EQ(c, Cpp::AddTypeQualifier(a, Cpp::QualKind::Const));
   EXPECT_EQ(d, Cpp::AddTypeQualifier(a, Cpp::QualKind::Volatile));
   EXPECT_EQ(b, Cpp::AddTypeQualifier(a, Cpp::QualKind::Restrict));
   EXPECT_EQ(h, Cpp::AddTypeQualifier(a, Cpp::QualKind::Const |
                                             Cpp::QualKind::Volatile |
                                             Cpp::QualKind::Restrict));
+}
+
+TYPED_TEST(CPPINTEROP_TEST_MODE, TypeReflection_IsIntegerType) {
+  std::vector<Decl*> Decls;
+  std::string code = R"(
+    int a;
+    int *b;
+    double c;
+    enum A { x, y };
+    A evar = x;
+    char k;
+    long int l;
+    unsigned int m;
+    unsigned long n;
+  )";
+
+  GetAllTopLevelDecls(code, Decls);
+
+  Cpp::Signedness sign;
+  EXPECT_TRUE(Cpp::IsIntegerType(Cpp::GetVariableType(Decls[0])));
+  EXPECT_FALSE(Cpp::IsIntegerType(Cpp::GetVariableType(Decls[1])));
+  EXPECT_FALSE(Cpp::IsIntegerType(Cpp::GetVariableType(Decls[2])));
+  EXPECT_TRUE(Cpp::IsIntegerType(Cpp::GetVariableType(Decls[4])));
+  EXPECT_TRUE(Cpp::IsIntegerType(Cpp::GetVariableType(Decls[5])));
+  EXPECT_TRUE(Cpp::IsIntegerType(Cpp::GetVariableType(Decls[6])));
+
+  // Check signedness via out parameter
+  EXPECT_TRUE(Cpp::IsIntegerType(Cpp::GetVariableType(Decls[0]), &sign));
+  EXPECT_EQ(sign, Cpp::Signedness::kSigned); // int
+  EXPECT_TRUE(Cpp::IsIntegerType(Cpp::GetVariableType(Decls[7]), &sign));
+  EXPECT_EQ(sign, Cpp::Signedness::kUnsigned); // unsigned int
+  EXPECT_TRUE(Cpp::IsIntegerType(Cpp::GetVariableType(Decls[8]), &sign));
+  EXPECT_EQ(sign, Cpp::Signedness::kUnsigned); // unsigned long
+}
+
+TYPED_TEST(CPPINTEROP_TEST_MODE, TypeReflection_IsFloatingType) {
+  std::vector<Decl*> Decls;
+  std::string code = R"(
+    float a;
+    double b;
+    long double c;
+    int d;
+    char e;
+  )";
+
+  GetAllTopLevelDecls(code, Decls);
+
+  EXPECT_TRUE(Cpp::IsFloatingType(Cpp::GetVariableType(Decls[0])));
+  EXPECT_TRUE(Cpp::IsFloatingType(Cpp::GetVariableType(Decls[1])));
+  EXPECT_TRUE(Cpp::IsFloatingType(Cpp::GetVariableType(Decls[2])));
+  EXPECT_FALSE(Cpp::IsFloatingType(Cpp::GetVariableType(Decls[3])));
+  EXPECT_FALSE(Cpp::IsFloatingType(Cpp::GetVariableType(Decls[4])));
+  EXPECT_FALSE(Cpp::IsFloatingType(0));
+}
+
+TYPED_TEST(CPPINTEROP_TEST_MODE, TypeReflection_IsVoidPointerType) {
+  std::vector<Decl*> Decls;
+  std::string code = R"(
+    class A {};
+    using VoidPtrType = void*;
+    VoidPtrType a = nullptr;
+    void * b = nullptr;
+    A *pa = nullptr;
+  )";
+
+  GetAllTopLevelDecls(code, Decls);
+
+  EXPECT_EQ(Cpp::GetTypeAsString(Cpp::GetVariableType(Decls[2])),
+            "VoidPtrType");
+  EXPECT_TRUE(Cpp::IsVoidPointerType(Cpp::GetVariableType(Decls[2])));
+  EXPECT_TRUE(Cpp::IsVoidPointerType(Cpp::GetVariableType(Decls[3])));
+  EXPECT_FALSE(Cpp::IsVoidPointerType(Cpp::GetVariableType(Decls[4])));
+}
+
+TYPED_TEST(CPPINTEROP_TEST_MODE, TypeReflection_IsSameType) {
+  std::vector<Decl*> Decls;
+
+  std::string code = R"(
+    #include <cstdarg>
+
+    typedef std::va_list VaListAlias;
+    std::va_list va1;
+    VaListAlias va2;
+    const int ci = 0;
+    int const ic = 0;
+    signed int si1 = 0;
+    int si2 = 0;
+    void *x;
+  )";
+
+  GetAllTopLevelDecls(code, Decls);
+  ASTContext& Ctxt = Interp->getCI()->getASTContext();
+  Decls.assign(Decls.end() - 8, Decls.end());
+
+  EXPECT_TRUE(
+      Cpp::IsSameType(Cpp::GetType("bool"), Ctxt.BoolTy.getAsOpaquePtr()));
+  EXPECT_TRUE(
+      Cpp::IsSameType(Cpp::GetType("float"), Ctxt.FloatTy.getAsOpaquePtr()));
+  EXPECT_TRUE(
+      Cpp::IsSameType(Cpp::GetType("long"), Ctxt.LongTy.getAsOpaquePtr()));
+  EXPECT_TRUE(Cpp::IsSameType(Cpp::GetType("long long"),
+                              Ctxt.LongLongTy.getAsOpaquePtr()));
+  EXPECT_TRUE(
+      Cpp::IsSameType(Cpp::GetType("short"), Ctxt.ShortTy.getAsOpaquePtr()));
+  EXPECT_TRUE(
+      Cpp::IsSameType(Cpp::GetType("char"), Ctxt.CharTy.getAsOpaquePtr()));
+  EXPECT_TRUE(Cpp::IsSameType(Cpp::GetType("unsigned char"),
+                              Ctxt.UnsignedCharTy.getAsOpaquePtr()));
+  EXPECT_TRUE(Cpp::IsSameType(Cpp::GetType("unsigned int"),
+                              Ctxt.UnsignedIntTy.getAsOpaquePtr()));
+
+  EXPECT_TRUE(Cpp::IsSameType(Cpp::GetVariableType(Decls[7]),
+                              Ctxt.VoidPtrTy.getAsOpaquePtr()));
+
+  // Expect the typedef to std::va_list to be the same type
+  EXPECT_TRUE(Cpp::IsSameType(Cpp::GetVariableType(Decls[1]),
+                              Cpp::GetVariableType(Decls[2])));
+  EXPECT_TRUE(Cpp::IsSameType(Cpp::GetVariableType(Decls[3]),
+                              Cpp::GetVariableType(Decls[4])));
+  EXPECT_TRUE(Cpp::IsSameType(Cpp::GetVariableType(Decls[5]),
+                              Cpp::GetVariableType(Decls[6])));
 }


### PR DESCRIPTION
Revived https://github.com/compiler-research/CppInterOp/pull/534.
This was earlier motivated by arg match scoring interfaces for numba, and recently a ROOT commit aliasing `size()` to `__len__` for container-like classes: https://github.com/root-project/root/commit/cccbacc64c431ecbd4ea113f247c9aee9145a672, so I opened a fresh PR and also addressed the last comment on making signedness an out parameter