### PR TITLE
Fix to https://github.com/compiler-research/CppInterOp/pull/931

### DIFF
--- a/.github/actions/Build_LLVM_WASM/action.yml
+++ b/.github/actions/Build_LLVM_WASM/action.yml
@@ -81,7 +81,7 @@ runs:
 
         # Trim source trees so the cache stays small. Cling rows additionally
         # need llvm/{utils} for runtime tablegen lookups.
-        rm -rf $(find . -maxdepth 1 ! -name "build" ! -name "llvm" ! -name "clang" ! -name ".")
+        rm -rf $(find . -maxdepth 1 ! -name "build" ! -name "llvm" ! -name "clang" ! -name "." ! -name "native_build"
         keep=('!' -name include '!' -name lib '!' -name cmake '!' -name .)
         if [[ "${cling_on}" == "ON" ]]; then
           keep=('!' -name include '!' -name lib '!' -name cmake '!' -name utils '!' -name .)
@@ -175,7 +175,7 @@ runs:
 
         # Trim source trees so the cache stays small. Cling rows additionally
         # need llvm/{utils} for runtime tablegen lookups.
-        rm -r -force $(find.exe . -maxdepth 1 ! -name "build" ! -name "llvm" ! -name "clang" ! -name ".")
+        rm -r -force $(find.exe . -maxdepth 1 ! -name "build" ! -name "llvm" ! -name "clang" ! -name "." ! -name "native_build")
         $keep = @("!", "-name", "include", "!", "-name", "lib", "!", "-name", "cmake", "!", "-name", ".")
         if ( $cling_on ) {
           $keep = @("!", "-name", "include", "!", "-name", "lib", "!", "-name", "cmake", "!", "-name", "utils", "!", "-name", ".")


### PR DESCRIPTION
https://github.com/compiler-research/CppInterOp/pull/931 didn't keep the change which made sure the native_build directory was kept. This wasn't caught since the Emscripten build on main was not deleted, so the new action was never actually tested. I noticed this was missing in my Emscripten llvm 22 PR, since I could no longer build the cppInterop-tblgen, since the native_build directory no longer existed.