### PR TITLE
Add IsIntegerType to Dispatch header

### DIFF
--- a/include/CppInterOp/Dispatch.h
+++ b/include/CppInterOp/Dispatch.h
@@ -84,6 +84,7 @@ extern "C" CPPINTEROP_API CppFnPtrTy CppGetProcAddress(const char* procname);
   DISPATCH_API(GetClassTemplateInstantiationArgs,                              \
                decltype(&CppImpl::GetClassTemplateInstantiationArgs))          \
   DISPATCH_API(IsClass, decltype(&CppImpl::IsClass))                           \
+  DISPATCH_API(IsIntegerType, decltype(&CppImpl::IsIntegerType))               \
   DISPATCH_API(GetType, decltype(&CppImpl::GetType))                           \
   DISPATCH_API(GetTypeFromScope, decltype(&CppImpl::GetTypeFromScope))         \
   DISPATCH_API(GetComplexType, decltype(&CppImpl::GetComplexType))             \

--- a/unittests/CppInterOp/TypeReflectionTest.cpp
+++ b/unittests/CppInterOp/TypeReflectionTest.cpp
@@ -714,12 +714,12 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, TypeReflection_IsIntegerType) {
   GetAllTopLevelDecls(code, Decls);
 
   Cpp::Signedness sign;
-  EXPECT_TRUE(Cpp::IsIntegerType(Cpp::GetVariableType(Decls[0])));
-  EXPECT_FALSE(Cpp::IsIntegerType(Cpp::GetVariableType(Decls[1])));
-  EXPECT_FALSE(Cpp::IsIntegerType(Cpp::GetVariableType(Decls[2])));
-  EXPECT_TRUE(Cpp::IsIntegerType(Cpp::GetVariableType(Decls[4])));
-  EXPECT_TRUE(Cpp::IsIntegerType(Cpp::GetVariableType(Decls[5])));
-  EXPECT_TRUE(Cpp::IsIntegerType(Cpp::GetVariableType(Decls[6])));
+  EXPECT_TRUE(Cpp::IsIntegerType(Cpp::GetVariableType(Decls[0]) DFLT_NULLPTR));
+  EXPECT_FALSE(Cpp::IsIntegerType(Cpp::GetVariableType(Decls[1]) DFLT_NULLPTR));
+  EXPECT_FALSE(Cpp::IsIntegerType(Cpp::GetVariableType(Decls[2]) DFLT_NULLPTR));
+  EXPECT_TRUE(Cpp::IsIntegerType(Cpp::GetVariableType(Decls[4]) DFLT_NULLPTR));
+  EXPECT_TRUE(Cpp::IsIntegerType(Cpp::GetVariableType(Decls[5]) DFLT_NULLPTR));
+  EXPECT_TRUE(Cpp::IsIntegerType(Cpp::GetVariableType(Decls[6]) DFLT_NULLPTR));
 
   // Check signedness via out parameter
   EXPECT_TRUE(Cpp::IsIntegerType(Cpp::GetVariableType(Decls[0]), &sign));


### PR DESCRIPTION
https://github.com/compiler-research/cppyy-backend/pull/198 needed the implementation in the dispatch header which https://github.com/compiler-research/CppInterOp/pull/913 missed