### PR TITLE
[ci] Make the LLVM/Cling cache leaner and the key readable.

### DIFF
--- a/.github/actions/Build_LLVM/action.yml
+++ b/.github/actions/Build_LLVM/action.yml
@@ -33,10 +33,23 @@ runs:
                 -DCLANG_ENABLE_ARCMT=OFF                           \
                 -DCLANG_ENABLE_FORMAT=OFF                          \
                 -DCLANG_ENABLE_BOOTSTRAP=OFF                       \
+                -DLLVM_INCLUDE_BENCHMARKS=OFF                      \
+                -DLLVM_INCLUDE_EXAMPLES=OFF                        \
+                -DLLVM_INCLUDE_TESTS=OFF                           \
                 -G Ninja                                           \
                 ../llvm
           ninja clang -j ${{ env.ncpus }}
           ninja LLVMOrcDebugging -j ${{ env.ncpus }}
+          # `clangInterpreter` (clang-repl's Interpreter library) is not
+          # a transitive dep of the `clang` driver, and the cling version
+          # we cache (v1.3) doesn't list it in its `LIBS`. ROOT's bundled
+          # `interpreter/cling/lib/Interpreter/CMakeLists.txt:14` does,
+          # so downstream consumers (the ROOT integration job) link
+          # against `libclangInterpreter.a` and fail with `missing and
+          # no known rule to make it` if it isn't in the cached build.
+          # The trim removes top-level `llvm/CMakeLists.txt`, so we can't
+          # ninja it later from the cache -- it has to be built here.
+          ninja clangInterpreter -j ${{ env.ncpus }}
           ninja clingInterpreter -j ${{ env.ncpus }}
         else
           if [[ "${{ matrix.oop-jit }}" == "On" ]]; then
@@ -74,18 +87,24 @@ runs:
         fi
         cd ../
         rm -rf $(find . -maxdepth 1 ! -name "build" ! -name "llvm" ! -name "clang" ! -name ".")
+        # Source-tree `lib/` dirs hold .cpp already linked into
+        # build/lib/*.a. CppInterOp consumers reference llvm/include and
+        # clang/include via CPLUS_INCLUDE_PATH, never the source `lib/`
+        # (see Build_and_Test_CppInterOp/action.yml). cling/lib stays --
+        # ROOT and downstream consumers may pick up cling header internals
+        # from there.
         if [[ "${cling_on}" == "ON" ]]; then
           cd ./llvm/
-          rm -rf $(find . -maxdepth 1 ! -name "include" ! -name "lib" ! -name "cmake" ! -name "utils" ! -name ".")
+          rm -rf $(find . -maxdepth 1 ! -name "include" ! -name "cmake" ! -name "utils" ! -name ".")
           cd ../clang/
-          rm -rf $(find . -maxdepth 1 ! -name "include" ! -name "lib" ! -name "cmake" ! -name "utils" ! -name ".")
+          rm -rf $(find . -maxdepth 1 ! -name "include" ! -name "cmake" ! -name "utils" ! -name ".")
           cd ../../cling/
           rm -rf $(find . -maxdepth 1 ! -name "include" ! -name "lib" ! -name "cmake" ! -name ".")
         else # repl
           cd ./llvm/
-          rm -rf $(find . -maxdepth 1 ! -name "include" ! -name "lib" ! -name "cmake" ! -name ".")
+          rm -rf $(find . -maxdepth 1 ! -name "include" ! -name "cmake" ! -name ".")
           cd ../clang/
-          rm -rf $(find . -maxdepth 1 ! -name "include" ! -name "lib" ! -name "cmake" ! -name ".")
+          rm -rf $(find . -maxdepth 1 ! -name "include" ! -name "cmake" ! -name ".")
           cd ../..
         fi
 
@@ -124,9 +143,14 @@ runs:
                 -DCLANG_ENABLE_ARCMT=OFF                           `
                 -DCLANG_ENABLE_FORMAT=OFF                          `
                 -DCLANG_ENABLE_BOOTSTRAP=OFF                       `
+                -DLLVM_INCLUDE_BENCHMARKS=OFF                      `
+                -DLLVM_INCLUDE_EXAMPLES=OFF                        `
+                -DLLVM_INCLUDE_TESTS=OFF                           `
                 ..\llvm
           cmake --build . --config Release --target clang --parallel ${{ env.ncpus }}
           cmake --build . --config Release --target LLVMOrcDebugging --parallel ${{ env.ncpus }}
