### PR TITLE
Add missing ) so that Emscripten llvm action works

### DIFF
--- a/.github/actions/Build_LLVM_WASM/action.yml
+++ b/.github/actions/Build_LLVM_WASM/action.yml
@@ -81,7 +81,7 @@ runs:
 
         # Trim source trees so the cache stays small. Cling rows additionally
         # need llvm/{utils} for runtime tablegen lookups.
-        rm -rf $(find . -maxdepth 1 ! -name "build" ! -name "llvm" ! -name "clang" ! -name "." ! -name "native_build"
+        rm -rf $(find . -maxdepth 1 ! -name "build" ! -name "llvm" ! -name "clang" ! -name "." ! -name "native_build")
         keep=('!' -name include '!' -name lib '!' -name cmake '!' -name .)
         if [[ "${cling_on}" == "ON" ]]; then
           keep=('!' -name include '!' -name lib '!' -name cmake '!' -name utils '!' -name .)


### PR DESCRIPTION
I have this added in my Emscripten llvm 22 PR so that the Emscripten llvm action can work. I have just opened this separate PR so that CppInterOps ci on main can pass until the Emscripten llvm 22 PR has been approved to keep everything moving. I will cancel the cis so this PR doesn't interfere with anything else.