### PR TITLE
[ci] Remove duplicate build_static_library gate conjunct.

### DIFF
--- a/.github/actions/Build_and_Test_CppInterOp/action.yml
+++ b/.github/actions/Build_and_Test_CppInterOp/action.yml
@@ -574,7 +574,7 @@ runs:
         echo "PREFIX=$env:PREFIX" >> $GITHUB_ENV
 
     - name: Emscripten build of CppInterOp on Windows systems (static library)
-      if: ${{ runner.os == 'Windows' && matrix.wasm == true && env.BUILD_STATIC_LIBRARY == 'On' && env.BUILD_STATIC_LIBRARY == 'On' }}
+      if: ${{ runner.os == 'Windows' && matrix.wasm == true && env.BUILD_STATIC_LIBRARY == 'On' }}
       shell: powershell
       run: |
        .\emsdk\emsdk activate ${{ env.EMSDK_VER }}


### PR DESCRIPTION
The Windows-side WASM static-library step repeated the `matrix.build_static_library == 'On'` check twice in its `if:` expression. Harmless (both conjuncts are equivalent) but reads as a copy-paste smell; drop the duplicate.
