### PR TITLE
Partially fix Emscripten ci on main (fixes osx job which fixes deployment, but Windows still broken)

### DIFF
--- a/.github/actions/Build_and_Test_CppInterOp/action.yml
+++ b/.github/actions/Build_and_Test_CppInterOp/action.yml
@@ -185,6 +185,8 @@ runs:
         cmake -DCMAKE_BUILD_TYPE=Release \
               -DLLVM_DIR=$NATIVE_LLVM_BUILD_DIR/lib/cmake/llvm \
               -DCPPINTEROP_ENABLE_TESTING=OFF \
+              -DCMAKE_CXX_STANDARD=17 \
+              -DLLVM_ENABLE_WERROR=On  \
               -DCPPINTEROP_BUILD_TABLEGEN_ONLY=ON \
               ../
         cmake --build . --target cppinterop-tblgen -j ${{ env.ncpus }}
@@ -488,6 +490,7 @@ runs:
         cmake -DCMAKE_BUILD_TYPE=Release `
               -DLLVM_DIR="$env:NATIVE_LLVM_BUILD_DIR\lib\cmake\llvm" `
               -DCPPINTEROP_ENABLE_TESTING=OFF `
+              -DCMAKE_CXX_STANDARD=17 -DLLVM_ENABLE_WERROR=On `
               -DCPPINTEROP_BUILD_TABLEGEN_ONLY=ON `
               ..\
         cmake --build . --target cppinterop-tblgen -j ${{ env.ncpus }}

--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -210,7 +210,7 @@ jobs:
           EMCC_CFLAGS="-fwasm-exceptions" emmake ninja libclang clangInterpreter clangStaticAnalyzerCore
         fi
         cd ../
-        rm -rf $(find . -maxdepth 1 ! -name "build" ! -name "llvm" ! -name "clang" ! -name ".")
+        rm -rf $(find . -maxdepth 1 ! -name "build" ! -name "llvm" ! -name "clang" ! -name "." ! -name "native_build")
         if [[ "${cling_on}" == "ON" ]]; then
           cd ./llvm/
           rm -rf $(find . -maxdepth 1 ! -name "include" ! -name "lib" ! -name "cmake" ! -name "utils" ! -name ".")
@@ -343,7 +343,7 @@ jobs:
           $env:EMCC_CFLAGS=""
         }
         cd ..\
-        rm -r -force $(find.exe . -maxdepth 1 ! -name "build" ! -name "llvm" ! -name "clang" ! -name ".")
+        rm -r -force $(find.exe . -maxdepth 1 ! -name "build" ! -name "llvm" ! -name "clang" ! -name "." ! -name "native_build")
         if ( "${{ matrix.cling }}" -imatch "On" )
         {
           cd .\llvm\

--- a/Emscripten-build-instructions.md
+++ b/Emscripten-build-instructions.md
@@ -75,7 +75,8 @@ mkdir native_build
 cd native_build
 cmake -DLLVM_ENABLE_PROJECTS=clang -DLLVM_TARGETS_TO_BUILD=host -DCMAKE_BUILD_TYPE=Release ../llvm/
 cmake --build . --target llvm-tblgen clang-tblgen --parallel $(nproc --all)
-export NATIVE_DIR=$PWD/bin/
+export NATIVE_LLVM_BUILD_DIR=$PWD
+export NATIVE_LLVM_BIN_DIR=$PWD/bin/
 cd ..
 mkdir build
 cd build
@@ -97,7 +98,7 @@ emcmake cmake -DCMAKE_BUILD_TYPE=Release \
                         -DLLVM_BUILD_TOOLS=OFF                          \
                         -DLLVM_ENABLE_LIBPFM=OFF                        \
                         -DCLANG_BUILD_TOOLS=OFF                         \
-                        -DLLVM_NATIVE_TOOL_DIR=$NATIVE_DIR              \
+                        -DLLVM_NATIVE_TOOL_DIR=$NATIVE_LLVM_BIN_DIR              \
                         -DCMAKE_C_FLAGS_RELEASE="-Oz -g0 -DNDEBUG" \
                         -DCMAKE_CXX_FLAGS_RELEASE="-Oz -g0 -DNDEBUG" \
                         -DLLVM_ENABLE_LTO=Full \
@@ -113,7 +114,8 @@ cd native_build
 cmake -DLLVM_ENABLE_PROJECTS=clang -DLLVM_TARGETS_TO_BUILD=host -DCMAKE_BUILD_TYPE=Release -G Ninja ../llvm/
 cmake --build . --target llvm-tblgen clang-tblgen --parallel $(nproc --all)
 $env:PWD_DIR= $PWD.Path
-$env:NATIVE_DIR="$env:PWD_DIR/bin/"
+$env:NATIVE_LLVM_BUILD_DIR="$env:PWD_DIR"
+$env:NATIVE_LLVM_BIN_DIR="$env:PWD_DIR/bin/"
 cd ..
 mkdir build
 cd build
@@ -135,7 +137,7 @@ emcmake cmake -DCMAKE_BUILD_TYPE=Release `
                         -DLLVM_BUILD_TOOLS=OFF                          `
                         -DLLVM_ENABLE_LIBPFM=OFF                        `
                         -DCLANG_BUILD_TOOLS=OFF                         `
-                        -DLLVM_NATIVE_TOOL_DIR="$env:NATIVE_DIR"        `
+                        -DLLVM_NATIVE_TOOL_DIR="$env:NATIVE_LLVM_BIN_DIR"        `
                         -G Ninja `
                         -DCMAKE_C_FLAGS_RELEASE="-Oz -g0 -DNDEBUG" `
                         -DCMAKE_CXX_FLAGS_RELEASE="-Oz -g0 -DNDEBUG" `
