### PR TITLE
[tablegen] Link cppinterop-tblgen against LLVMTableGen.

### DIFF
--- a/.github/actions/Build_and_Test_CppInterOp/action.yml
+++ b/.github/actions/Build_and_Test_CppInterOp/action.yml
@@ -487,7 +487,11 @@ runs:
         mkdir native_cppinterop_build
         pushd native_cppinterop_build
         $env:NATIVE_LLVM_BUILD_DIR="$env:PWD_DIR\llvm-project\native_build"
-        cmake -DCMAKE_BUILD_TYPE=Release `
+        # Use -G Ninja explicitly: cmake's default on Windows is the
+        # Visual Studio multi-config generator, which ignores
+        # CMAKE_BUILD_TYPE and builds Debug, then fails to link against
+        # the Release LLVM static libs produced by the native LLVM build.
+        cmake -G Ninja -DCMAKE_BUILD_TYPE=Release `
               -DLLVM_DIR="$env:NATIVE_LLVM_BUILD_DIR\lib\cmake\llvm" `
               -DCPPINTEROP_ENABLE_TESTING=OFF `
               -DCMAKE_CXX_STANDARD=17 -DLLVM_ENABLE_WERROR=On `

--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -32,27 +32,27 @@ jobs:
         # (cache key reads matrix.clang-runtime, so the field must live on
         # each row). micromamba_shell_init is derived below from runner.os.
         include:
-          - { name: ubu24-arm-emscr-llvm21,   os: ubuntu-24.04-arm, clang-runtime: &clang_rt '21', wasm: true, run-in-prs: true }
+          - { name: ubu24-arm-emscr-llvm21,   os: ubuntu-24.04-arm, clang-runtime: &clang_rt '21', wasm: true }
           - { name: osx26-arm-emscr-llvm21,   os: macos-26,         clang-runtime: *clang_rt, wasm: true }
           - { name: ubu24-x86-emscr-llvm21,   os: ubuntu-24.04,     clang-runtime: *clang_rt, wasm: true }
           - { name: win2025-x86-emscr-llvm21, os: windows-2025,     clang-runtime: *clang_rt, wasm: true }
 
     steps:
     - uses: actions/checkout@v6
-      if: ${{ !(github.event_name == 'pull_request' && matrix.run-in-prs != true) }}
+      if: ${{ !(github.event_name == 'pull_request' && matrix.skip-in-prs == true) }}
 
     - name: Set up Python
-      if: ${{ !(github.event_name == 'pull_request' && matrix.run-in-prs != true) }}
+      if: ${{ !(github.event_name == 'pull_request' && matrix.skip-in-prs == true) }}
       uses: actions/setup-python@v6
       with:
         python-version: '3.11'
 
     - name: Save PR Info
-      if: ${{ !(github.event_name == 'pull_request' && matrix.run-in-prs != true) }}
+      if: ${{ !(github.event_name == 'pull_request' && matrix.skip-in-prs == true) }}
       uses: ./.github/actions/Miscellaneous/Save_PR_Info
 
     - name: Restore cached LLVM-${{ matrix.clang-runtime }} and ${{ matrix.cling == 'On' && 'Cling' || 'Clang-REPL' }} build (Unix like systems emscripten)
-      if: ${{ !(github.event_name == 'pull_request' && matrix.run-in-prs != true) }}
+      if: ${{ !(github.event_name == 'pull_request' && matrix.skip-in-prs == true) }}
       uses: actions/cache/restore@v4
       id: cache
       with:
@@ -62,25 +62,25 @@ jobs:
         key: ${{ env.CLING_HASH }}-${{ runner.os }}-${{ matrix.os }}-clang-${{ matrix.clang-runtime }}.x-emscripten
 
     - name: Setup emsdk
-      if: ${{ !(github.event_name == 'pull_request' && matrix.run-in-prs != true) }}
+      if: ${{ !(github.event_name == 'pull_request' && matrix.skip-in-prs == true) }}
       run: |
           git clone --depth=1 https://github.com/emscripten-core/emsdk.git
           cd emsdk
           ./emsdk install  ${{ env.EMSDK_VER }}
 
     - name: Setup default Build Type
-      if: ${{ !(github.event_name == 'pull_request' && matrix.run-in-prs != true) }}
+      if: ${{ !(github.event_name == 'pull_request' && matrix.skip-in-prs == true) }}
       uses: ./.github/actions/Miscellaneous/Select_Default_Build_Type
 
     - name: Install deps on Windows
-      if: ${{ runner.os == 'windows' && steps.cache.outputs.cache-hit != 'true' && !(github.event_name == 'pull_request' && matrix.run-in-prs != true) }}
+      if: ${{ runner.os == 'windows' && steps.cache.outputs.cache-hit != 'true' && !(github.event_name == 'pull_request' && matrix.skip-in-prs == true) }}
       run: |
         choco install findutils ninja
         $env:PATH="C:\Program Files (x86)\GnuWin32\bin;$env:PATH"
         $env:PATH="C:\Program Files (x86)\Ninja\bin;$env:PATH"
 
     - name: Install deps on MacOS
-      if: ${{ runner.os == 'macOS' && steps.cache.outputs.cache-hit != 'true' && !(github.event_name == 'pull_request' && matrix.run-in-prs != true) }}
+      if: ${{ runner.os == 'macOS' && steps.cache.outputs.cache-hit != 'true' && !(github.event_name == 'pull_request' && matrix.skip-in-prs == true) }}
       run: |
         brew update
         export ARCHITECHURE=$(uname -m)
@@ -95,7 +95,7 @@ jobs:
         brew install ninja
 
     - name: Install deps on Linux
-      if: ${{ runner.os == 'Linux' && steps.cache.outputs.cache-hit != 'true' && !(github.event_name == 'pull_request' && matrix.run-in-prs != true) }}
+      if: ${{ runner.os == 'Linux' && steps.cache.outputs.cache-hit != 'true' && !(github.event_name == 'pull_request' && matrix.skip-in-prs == true) }}
       run: |
         # Install deps
         sudo apt-get update
@@ -104,13 +104,13 @@ jobs:
         sudo apt-get clean
 
     - name: Build LLVM/Cling if the cache is invalid (emscripten)
-      if: ${{ !(github.event_name == 'pull_request' && matrix.run-in-prs != true) }}
+      if: ${{ !(github.event_name == 'pull_request' && matrix.skip-in-prs == true) }}
       uses: ./.github/actions/Build_LLVM_WASM
       with:
         cache-hit: ${{ steps.cache.outputs.cache-hit }}
 
     - name: Cache LLVM-${{ matrix.clang-runtime }} and ${{ matrix.cling == 'On' && 'Cling' || 'Clang-REPL' }} build
-      if: ${{ steps.cache.outputs.cache-hit != 'true' && !(github.event_name == 'pull_request' && matrix.run-in-prs != true) }}
+      if: ${{ steps.cache.outputs.cache-hit != 'true' && !(github.event_name == 'pull_request' && matrix.skip-in-prs == true) }}
       uses: actions/cache/save@v4
       with:
         path: |
@@ -119,24 +119,24 @@ jobs:
         key: ${{ steps.cache.outputs.cache-primary-key }}
 
     - name: install mamba
-      if: ${{ !(github.event_name == 'pull_request' && matrix.run-in-prs != true) }}
+      if: ${{ !(github.event_name == 'pull_request' && matrix.skip-in-prs == true) }}
       uses: mamba-org/setup-micromamba@main
       with:
         init-shell: >-
           ${{ runner.os == 'Windows' && 'powershell' || 'bash' }}
 
     - name: micromamba shell hook
-      if: ${{ runner.os == 'Windows' && !(github.event_name == 'pull_request' && matrix.run-in-prs != true) }}
+      if: ${{ runner.os == 'Windows' && !(github.event_name == 'pull_request' && matrix.skip-in-prs == true) }}
       shell: powershell
       run: |
         micromamba shell hook -s cmd.exe --root-prefix C:\Users\runneradmin\micromamba-root
 
     - name: Build and test CppInterOp
-      if: ${{ !(github.event_name == 'pull_request' && matrix.run-in-prs != true) }}
+      if: ${{ !(github.event_name == 'pull_request' && matrix.skip-in-prs == true) }}
       uses: ./.github/actions/Build_and_Test_CppInterOp
 
     - name: Build xeus-cpp on Unix Systems
-      if: ${{ runner.os != 'windows' && !(github.event_name == 'pull_request' && matrix.run-in-prs != true) }}
+      if: ${{ runner.os != 'windows' && !(github.event_name == 'pull_request' && matrix.skip-in-prs == true) }}
       shell: bash -l {0}
       run: |
         ./emsdk/emsdk activate ${{ env.EMSDK_VER }}
@@ -160,7 +160,7 @@ jobs:
         emmake make -j ${{ env.ncpus }} install
 
     - name: Build xeus-cpp on Windows systems
-      if: ${{ runner.os == 'windows' && !(github.event_name == 'pull_request' && matrix.run-in-prs != true) }}
+      if: ${{ runner.os == 'windows' && !(github.event_name == 'pull_request' && matrix.skip-in-prs == true) }}
       shell: powershell
       run: |
         .\emsdk\emsdk activate ${{ env.EMSDK_VER }}
@@ -184,7 +184,7 @@ jobs:
         emmake make -j ${{ env.ncpus }} install
 
     - name: Test xeus-cpp C++ Emscripten on Unix Systems
-      if: ${{ runner.os != 'windows' && !(github.event_name == 'pull_request' && matrix.run-in-prs != true) }}
+      if: ${{ runner.os != 'windows' && !(github.event_name == 'pull_request' && matrix.skip-in-prs == true) }}
       shell: bash -l {0}
       run: |
         set -e
@@ -193,7 +193,7 @@ jobs:
         node test_xeus_cpp.js
 
     - name: Test xeus-cpp C++ Emscripten on Windows Systems
-      if: ${{ runner.os == 'windows' && !(github.event_name == 'pull_request' && matrix.run-in-prs != true) }}
+      if: ${{ runner.os == 'windows' && !(github.event_name == 'pull_request' && matrix.skip-in-prs == true) }}
       shell: powershell
       run: |
         function Error-OnFailure {
@@ -217,7 +217,7 @@ jobs:
         Error-OnFailure { emrun.bat --browser="chrome.exe" --kill_exit --timeout 60 --browser-args="--headless --no-sandbox"  test_xeus_cpp.html }
 
     - name: Jupyter Lite integration
-      if: ${{ runner.os != 'windows' && !(github.event_name == 'pull_request' && matrix.run-in-prs != true) }}
+      if: ${{ runner.os != 'windows' && !(github.event_name == 'pull_request' && matrix.skip-in-prs == true) }}
       shell: bash -l {0}
       run: |
           cd ./xeus-cpp/
@@ -226,7 +226,7 @@ jobs:
           jupyter lite build --XeusAddon.prefix=${{ env.PREFIX }} --contents notebooks/xeus-cpp-lite-demo.ipynb --contents notebooks/tinyraytracer.ipynb --contents notebooks/images/marie.png --contents notebooks/audio/audio.wav --output-dir dist
 
     - name: Jupyter Lite integration
-      if: ${{ runner.os == 'windows' && !(github.event_name == 'pull_request' && matrix.run-in-prs != true)}}
+      if: ${{ runner.os == 'windows' && !(github.event_name == 'pull_request' && matrix.skip-in-prs == true)}}
       shell: powershell
       run: |
           cd .\xeus-cpp\

--- a/utils/TableGen/CMakeLists.txt
+++ b/utils/TableGen/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(LLVM_LINK_COMPONENTS Support)
+set(LLVM_LINK_COMPONENTS Support TableGen)
 
 add_tablegen(cppinterop-tblgen CPPINTEROP
   CppInterOpEmitter.cpp


### PR DESCRIPTION
CppInterOpEmitter and TableGen.cpp call into the LLVM TableGen runtime (`llvm::Record::getValueAs*`, `llvm::TableGenMain`, `llvm::RecordKeeper::getAllDerivedDefinitions`, the cl::opt machinery's `printGenericOptionDiff` helper). Those symbols live in `libLLVMTableGen`, not `libLLVMSupport`.

On Linux and macOS the link succeeds incidentally: `add_tablegen` defaults to using the LLVM shared library (`libLLVM.so` / `libLLVM.dylib`), which already exports the TableGen symbols. On Windows MSVC every static dependency must be named, so the absence trips a swarm of `LNK2019: unresolved external symbol` errors when building the native cppinterop-tblgen for the WebAssembly cross- build (which sets `LLVM_BUILD_LLVM_DYLIB=OFF` implicitly).

Mirror what `clang/utils/TableGen/CMakeLists.txt` and `mlir/tools/mlir-tblgen/CMakeLists.txt` upstream do: list both `Support` and `TableGen` in `LLVM_LINK_COMPONENTS`. No change in behavior on platforms that already build cleanly; fixes the Windows-WASM linker error.

To make sure the fix exercises on the failing platform in PR CI rather than only on push/schedule, invert the WASM PR-gate field from `run-in-prs` (opt-in) to `skip-in-prs` (opt-out) and drop the now-redundant `run-in-prs: true` from the one row that had it. No row sets `skip-in-prs: true` today, so every WASM row runs on every PR; future rows can set the flag to skip.