+          # See Linux block above for why clangInterpreter is built here.
+          cmake --build . --config Release --target clangInterpreter --parallel ${{ env.ncpus }}
           cmake --build . --config Release --target clingInterpreter --parallel ${{ env.ncpus }}
         }
         else
@@ -146,20 +170,21 @@ runs:
         }
         cd ..\
         rm -r -force $(find.exe . -maxdepth 1 ! -name "build" ! -name "llvm" ! -name "clang" ! -name ".")
+        # See Linux block above for why source `lib/` is dropped.
         if ( "${{ matrix.cling }}" -imatch "On" )
         {
           cd .\llvm\
-          rm -r -force $(find.exe . -maxdepth 1 ! -name "include" ! -name "lib" ! -name "cmake" ! -name "utils" ! -name ".")
+          rm -r -force $(find.exe . -maxdepth 1 ! -name "include" ! -name "cmake" ! -name "utils" ! -name ".")
           cd ..\clang\
-          rm -r -force $(find.exe . -maxdepth 1 ! -name "include" ! -name "lib" ! -name "cmake" ! -name "utils" ! -name ".")
+          rm -r -force $(find.exe . -maxdepth 1 ! -name "include" ! -name "cmake" ! -name "utils" ! -name ".")
           cd ..\..\cling\
           rm -r -force $(find.exe . -maxdepth 1 ! -name "include" ! -name "lib" ! -name "cmake" ! -name ".")
         }
         else
         {
           cd .\llvm\
-          rm -r -force $(find.exe . -maxdepth 1 ! -name "include" ! -name "lib" ! -name "cmake" ! -name ".")
+          rm -r -force $(find.exe . -maxdepth 1 ! -name "include" ! -name "cmake" ! -name ".")
           cd ..\clang\
-          rm -r -force $(find.exe . -maxdepth 1 ! -name "include" ! -name "lib" ! -name "cmake"  ! -name ".")
+          rm -r -force $(find.exe . -maxdepth 1 ! -name "include" ! -name "cmake"  ! -name ".")
           cd ..\..
         }

--- a/.github/actions/Build_LLVM_WASM/action.yml
+++ b/.github/actions/Build_LLVM_WASM/action.yml
@@ -80,11 +80,13 @@ runs:
         cd ..
 
         # Trim source trees so the cache stays small. Cling rows additionally
