### PR TITLE
[ci] Auto-detect OOP-JIT support from the LLVM version.

### DIFF
--- a/.github/actions/Build_LLVM/action.yml
+++ b/.github/actions/Build_LLVM/action.yml
@@ -55,14 +55,6 @@ runs:
                 -DLLVM_INCLUDE_TESTS=OFF                        \
                 ../llvm
           ninja clang clangInterpreter clangStaticAnalyzerCore
-          if [[ "${{ matrix.oop-jit }}" == "On" ]]; then
-            if [[ "${{ matrix.os }}" == macos* ]]; then
-              SUFFIX="_osx"
-            elif [[ "${{ matrix.os }}" == ubuntu* ]]; then
-              SUFFIX="-x86_64"
-            fi
-            ninja llvm-jitlink-executor orc_rt${SUFFIX} -j ${{ env.ncpus }}       
-          fi
           cd ./tools/
           rm -rf $(find . -maxdepth 1 ! -name "clang" ! -name ".")
           cd ..

--- a/.github/actions/Build_and_Test_CppInterOp/action.yml
+++ b/.github/actions/Build_and_Test_CppInterOp/action.yml
@@ -54,7 +54,6 @@ runs:
                 -DCODE_COVERAGE=${{ env.CODE_COVERAGE }}     \
                 -DCMAKE_INSTALL_PREFIX=$CPPINTEROP_DIR       \
                 -DLLVM_ENABLE_WERROR=On                      \
-                -DLLVM_BUILT_WITH_OOP_JIT=${{ matrix.oop-jit }} \
                 ../
         fi
         docs_on=$(echo "${{ matrix.documentation }}" | tr '[:lower:]' '[:upper:]')

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -136,7 +136,7 @@ jobs:
         path: |
           llvm-project
           ${{ matrix.cling=='On' && 'cling' || '' }}
-        key: ${{ env.CLING_HASH }}-${{ runner.os }}-${{ matrix.os }}-${{ matrix.compiler }}-clang-${{ matrix.clang-runtime }}-${{ matrix.root-llvm-tag || 'none' }}.x-patch-${{ hashFiles(format('patches/llvm/clang{0}-*.patch', matrix.clang-runtime)) || 'none' }}${{ matrix.oop-jit == 'On' && '-oop' || '' }}${{ matrix.sanitizer || '' }}
+        key: ${{ env.CLING_HASH }}-${{ runner.os }}-${{ matrix.os }}-${{ matrix.compiler }}-clang-${{ matrix.clang-runtime }}-${{ matrix.root-llvm-tag || 'none' }}.x-patch-${{ hashFiles(format('patches/llvm/clang{0}-*.patch', matrix.clang-runtime)) || 'none' }}${{ matrix.sanitizer || '' }}
     - name: Setup default Build Type
       uses: ./.github/actions/Miscellaneous/Select_Default_Build_Type
 
@@ -170,6 +170,75 @@ jobs:
           llvm-project
           ${{ matrix.cling=='On' && 'cling' || '' }}
         key: ${{ steps.cache.outputs.cache-primary-key }}
