### PR TITLE
[ci] Consolidate the OOP-JIT and in-process LLVM caches.

### DIFF
--- a/.github/actions/Build_LLVM/action.yml
+++ b/.github/actions/Build_LLVM/action.yml
@@ -55,14 +55,6 @@ runs:
                 -DLLVM_INCLUDE_TESTS=OFF                        \
                 ../llvm
           ninja clang clangInterpreter clangStaticAnalyzerCore
-          if [[ "${{ matrix.oop-jit }}" == "On" ]]; then
-            if [[ "${{ matrix.os }}" == macos* ]]; then
-              SUFFIX="_osx"
-            elif [[ "${{ matrix.os }}" == ubuntu* ]]; then
-              SUFFIX="-x86_64"
-            fi
-            ninja llvm-jitlink-executor orc_rt${SUFFIX} -j ${{ env.ncpus }}       
-          fi
           cd ./tools/
           rm -rf $(find . -maxdepth 1 ! -name "clang" ! -name ".")
           cd ..

--- a/.github/actions/Build_and_Test_CppInterOp/action.yml
+++ b/.github/actions/Build_and_Test_CppInterOp/action.yml
@@ -28,8 +28,15 @@ runs:
         export CB_PYTHON_DIR="$PWD/cppyy-backend/python"
         export CPPINTEROP_DIR="$CB_PYTHON_DIR/cppyy_backend"
 
-        # Build CppInterOp next to cling and llvm-project.
-        mkdir build && cd build
+        # Build CppInterOp next to cling and llvm-project. `-p` so we
+        # tolerate the directory pre-existing -- the OOP-JIT install
+        # step in `main.yml` symlinks runtime parts under
+        # `<workspace>/build/unittests/CppInterOp/bin/<config>/` before
+        # this step runs, which implicitly creates the top-level
+        # `build/`. Without `-p`, the bare `mkdir` would fail and the
+        # `&& cd build` short-circuit would leave us in `<workspace>`
+        # with `cmake ../` resolving one level too high.
+        mkdir -p build && cd build
         export CPPINTEROP_BUILD_DIR=$PWD
         cling_on=$(echo "${{ matrix.cling }}" | tr '[:lower:]' '[:upper:]')
         if [[ "${cling_on}" == "ON" ]]; then

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -95,7 +95,6 @@ jobs:
             os: ubuntu-24.04
             compiler: gcc-12
             clang-runtime: '22'
-            llvm_enable_projects: "clang;compiler-rt"
             oop-jit: On
             Valgrind: On
           # MacOS Arm
@@ -106,7 +105,6 @@ jobs:
             os: macos-26
             compiler: clang
             clang-runtime: '22'
-            llvm_enable_projects: "clang;compiler-rt"
             llvm_targets_to_build: host
             oop-jit: On
           # MacOS X86
@@ -136,7 +134,7 @@ jobs:
         path: |
           llvm-project
           ${{ matrix.cling=='On' && 'cling' || '' }}
-        key: ${{ env.CLING_HASH }}-${{ runner.os }}-${{ matrix.os }}-${{ matrix.compiler }}-clang-${{ matrix.clang-runtime }}-${{ matrix.root-llvm-tag || 'none' }}.x-patch-${{ hashFiles(format('patches/llvm/clang{0}-*.patch', matrix.clang-runtime)) || 'none' }}${{ matrix.oop-jit == 'On' && '-oop' || '' }}${{ matrix.sanitizer || '' }}
+        key: ${{ env.CLING_HASH }}-${{ runner.os }}-${{ matrix.os }}-${{ matrix.compiler }}-clang-${{ matrix.clang-runtime }}-${{ matrix.root-llvm-tag || 'none' }}.x-patch-${{ hashFiles(format('patches/llvm/clang{0}-*.patch', matrix.clang-runtime)) || 'none' }}${{ matrix.sanitizer || '' }}
     - name: Setup default Build Type
       uses: ./.github/actions/Miscellaneous/Select_Default_Build_Type
 