-        # need llvm/{utils} for runtime tablegen lookups.
-        rm -rf $(find . -maxdepth 1 ! -name "build" ! -name "llvm" ! -name "clang" ! -name "." ! -name "native_build"
-        keep=('!' -name include '!' -name lib '!' -name cmake '!' -name .)
+        # need llvm/{utils} for runtime tablegen lookups. Source-tree
+        # `lib/` dirs hold .cpp already linked into build/lib/*.a and
+        # nothing on the consumer include path references them.
+        rm -rf $(find . -maxdepth 1 ! -name "build" ! -name "llvm" ! -name "clang" ! -name "." ! -name "native_build")
+        keep=('!' -name include '!' -name cmake '!' -name .)
         if [[ "${cling_on}" == "ON" ]]; then
-          keep=('!' -name include '!' -name lib '!' -name cmake '!' -name utils '!' -name .)
+          keep=('!' -name include '!' -name cmake '!' -name utils '!' -name .)
         fi
         for d in llvm clang; do
           (cd "$d" && rm -rf $(find . -maxdepth 1 "${keep[@]}"))
@@ -176,9 +178,9 @@ runs:
         # Trim source trees so the cache stays small. Cling rows additionally
         # need llvm/{utils} for runtime tablegen lookups.
         rm -r -force $(find.exe . -maxdepth 1 ! -name "build" ! -name "llvm" ! -name "clang" ! -name "." ! -name "native_build")
-        $keep = @("!", "-name", "include", "!", "-name", "lib", "!", "-name", "cmake", "!", "-name", ".")
+        $keep = @("!", "-name", "include", "!", "-name", "cmake", "!", "-name", ".")
         if ( $cling_on ) {
-          $keep = @("!", "-name", "include", "!", "-name", "lib", "!", "-name", "cmake", "!", "-name", "utils", "!", "-name", ".")
+          $keep = @("!", "-name", "include", "!", "-name", "cmake", "!", "-name", "utils", "!", "-name", ".")
         }
         foreach ($d in @("llvm", "clang")) {
           Push-Location $d

--- a/.github/actions/Miscellaneous/Save_PR_Info/action.yml
+++ b/.github/actions/Miscellaneous/Save_PR_Info/action.yml
@@ -13,15 +13,25 @@ runs:
         echo ${{ github.event.number }} > ./pr/NR
         echo ${{ github.repository }} > ./pr/REPO
 
+        # Build a readable, short cache-key tag from `git ls-remote`'s
+        # SHA. Previously we piped the whole `<sha>\t<ref>` line through
+        # `tr '\t' '-'`, which leaked the `refs/tags/...` git internals
+        # into the cache key. Format: `<label>-<short-sha>` -- label first
+        # so the key is greppable, 8-char SHA so it's still unique across
+        # the few tags we care about without the 40-char eyesore.
         cling_on=$(echo "${{ matrix.cling }}" | tr '[:lower:]' '[:upper:]')
         if [[ "$cling_on" == "ON" ]]; then
-          export CLING_HASH=$(git ls-remote https://github.com/root-project/cling.git refs/tags/v${{ matrix.cling-version || env.CLING_VERSION }} | tr '\t' '-')
-          export LLVM_HASH=$(git ls-remote https://github.com/root-project/llvm-project.git cling-llvm${{ matrix.clang-runtime}} | tr '\t' '-')
+          cling_version='${{ matrix.cling-version || env.CLING_VERSION }}'
+          cling_sha=$(git ls-remote https://github.com/root-project/cling.git "refs/tags/v${cling_version}" | awk '{print $1}')
+          export CLING_HASH="cling-v${cling_version}-${cling_sha:0:8}"
+          llvm_sha=$(git ls-remote https://github.com/root-project/llvm-project.git "cling-llvm${{ matrix.clang-runtime }}" | awk '{print $1}')
+          export LLVM_HASH="cling-llvm${{ matrix.clang-runtime }}-${llvm_sha:0:8}"
         else
           export CLING_HASH="Repl"
           # May need to revert back to both having same llvm_hash, as below cause llvm to be rebuilt everytime commit is made to llvm/llvm-project for release a.x
           # which could be quite often for new releases
-          export LLVM_HASH=$(git ls-remote https://github.com/llvm/llvm-project.git refs/heads/release/${{ matrix.clang-runtime}}.x | tr '\t' '-')
+          llvm_sha=$(git ls-remote https://github.com/llvm/llvm-project.git "refs/heads/release/${{ matrix.clang-runtime }}.x" | awk '{print $1}')
+          export LLVM_HASH="llvm-release-${{ matrix.clang-runtime }}.x-${llvm_sha:0:8}"
         fi
 
         echo "CLING_HASH=$CLING_HASH" >> $GITHUB_ENV
@@ -36,18 +46,22 @@ runs:
         echo "${{ github.event.number }}" > ./pr/NR
         echo ${{ github.repository }} > ./pr/REPO
 
+        # See bash block above for the format rationale.
         if ( "${{ matrix.cling }}" -imatch "On" )
         {
-          $env:CLING_HASH_TEMP = ( git ls-remote https://github.com/root-project/cling.git refs/tags/v${{ matrix.cling-version || env.CLING_VERSION }} )
-          $env:CLING_HASH = $env:CLING_HASH_TEMP -replace "\t","-"
+          $cling_version = "${{ matrix.cling-version || env.CLING_VERSION }}"
+          $cling_sha = ( git ls-remote https://github.com/root-project/cling.git "refs/tags/v$cling_version" ).Split("`t")[0]
+          $env:CLING_HASH = "cling-v$cling_version-$($cling_sha.Substring(0, 8))"
+          $llvm_sha = ( git ls-remote https://github.com/root-project/llvm-project.git "cling-llvm${{ matrix.clang-runtime }}" ).Split("`t")[0]
+          $env:LLVM_HASH = "cling-llvm${{ matrix.clang-runtime }}-$($llvm_sha.Substring(0, 8))"
         }
         else
         {
           $env:CLING_HASH="Repl"
           # May need to revert back to both having same llvm_hash, as below cause llvm to be rebuilt everytime commit is made to llvm/llvm-project for release a.x
           # which could be quite often for new releases
-          $env:LLVM_HASH_TEMP = (git ls-remote https://github.com/llvm/llvm-project.git refs/heads/release/${{ matrix.clang-runtime}}.x )
-          $env:LLVM_HASH = $env:LLVM_HASH_TEMP -replace "\t","-"
+          $llvm_sha = ( git ls-remote https://github.com/llvm/llvm-project.git "refs/heads/release/${{ matrix.clang-runtime }}.x" ).Split("`t")[0]
+          $env:LLVM_HASH = "llvm-release-${{ matrix.clang-runtime }}.x-$($llvm_sha.Substring(0, 8))"
         }
 
         echo "CLING_HASH=$env:CLING_HASH"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,7 +87,7 @@ jobs:
           - { name: ubu24-x86-clang22-llvm22-asan-ubsan, os: ubuntu-24.04, compiler: clang-22, clang-runtime: '22', sanitizer: "Address;Undefined" }
           - { name: ubu24-x86-gcc12-llvm21-cppyy-vg, os: ubuntu-24.04, compiler: gcc-12, clang-runtime: '21', cppyy: On, Valgrind: On }
           - { name: ubu24-x86-gcc12-llvm22-cppyy, os: ubuntu-24.04, compiler: gcc-12, clang-runtime: '22', cppyy: On }
-          - { name: ubu24-x86-gcc14-cling-llvm20-cppyy, os: ubuntu-24.04, compiler: gcc-14, clang-runtime: '20', cling: On, cppyy: On, root-llvm-tag: &root_llvm_tag 'cling-llvm20-20260119-01' }
+          - { name: ubu24-x86-gcc14-cling-llvm20-cppyy, os: ubuntu-24.04, compiler: gcc-14, clang-runtime: '20', cling: 'On', cppyy: On, root-llvm-tag: &root_llvm_tag 'cling-llvm20-20260119-01' }
           - name: selfh-ubu22-x86-gcc12-llvm22-cuda
             os: [self-hosted, cuda, heavy]
             compiler: gcc-12
@@ -104,7 +104,7 @@ jobs:
           # MacOS Arm
           - { name: osx26-arm-clang-llvm22, os: macos-26, compiler: clang, clang-runtime: '22', llvm_targets_to_build: host }
           - { name: osx26-arm-clang-llvm21-cppyy, os: macos-26, compiler: clang, clang-runtime: '21', cppyy: On, llvm_targets_to_build: host }
-          - { name: osx26-arm-clang-cling-llvm20-cppyy, os: macos-26, compiler: clang, clang-runtime: '20', cling: On, cppyy: On, root-llvm-tag: *root_llvm_tag }
+          - { name: osx26-arm-clang-cling-llvm20-cppyy, os: macos-26, compiler: clang, clang-runtime: '20', cling: 'On', cppyy: On, root-llvm-tag: *root_llvm_tag }
           - name: osx26-arm-clang-llvm20-oop
             os: macos-26
             compiler: clang
@@ -115,11 +115,11 @@ jobs:
             python-version: '3.13'
           # MacOS X86
           - { name: osx26-x86-clang-llvm21-cppyy, os: macos-26-intel, compiler: clang, clang-runtime: '21', cppyy: On, llvm_targets_to_build: host }
-          - { name: osx26-x86-clang-cling-llvm20-cppyy, os: macos-26-intel, compiler: clang, clang-runtime: '20', cling: On, cppyy: On, root-llvm-tag: *root_llvm_tag }
+          - { name: osx26-x86-clang-cling-llvm20-cppyy, os: macos-26-intel, compiler: clang, clang-runtime: '20', cling: 'On', cppyy: On, root-llvm-tag: *root_llvm_tag }
           # Windows
           - { name: win11-msvc-llvm22, os: windows-11-arm, compiler: msvc, clang-runtime: '22' }
           - { name: win2025-msvc-llvm22, os: windows-2025, compiler: msvc, clang-runtime: '22' }
-          - { name: win2025-msvc-cling-llvm20, os: windows-2025, compiler: msvc, clang-runtime: '20', cling: On, root-llvm-tag: *root_llvm_tag }
+          - { name: win2025-msvc-cling-llvm20, os: windows-2025, compiler: msvc, clang-runtime: '20', cling: 'On', root-llvm-tag: *root_llvm_tag }
 
     steps:
     - uses: actions/checkout@v6


### PR DESCRIPTION
Five tied-together hygiene fixes on the cache and Build_LLVM action. None of them is individually large enough to ship alone; together they shrink the cached artifact, make the key string greppable, fix a latent WASM trim bug, and unblock the parallel ROOT-integration work which needs `clangInterpreter` and the source-tree `lib/` drop.

Source-tree shrink. `Build_LLVM` and `Build_LLVM_WASM` were keeping the source `lib/` dirs of `llvm-project/{llvm,clang}` in the cache even though nothing on the consumer include path references them (`Build_and_Test_CppInterOp/action.yml` only adds `llvm/include` and `clang/include` to `CPLUS_INCLUDE_PATH`) and ROOT with `builtin_*=OFF` links the pre-built `.a` files instead of recompiling. Drop them from the keep-lists. Estimated savings ~50-100 MB compressed per cache row, ~1-1.5 GB across the pool.

Build a leaner LLVM. The cling cmake call gains
`-DLLVM_INCLUDE_BENCHMARKS=OFF -DLLVM_INCLUDE_EXAMPLES=OFF -DLLVM_INCLUDE_TESTS=OFF`, mirroring the repl branch. These suppress targets that never end up in the cache but cost configure time and incremental dependency tracking.

Add `clangInterpreter` to the cling ninja line. ROOT's bundled `interpreter/cling/lib/Interpreter/CMakeLists.txt:14` lists `clangInterpreter` in its `LIBS`, but cling v1.3 (the version we cache against) does not. Without it, downstream consumers that rebuild ROOT's bundled cling fail at link with `libclangInterpreter.a ... missing and no known rule to make it`: the imported target from `ClangTargets.cmake` points at a file that was never built. The Build_LLVM trim deletes the top-level `llvm/CMakeLists.txt`, so the lib cannot be ninja'd later from the cached build -- it must be built here.

Fix Build_LLVM_WASM source-trim. The Linux block's `find` was missing its closing `)`, leaving the substitution unterminated and swallowing the next half-dozen lines. Cling-on-WASM trims have been broken since the action was last refactored; correct on its own merits and required for the source-`lib/` shrink to actually take effect on the WASM side.

Quote `cling: 'On'` on all matrix rows. YAML 1.1 parsers (notably nektos/act) interpret bare `On` as boolean true; the upper-cased comparison in Save_PR_Info against the literal string `"ON"` then fails, the row gets `CLING_HASH=Repl`, and the cache key drifts off real CI. GitHub Actions own parser preserves bare `On` as a string, so real CI was unaffected; quoting eliminates the act-only divergence.

Cache key cleanup. The previous key embedded git ls-remote internals verbatim (`refs/tags/v1.3`), a literal `-clang-` separator that produced `clang-clang-20` when `matrix.compiler` was clang, and a `.x` suffix appended unconditionally to `matrix.root-llvm-tag` (a leftover from when the formula assumed a `release/<major>.x` branch). Save_PR_Info now extracts the SHA via `awk` and prefixes it with a readable label, truncated to 8 chars. The formula in `main.yml` swaps `-clang-` for `-llvm`, drops the `.x`, and only emits `-<root-llvm-tag>` when the tag is set. The shape change itself invalidates the existing cache pool; no salt is needed.

Save_PR_Info is also converted to LF line endings (it was the only CRLF file in the action set, which made every prior diff to the file noisy with `^M`).