+
+    - name: Install OOP-JIT runtime
+      # Mirror the cmake auto-detect in CMakeLists.txt: rows building
+      # against LLVM >= 22 on Linux x86_64/aarch64 or macOS arm64 get
+      # the OOP path compiled in, so they need the runtime parts at
+      # test time. Cling rows are excluded -- they're on patched
+      # LLVM 20 and don't exercise OOP-JIT.
+      if: ${{ matrix.cling != 'On' && fromJSON(matrix.clang-runtime) >= 22 && (runner.os == 'Linux' || runner.os == 'macOS') && runner.environment != 'self-hosted' }}
+      shell: bash
+      run: |
+        # `llvm-jitlink-executor` is the binary the interpreter forks
+        # to run JIT'd code in a separate process; `orc_rt-<arch>` is
+        # the ORC runtime static archive the JIT links into JIT'd
+        # code. Both are layered on top of the cached vanilla LLVM
+        # build instead of being baked into the cache. The cached
+        # LLVM keeps `LLVM_ENABLE_ASSERTIONS=ON` (catches a class of
+        # CppInterOp bugs at test time); `orc_rt` and the executor
+        # are runtime support code, not the assertion-rich JIT
+        # compiler that runs in-process, so the assertion coverage
+        # is unchanged by sourcing them from packages.
+        #
+        # CppInterOp's `IncrementalCompilerBuilder` (since fb595acb)
+        # discovers `orc_rt` from the driver's toolchain rooted at
+        # the cached build dir. Symlink the apt/brew-installed paths
+        # into that layout so discovery succeeds without needing a
+        # custom search path.
+        set -eu
+        LLVM_BUILD="${GITHUB_WORKSPACE}/llvm-project/build"
+        if [[ "${{ runner.os }}" == "Linux" ]]; then
+          # apt.llvm.org's `llvm-${runtime}` package contains the
+          # executor at `/usr/lib/llvm-${runtime}/bin/llvm-jitlink-executor`;
+          # `libclang-rt-${runtime}-dev` ships orc_rt under
+          # `/usr/lib/llvm-${runtime}/lib/clang/${runtime}/lib/<triple>/`.
+          wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key \
+            | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc > /dev/null
+          codename="$(. /etc/os-release && echo $UBUNTU_CODENAME)"
+          echo "deb http://apt.llvm.org/${codename}/ llvm-toolchain-${codename}-${{ matrix.clang-runtime }} main" \
+            | sudo tee /etc/apt/sources.list.d/llvm.list > /dev/null
+          sudo apt-get update
+          sudo apt-get install -y \
+            llvm-${{ matrix.clang-runtime }} \
+            libclang-rt-${{ matrix.clang-runtime }}-dev
+          PFX=/usr/lib/llvm-${{ matrix.clang-runtime }}
+          mkdir -p "${LLVM_BUILD}/bin"
+          ln -sf "${PFX}/bin/llvm-jitlink-executor" "${LLVM_BUILD}/bin/llvm-jitlink-executor"
+          RT_SRC="${PFX}/lib/clang/${{ matrix.clang-runtime }}/lib"
+          RT_DST="${LLVM_BUILD}/lib/clang/${{ matrix.clang-runtime }}/lib"
+          for triple_dir in "$RT_SRC"/*/; do
+            [[ -d "$triple_dir" ]] || continue
+            triple=$(basename "$triple_dir")
+            mkdir -p "${RT_DST}/${triple}"
+            for archive in "$triple_dir"liborc_rt*.a; do
+              [[ -f "$archive" ]] || continue
+              ln -sf "$archive" "${RT_DST}/${triple}/$(basename "$archive")"
+            done
+          done
+        elif [[ "${{ runner.os }}" == "macOS" ]]; then
+          brew install "llvm@${{ matrix.clang-runtime }}" || brew install llvm
+          PFX="$(brew --prefix llvm@${{ matrix.clang-runtime }} 2>/dev/null || brew --prefix llvm)"
+          mkdir -p "${LLVM_BUILD}/bin"
+          ln -sf "${PFX}/bin/llvm-jitlink-executor" "${LLVM_BUILD}/bin/llvm-jitlink-executor"
+          RT_SRC="${PFX}/lib/clang/${{ matrix.clang-runtime }}/lib/darwin"
+          RT_DST="${LLVM_BUILD}/lib/clang/${{ matrix.clang-runtime }}/lib/darwin"
+          mkdir -p "$RT_DST"
+          for archive in "$RT_SRC"/liborc_rt*.a; do
+            [[ -f "$archive" ]] || continue
+            ln -sf "$archive" "${RT_DST}/$(basename "$archive")"
+          done
+        fi
 
     - name: Setup code coverage
       if: ${{ success() && (matrix.coverage == true) }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -342,13 +342,20 @@ add_definitions(${LLVM_DEFINITIONS_LIST})
 string(REGEX REPLACE "/lib/cmake/llvm$" "" LLVM_BINARY_LIB_DIR "${LLVM_DIR}")
 add_definitions(-DLLVM_BINARY_LIB_DIR="${LLVM_BINARY_LIB_DIR}")
 
-if(LLVM_BUILT_WITH_OOP_JIT)
-  if((CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND CMAKE_SYSTEM_PROCESSOR MATCHES "arm64") OR
-     (CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|aarch64|arm64"))
-    add_definitions(-DLLVM_BUILT_WITH_OOP_JIT)
-  else()
-    message(FATAL_ERROR "LLVM_BUILT_WITH_OOP_JIT is only supported on MacOS arm64 or Linux (x86_64/aarch64). Build aborted.")
-  endif()
+# OOP-JIT support is auto-detected from the LLVM version we're
+# building against. Upstream `release/22.x` ships
+# `clang::IncrementalExecutorBuilder` -- the API the OOP path in
+# `lib/CppInterOp/Compatibility.h` calls into (see fb595acb /
+# PR #924, which retired the local clang20 backport patch in favour
+# of the upstream surface). Older runtimes don't have that API, so
+# the OOP code path stays excluded there and tests fall back to
+# in-process JIT only. The platform predicate matches the set
+# CppInterOp's OOP path has been validated against; relax as more
+# platforms get tested.
+if(LLVM_VERSION_MAJOR GREATER_EQUAL 22 AND
+   ((CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND CMAKE_SYSTEM_PROCESSOR MATCHES "arm64") OR
+    (CMAKE_SYSTEM_NAME STREQUAL "Linux"  AND CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|aarch64|arm64")))
+  add_definitions(-DLLVM_BUILT_WITH_OOP_JIT)
 endif()
 
 # If the llvm sources are present add them with higher priority.


### PR DESCRIPTION
`LLVM_BUILT_WITH_OOP_JIT` was a user-driven cmake variable that told `lib/CppInterOp/Compatibility.h` whether to compile its out-of-process JIT path. CI threaded it through the matrix as `matrix.oop-jit`, which meant we needed dedicated cells (and a dedicated `-oop` cache slot) to flip it on. With fb595acb (#924) porting the OOP path to upstream `release/22.x`'s
`clang::IncrementalExecutorBuilder`, the criterion is no longer a user toggle -- it's "is the upstream API present", which is "LLVM >= 22 on a supported platform".

Switch to that. CMakeLists.txt now sets
`-DLLVM_BUILT_WITH_OOP_JIT` automatically when
`LLVM_VERSION_MAJOR >= 22` and the platform is Linux x86_64/ aarch64 or macOS arm64 (the set CppInterOp's OOP path has been validated against). For older runtimes (clang-runtime 20/21 in the matrix) and other platforms, the OOP `#ifdef`s in `Compatibility.h`, `CppInterOpInterpreter.h`, and
`unittests/CppInterOp/Utils.h` continue to gate the code out exactly as before -- so cling rows (clang-20) and Windows rows keep their in-process-only behavior.

`Build_and_Test_CppInterOp` no longer passes
`-DLLVM_BUILT_WITH_OOP_JIT=${{ matrix.oop-jit }}` because the cmake side decides for itself. The matrix's `oop-jit` field still exists -- it's now just a Valgrind-mode hint at
`Build_and_Test_CppInterOp/action.yml:68`, controlling whether Valgrind invokes the test binary with OOP-specific suppressions. The rows themselves can collapse into the existing `*-llvm22` rows in a follow-up; that's a coverage decision rather than a mechanical one.

Cache-shape changes that ride along:

  - Drop `${{ matrix.oop-jit == 'On' && '-oop' || '' }}` from the cache key in `main.yml`. Non-OOP rows had this evaluate to empty string already, so their key is bit-identical -- no invalidation. The previously `-oop`-suffixed entries get orphaned (still in storage until eviction, just unreferenced).
  - Drop the `oop-jit`-gated `ninja llvm-jitlink-executor orc_rt-<arch>` block from `Build_LLVM`. The cached LLVM build is now uniform between OOP-capable and in-process-only rows on the same axes.
  - Add an `Install OOP-JIT runtime` step in `main.yml` that runs on `clang-runtime >= 22` non-cling Linux/macOS rows and layers `llvm-jitlink-executor` + `orc_rt-<arch>` from apt.llvm.org / Homebrew on top of the cached LLVM, symlinked into the resource layout the driver's toolchain searches. The cached LLVM keeps `LLVM_ENABLE_ASSERTIONS=ON` (which is what catches LLVM-internal assertions during JIT compilation -- the bit we want assertion coverage for); `orc_rt` and the executor are runtime support code, not assertion-rich, so sourcing them from packages doesn't lose signal.

Restoring a separate OOP build shape (e.g. for a future variant that needs an LLVM-internal patch again) is local: re-add the `matrix.oop-jit == 'On' && '-oop' || ''` segment to the cache key and the matching ninja gate in `Build_LLVM`.