@@ -184,7 +186,42 @@ $env:CMAKE_PREFIX_PATH=$env:PREFIX
 $env:CMAKE_SYSTEM_PREFIX_PATH=$env:PREFIX
 ```
 
-on Windows. Now to build and test your Emscripten build of CppInterOp using node on Linux and osx execute the following
+on Windows. efore building the Emscripten version of CppInterOp, we need
+to build ``cppinterop-tblgen`` natively. This tool generates ``.inc`` files
+from ``.td`` definitions and must run on the host (not under Emscripten).
+We use the native LLVM build from the earlier step since it has the required
+``libLLVMTableGen`` library.
+
+On Linux and osx:
+
+```bash
+mkdir -p native_cppinterop_build && cd native_cppinterop_build
+cmake -DCMAKE_BUILD_TYPE=Release \
+      -DLLVM_DIR=$NATIVE_LLVM_BUILD_DIR/lib/cmake/llvm \
+      -DCMAKE_CXX_STANDARD=17 \
+      -DCPPINTEROP_BUILD_TABLEGEN_ONLY=ON \
+       ../
+cmake --build . --target cppinterop-tblgen -j $(nproc --all)
+export CPPINTEROP_TBLGEN_EXE=$(find $PWD -name cppinterop-tblgen -type f | head -1)
+cd ..
+```
+
+On Windows:
+
+```powershell
+mkdir native_cppinterop_build
+cd native_cppinterop_build
+cmake -DCMAKE_BUILD_TYPE=Release `
+      -DLLVM_DIR="$env:NATIVE_LLVM_BUILD_DIR\lib\cmake\llvm" `
+      -DCMAKE_CXX_STANDARD=17 `
+      -DCPPINTEROP_BUILD_TABLEGEN_ONLY=ON `
+..\
+cmake --build . --target cppinterop-tblgen -j $(nproc --all)
+$env:CPPINTEROP_TBLGEN_EXE = (Get-ChildItem -Recurse -Filter "cppinterop-tblgen.exe" | Select-Object -First 1).FullName
+cd ..
+```
+
+Now to build and test your Emscripten build of CppInterOp using node on Linux and osx execute the following
 (BUILD_SHARED_LIBS=ON is only needed if building xeus-cpp, as CppInterOp can be built as an Emscripten static library)
 
 ```bash
@@ -198,6 +235,7 @@ emcmake cmake -DCMAKE_BUILD_TYPE=Release    \
                 -DCMAKE_FIND_ROOT_PATH_MODE_PACKAGE=ON            \
                 -DCMAKE_INSTALL_PREFIX=$PREFIX         \
                 -DSYSROOT_PATH=$SYSROOT_PATH                                   \
