### PR TITLE
Fix Windows Emscripten build instructions to use Ninja generator when building cppinterop-tblgen

### DIFF
--- a/Emscripten-build-instructions.md
+++ b/Emscripten-build-instructions.md
@@ -211,7 +211,7 @@ On Windows:
 ```powershell
 mkdir native_cppinterop_build
 cd native_cppinterop_build
-cmake -DCMAKE_BUILD_TYPE=Release `
+cmake -G Ninja -DCMAKE_BUILD_TYPE=Release `
       -DLLVM_DIR="$env:NATIVE_LLVM_BUILD_DIR\lib\cmake\llvm" `
       -DCMAKE_CXX_STANDARD=17 `
       -DCPPINTEROP_BUILD_TABLEGEN_ONLY=ON `

--- a/docs/Emscripten-build-instructions.rst
+++ b/docs/Emscripten-build-instructions.rst
@@ -236,7 +236,7 @@ On Windows:
 
    mkdir native_cppinterop_build
    cd native_cppinterop_build
-   cmake -DCMAKE_BUILD_TYPE=Release `
+   cmake -G Ninja -DCMAKE_BUILD_TYPE=Release `
          -DLLVM_DIR="$env:NATIVE_LLVM_BUILD_DIR\lib\cmake\llvm" `
 	     -DCMAKE_CXX_STANDARD=17 `
          -DCPPINTEROP_BUILD_TABLEGEN_ONLY=ON `


### PR DESCRIPTION
https://github.com/compiler-research/CppInterOp/pull/928/changes didn't include the documentation changes so that users locally could replicate the build.