@@ -170,6 +168,67 @@ jobs:
           llvm-project
           ${{ matrix.cling=='On' && 'cling' || '' }}
         key: ${{ steps.cache.outputs.cache-primary-key }}
+
+    - name: Install OOP-JIT runtime
+      # OOP rows used to bake `llvm-jitlink-executor` and
+      # `orc_rt-<arch>` into the cached LLVM build (under a
+      # `-oop`-suffixed cache slot). The cache slot is gone, so the
+      # runtime parts are layered on top from system packages
+      # instead. Symlinks point at the test binary's expected
+      # resource-dir layout (`<test-bin-dir>/lib/clang/<major>/lib/
+      # <triple>/`) -- that's where clang::IncrementalExecutorBuilder
+      # looks at runtime, computed from getMainExecutable(). The
+      # cached LLVM keeps `LLVM_ENABLE_ASSERTIONS=ON`, so the
+      # in-process JIT compiler still fires its assertions during
+      # tests; orc_rt and the executor are runtime support, not the
+      # assertion-rich JIT, so sourcing them from packages doesn't
+      # change the assertion signal.
+      if: ${{ matrix.oop-jit == 'On' && runner.environment != 'self-hosted' }}
+      shell: bash
+      run: |
+        set -eu
+        BIN_DIR="${GITHUB_WORKSPACE}/build/unittests/CppInterOp/bin/${{ env.BUILD_TYPE }}"
+        # Pre-create the resource-dir layout so symlinks land in
+        # place before CppInterOp builds the test binary into the
+        # same directory.
+        mkdir -p "${BIN_DIR}"
+        if [[ "${{ runner.os }}" == "Linux" ]]; then
+          wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key \
+            | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc > /dev/null
+          codename="$(. /etc/os-release && echo $UBUNTU_CODENAME)"
+          echo "deb http://apt.llvm.org/${codename}/ llvm-toolchain-${codename}-${{ matrix.clang-runtime }} main" \
+            | sudo tee /etc/apt/sources.list.d/llvm.list > /dev/null
+          sudo apt-get update
+          sudo apt-get install -y \
+            llvm-${{ matrix.clang-runtime }} \
+            libclang-rt-${{ matrix.clang-runtime }}-dev
+          PFX=/usr/lib/llvm-${{ matrix.clang-runtime }}
+          mkdir -p "${BIN_DIR}/bin"
+          ln -sf "${PFX}/bin/llvm-jitlink-executor" "${BIN_DIR}/bin/llvm-jitlink-executor"
+          RT_SRC="${PFX}/lib/clang/${{ matrix.clang-runtime }}/lib"
+          RT_DST="${BIN_DIR}/lib/clang/${{ matrix.clang-runtime }}/lib"
+          for triple_dir in "${RT_SRC}"/*/; do
+            [[ -d "${triple_dir}" ]] || continue
+            triple=$(basename "${triple_dir}")
+            mkdir -p "${RT_DST}/${triple}"
+            for archive in "${triple_dir}"liborc_rt*.a; do
+              [[ -f "${archive}" ]] || continue
+              ln -sf "${archive}" "${RT_DST}/${triple}/$(basename "${archive}")"
+            done
+          done
+        elif [[ "${{ runner.os }}" == "macOS" ]]; then
+          brew install "llvm@${{ matrix.clang-runtime }}" || brew install llvm
+          PFX="$(brew --prefix llvm@${{ matrix.clang-runtime }} 2>/dev/null || brew --prefix llvm)"
+          mkdir -p "${BIN_DIR}/bin"
+          ln -sf "${PFX}/bin/llvm-jitlink-executor" "${BIN_DIR}/bin/llvm-jitlink-executor"
+          RT_SRC="${PFX}/lib/clang/${{ matrix.clang-runtime }}/lib/darwin"
+          RT_DST="${BIN_DIR}/lib/clang/${{ matrix.clang-runtime }}/lib/darwin"
+          mkdir -p "${RT_DST}"
+          for archive in "${RT_SRC}"/liborc_rt*.a; do
+            [[ -f "${archive}" ]] || continue
+            ln -sf "${archive}" "${RT_DST}/$(basename "${archive}")"
+          done
+        fi
 
     - name: Setup code coverage
       if: ${{ success() && (matrix.coverage == true) }}


### PR DESCRIPTION
Two OOP-JIT cells (`ubu24-x86-gcc12-llvm22-oop-vg`, `osx26-arm-clang-llvm22-oop`) used a dedicated `-oop`-suffixed cache slot. `Build_LLVM` baked `llvm-jitlink-executor` and `orc_rt-<arch>` into that slot under a `matrix.oop-jit == 'On'` gate, and the matrix rows additionally enabled
`llvm_enable_projects: clang;compiler-rt` so the orc_rt target existed in the LLVM build. The whole arrangement existed because OOP-JIT used to require `clang20-1-out-of-process.patch` (a 966-line backport of `clang::Interpreter::JITConfig`), which genuinely changed the cached binary.

That patch retired in fb595acb (#924) when OOP-JIT moved to upstream `release/22.x`'s `clang::IncrementalExecutorBuilder`. The OOP and in-process LLVM builds are now identical modulo the two runtime-only artifacts (`llvm-jitlink-executor` and `orc_rt`). Drop the dedicated cache slot and source the runtime parts from packages instead, so OOP rows free-ride the same cache as their in-process counterparts.

Cache-side:

  - `main.yml`: drop the `${{ matrix.oop-jit == 'On' && '-oop' || '' }}` segment from the cache key. Every non-OOP key is bit-identical to before, so existing cache entries continue to hit -- no invalidation. The previously `-oop`-suffixed entries become orphaned (still in storage until eviction, just unreferenced).
  - `main.yml` matrix: drop `llvm_enable_projects: clang;compiler-rt` from both OOP rows so they share build config, and therefore cache content, with their non-OOP twins on the same axes.
  - `Build_LLVM/action.yml`: drop the `if oop-jit == On: ninja llvm-jitlink-executor orc_rt-<suffix>` block. The cache now contains a vanilla LLVM build regardless of `matrix.oop-jit`.

Runtime-side, OOP coverage preserved:

  - `main.yml` adds an `Install OOP-JIT runtime` step gated on `matrix.oop-jit == 'On'`. It installs the runtime parts via apt.llvm.org (`llvm-${runtime}` for the executor binary, `libclang-rt-${runtime}-dev` for the orc_rt static archive) on Linux, or `brew install llvm@${runtime}` on macOS. The install step then symlinks both into the test binary's expected resource-dir layout (`<test-bin-dir>/lib/clang/<major>/{bin,lib/<triple>}/`). That path matters: at test time `clang::IncrementalExecutor Builder` derives the resource directory from `getMainExecutable()` (the test binary), and the upstream safety check refuses to use an `orc_rt` whose path isn't under that directory. Symlinking before `Build_and_Test_ CppInterOp` runs is fine -- CppInterOp's build doesn't overwrite those paths.
  - `Build_and_Test_CppInterOp/action.yml` keeps both the `-DLLVM_BUILT_WITH_OOP_JIT=${{ matrix.oop-jit }}` cmake flag and the OOP-specific Valgrind suppression branch. The OOP test fixtures from PR #717 still parameterize over both in-process and OOP modes on those rows.

The cached LLVM stays `LLVM_ENABLE_ASSERTIONS=ON`, so the JIT compiler that runs in-process during CppInterOp's tests still fires its internal assertions -- which is the assertion signal worth keeping. `orc_rt` and `llvm-jitlink-executor` are runtime support code, not assertion-rich, so sourcing them from packages doesn't lose coverage.

Two follow-ups out of scope for this commit:

  - Retire the `LLVM_BUILT_WITH_OOP_JIT` macro from CppInterOp source. The compile-time gate becomes an LLVM-version / platform check, and a runtime check decides whether to actually use OOP. After that, `Build_and_Test_CppInterOp` no longer needs the cmake flag and the matrix's `oop-jit` field becomes purely a Valgrind-mode hint.
  - Bundle `orc_rt` (and ship `llvm-jitlink-executor`) inside `libclangCppInterOp.so`'s distribution so the library is self-contained. Removes the install step entirely.