+                -DCPPINTEROP_TABLEGEN_EXE=$CPPINTEROP_TBLGEN_EXE \
                 ../
 emmake make -j $(nproc --all) check-cppinterop
 ```
@@ -216,6 +254,7 @@ emcmake cmake -DCMAKE_BUILD_TYPE=Release    `
                 -DCMAKE_FIND_ROOT_PATH_MODE_PACKAGE=ON            `
                 -DLLVM_ENABLE_WERROR=On                      `
                 -DSYSROOT_PATH="$env:SYSROOT_PATH"                     `
+                -DCPPINTEROP_TABLEGEN_EXE="$env:CPPINTEROP_TBLGEN_EXE" `
                 ..\
     emmake make -j $(nproc --all) check-cppinterop
 ```

--- a/docs/Emscripten-build-instructions.rst
+++ b/docs/Emscripten-build-instructions.rst
@@ -95,7 +95,8 @@ and osx
    cd native_build
    cmake -DLLVM_ENABLE_PROJECTS=clang -DLLVM_TARGETS_TO_BUILD=host -DCMAKE_BUILD_TYPE=Release ../llvm/
    cmake --build . --target llvm-tblgen clang-tblgen --parallel $(nproc --all)
-   export NATIVE_DIR=$PWD/bin/
+   export NATIVE_LLVM_BUILD_DIR==$PWD
+   export NATIVE_LLVM_BIN_DIR=$PWD/bin/
    cd ..
    mkdir build
    cd build
@@ -117,7 +118,7 @@ and osx
                  -DLLVM_BUILD_TOOLS=OFF                          \
                  -DLLVM_ENABLE_LIBPFM=OFF                        \
                  -DCLANG_BUILD_TOOLS=OFF                         \
-                 -DLLVM_NATIVE_TOOL_DIR=$NATIVE_DIR 		\
+                 -DLLVM_NATIVE_TOOL_DIR=$NATIVE_LLVM_BIN_DIR 		\
                  -DCMAKE_C_FLAGS_RELEASE="-Oz -g0 -DNDEBUG" \
                  -DCMAKE_CXX_FLAGS_RELEASE="-Oz -g0 -DNDEBUG" \
                  -DLLVM_ENABLE_LTO=Full \
@@ -133,7 +134,8 @@ or executing
    cmake -DLLVM_ENABLE_PROJECTS=clang -DLLVM_TARGETS_TO_BUILD=host -DCMAKE_BUILD_TYPE=Release -G Ninja ../llvm/
    cmake --build . --target llvm-tblgen clang-tblgen --parallel $(nproc --all)
    $env:PWD_DIR= $PWD.Path
-   $env:NATIVE_DIR="$env:PWD_DIR/bin/"
+   $env:NATIVE_LLVM_BUILD_DIR=="$env:PWD_DIR"
+   $env:NATIVE_LLVM_BIN_DIR=="$env:PWD_DIR/bin/"
    cd ..
    mkdir build
    cd build
@@ -155,7 +157,7 @@ or executing
                         -DLLVM_BUILD_TOOLS=OFF                          `
                         -DLLVM_ENABLE_LIBPFM=OFF                        `
                         -DCLANG_BUILD_TOOLS=OFF                         `
-                        -DLLVM_NATIVE_TOOL_DIR="$env:NATIVE_DIR" 		    `
+                        -DLLVM_NATIVE_TOOL_DIR="$env:NATIVE_BIN_DIR" 		    `
                         -G Ninja `
                         -DCMAKE_C_FLAGS_RELEASE="-Oz -g0 -DNDEBUG" `
                         -DCMAKE_CXX_FLAGS_RELEASE="-Oz -g0 -DNDEBUG" `
@@ -218,11 +220,10 @@ On Linux and osx:
 
 .. code:: bash
 
-   cd ../CppInterOp/
-   NATIVE_LLVM_BUILD_DIR=$(pwd)/../llvm-project/native_build
    mkdir -p native_cppinterop_build && cd native_cppinterop_build
    cmake -DCMAKE_BUILD_TYPE=Release \
          -DLLVM_DIR=$NATIVE_LLVM_BUILD_DIR/lib/cmake/llvm \
+	     -DCMAKE_CXX_STANDARD=17 \
          -DCPPINTEROP_BUILD_TABLEGEN_ONLY=ON \
          ../
    cmake --build . --target cppinterop-tblgen -j $(nproc --all)
@@ -233,12 +234,11 @@ On Windows:
 
 .. code:: powershell
 
-   cd ..\CppInterOp\
-   $env:NATIVE_LLVM_BUILD_DIR="$env:PWD_DIR\llvm-project\native_build"
    mkdir native_cppinterop_build
    cd native_cppinterop_build
    cmake -DCMAKE_BUILD_TYPE=Release `
          -DLLVM_DIR="$env:NATIVE_LLVM_BUILD_DIR\lib\cmake\llvm" `
+	     -DCMAKE_CXX_STANDARD=17 `
          -DCPPINTEROP_BUILD_TABLEGEN_ONLY=ON `
          ..\
    cmake --build . --target cppinterop-tblgen -j $(nproc --all)

--- a/utils/TableGen/TableGen.cpp
+++ b/utils/TableGen/TableGen.cpp
@@ -40,8 +40,6 @@ bool CppInterOpTableGenMain(raw_ostream& OS, const RecordKeeper& Records) {
   case GenCppInterOpDecl:
     EmitCppInterOpDecl(Records, OS);
     break;
-  default:
-    return true;
   }
   return false;
 }


### PR DESCRIPTION
This PR will partially fix the broken Emscripten ci on main. If the Emscripten cache is cleared before this is merged into main, the osx jobs will be fixed, and the Windows jobs will be partially fixed. To fix the Windows job we need to work out how to make these 29 unresolved symbols https://github.com/mcbarton/CppInterOp/actions/runs/24837217861/job/72700808805#step:16:304  available to the cppinterop-tblgen executable. I couldn't work out how to do it. 