### PR TITLE
[ci] Source asan LLVM from ci-workflows recipe cache.

### DIFF
--- a/.github/actions/Build_and_Test_CppInterOp/action.yml
+++ b/.github/actions/Build_and_Test_CppInterOp/action.yml
@@ -14,14 +14,36 @@ runs:
           CPLUS_INCLUDE_PATH="/usr/lib/llvm-${{ matrix.clang-runtime }}/include:$PWD/include"
         else
           LLVM_DIR="$(pwd)/llvm-project"
-          LLVM_BUILD_DIR="$(pwd)/llvm-project/build"
+          # Two layouts coexist on github-hosted runners:
+          #   - rows that build LLVM from source (everything except the
+          #     asan row today) leave a build tree at llvm-project/build/.
+          #   - rows that pull a prebuilt asset via setup-recipe extract
+          #     a cmake --install tree directly under llvm-project/, with
+          #     LLVMConfig.cmake at lib/cmake/llvm/ (no build/ prefix).
+          # Probe for lib/cmake/llvm to pick LLVM_BUILD_DIR; LLVMConfig.cmake
+          # lives there in either layout.
+          if [[ -d "$LLVM_DIR/lib/cmake/llvm" ]]; then
+            LLVM_BUILD_DIR="$LLVM_DIR"
+          else
+            LLVM_BUILD_DIR="$LLVM_DIR/build"
+          fi
           cling_on=$(echo "${{ matrix.cling }}" | tr '[:lower:]' '[:upper:]')
+          # FIXME: CPLUS_INCLUDE_PATH itself is a workaround for missing
+          # target-based include propagation in CppInterOp's cmake;
+          # find_package(LLVM)/Clang already export INTERFACE_INCLUDE_DIRECTORIES.
+          # Drop this whole CPLUS_INCLUDE_PATH plumbing once the cmake side
+          # depends on imported targets correctly.
+          #
+          # CPLUS_INCLUDE_PATH unions both layouts' include roots:
+          # ${LLVM_DIR}/include is the install-tree flat header directory;
+          # ${LLVM_DIR}/{llvm,clang}/include and ${LLVM_BUILD_DIR}/{include,tools/clang/include}
+          # are the build-tree split. Non-existent paths in the union are harmless.
           if [[ "${cling_on}" == "ON" ]]; then
             CLING_DIR="$(pwd)/cling"
             CLING_BUILD_DIR="$(pwd)/cling/build"
-            CPLUS_INCLUDE_PATH="${CLING_DIR}/tools/cling/include:${CLING_BUILD_DIR}/include:${LLVM_DIR}/llvm/include:${LLVM_DIR}/clang/include:${LLVM_BUILD_DIR}/include:${LLVM_BUILD_DIR}/tools/clang/include:$PWD/include"
+            CPLUS_INCLUDE_PATH="${CLING_DIR}/tools/cling/include:${CLING_BUILD_DIR}/include:${LLVM_DIR}/include:${LLVM_DIR}/llvm/include:${LLVM_DIR}/clang/include:${LLVM_BUILD_DIR}/include:${LLVM_BUILD_DIR}/tools/clang/include:$PWD/include"
           else
-            CPLUS_INCLUDE_PATH="${LLVM_DIR}/llvm/include:${LLVM_DIR}/clang/include:${LLVM_BUILD_DIR}/include:${LLVM_BUILD_DIR}/tools/clang/include:$PWD/include"
+            CPLUS_INCLUDE_PATH="${LLVM_DIR}/include:${LLVM_DIR}/llvm/include:${LLVM_DIR}/clang/include:${LLVM_BUILD_DIR}/include:${LLVM_BUILD_DIR}/tools/clang/include:$PWD/include"
           fi
         fi
 
@@ -32,6 +54,13 @@ runs:
         mkdir build && cd build
         export CPPINTEROP_BUILD_DIR=$PWD
         cling_on=$(echo "${{ matrix.cling }}" | tr '[:lower:]' '[:upper:]')
+        # Propagate matrix.sanitizer to CppInterOp's cmake. CppInterOp's
+        # CMakeLists tried to recover this from the LLVM build's
+        # CMakeCache.txt via load_cache(); install trees don't ship
+        # CMakeCache.txt (it's build state, not install state), so on
+        # the recipe-cached path CppInterOp would compile without
+        # -fsanitize=address while libLLVMSupport.a is asan-instrumented,
+        # leaving __asan_* symbols unresolved at link.
         if [[ "${cling_on}" == "ON" ]]; then
           cmake -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }}        \
                 -DCPPINTEROP_USE_CLING=ON                                  \
@@ -40,6 +69,7 @@ runs:
                 -DCling_DIR=$LLVM_BUILD_DIR/tools/cling         \
                 -DLLVM_DIR=$LLVM_BUILD_DIR/lib/cmake/llvm       \
                 -DClang_DIR=$LLVM_BUILD_DIR/lib/cmake/clang     \
+                -DLLVM_USE_SANITIZER="${{ matrix.sanitizer }}"  \
                 -DBUILD_SHARED_LIBS=ON                          \
                 -DCODE_COVERAGE=${{ env.CODE_COVERAGE }}        \
                 -DCMAKE_INSTALL_PREFIX=$CPPINTEROP_DIR          \
@@ -50,6 +80,7 @@ runs:
                 -DCPPINTEROP_INCLUDE_DOCS=${{ matrix.documentation }} \
                 -DLLVM_DIR=$LLVM_BUILD_DIR/lib/cmake/llvm    \
                 -DClang_DIR=$LLVM_BUILD_DIR/lib/cmake/clang  \
+                -DLLVM_USE_SANITIZER="${{ matrix.sanitizer }}" \
                 -DBUILD_SHARED_LIBS=ON                       \
                 -DCODE_COVERAGE=${{ env.CODE_COVERAGE }}     \
                 -DCMAKE_INSTALL_PREFIX=$CPPINTEROP_DIR       \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -89,7 +89,7 @@ jobs:
           - { name: ubu24-arm-gcc12-llvm22-vg, os: ubuntu-24.04-arm, compiler: gcc-12, clang-runtime: '22', Valgrind: On }
           # Ubuntu X86
           - { name: ubu24-x86-gcc12-llvm22, os: ubuntu-24.04, compiler: gcc-12, clang-runtime: '22' }
-          - { name: ubu24-x86-clang22-llvm22-asan-ubsan, os: ubuntu-24.04, compiler: clang-22, clang-runtime: '22', sanitizer: "Address;Undefined" }
+          - { name: ubu24-x86-clang22-llvm22-asan-ubsan, os: ubuntu-24.04, compiler: clang-22, clang-runtime: '22', sanitizer: "Address;Undefined", use-recipe: 'llvm-asan' }
           - { name: ubu24-x86-gcc12-llvm21-cppyy-vg, os: ubuntu-24.04, compiler: gcc-12, clang-runtime: '21', cppyy: On, Valgrind: On }
           - { name: ubu24-x86-gcc12-llvm22-cppyy, os: ubuntu-24.04, compiler: gcc-12, clang-runtime: '22', cppyy: On }
           - { name: ubu24-x86-gcc14-cling-llvm20-cppyy, os: ubuntu-24.04, compiler: gcc-14, clang-runtime: '20', cling: 'On', cppyy: On, root-llvm-tag: &root_llvm_tag 'ROOT-llvm20-20260408-01' }
@@ -127,7 +127,7 @@ jobs:
       uses: ./.github/actions/Miscellaneous/Save_PR_Info
 
     - name: Restore cached LLVM-${{ matrix.clang-runtime }} and ${{ matrix.cling == 'On' && 'Cling' || 'Clang-REPL' }} build
-      if: ${{ runner.environment != 'self-hosted' }}
+      if: ${{ runner.environment != 'self-hosted' && !matrix.use-recipe }}
       uses: actions/cache/restore@v4
       id: cache
       with:
@@ -155,14 +155,43 @@ jobs:
         sudo apt-get install -y llvm-${{ matrix.clang-runtime }}-dev libclang-${{ matrix.clang-runtime }}-dev clang-${{ matrix.clang-runtime }} libpolly-${{ matrix.clang-runtime }}-dev libzstd-dev
 
     - name: Build LLVM-${{ matrix.clang-runtime }} and ${{ matrix.cling == 'On' && 'Cling' || 'Clang-REPL' }}
-      if: ${{ runner.environment != 'self-hosted' }}
+      if: ${{ runner.environment != 'self-hosted' && !matrix.use-recipe }}
       uses: ./.github/actions/Build_LLVM
       with:
         cache-hit: ${{ steps.cache.outputs.cache-hit }}
 
+    # When matrix.use-recipe is set, this row pulls a prebuilt LLVM tree
+    # from compiler-research/ci-workflows' Releases cache. The actions/
+    # cache restore + Build_LLVM + cache save trio above is gated by
+    # !matrix.use-recipe so it doesn't run for these rows; the recipe
+    # cache is the only place LLVM comes from. Downstream
+    # Build_and_Test_* discovers the tree at
+    # $GITHUB_WORKSPACE/llvm-project automatically.
+    #
+    # build-on-miss: false — refuse to rebuild LLVM inline on a cache
+    # miss. A miss here means the publish-recipe pipeline didn't warm
+    # the cell we asked for; rebuilding inline (~30 min) on every PR
+    # run would defeat the point of the cache. Fail fast with a
+    # populate-via-gh-workflow-run hint instead, and let the operator
+    # warm the cell explicitly.
+    #
+    # Pinned to a ci-workflows commit sha for reproducibility; bump
+    # explicitly when consuming new behaviour. arch is hard-coded to
+    # x86_64 since the only use-recipe row today is the ubuntu-24.04
+    # asan one — generalise to runner.arch when more rows migrate.
+    - name: Setup recipe ${{ matrix.use-recipe }} (LLVM ${{ matrix.clang-runtime }})
+      if: ${{ runner.environment != 'self-hosted' && matrix.use-recipe }}
+      uses: compiler-research/ci-workflows/actions/setup-recipe@2959f335445995fff4613bc1fa868171657b7672
+      with:
+        recipe: ${{ matrix.use-recipe }}
+        version: ${{ matrix.clang-runtime }}
+        os: ${{ matrix.os }}
+        arch: x86_64
+        build-on-miss: 'false'
+
     - name: Cache LLVM-${{ matrix.clang-runtime }} and ${{ matrix.cling == 'On' && 'Cling' || 'Clang-REPL' }} build
       uses: actions/cache/save@v4
-      if: ${{ runner.environment != 'self-hosted' && steps.cache.outputs.cache-hit != 'true' }}
+      if: ${{ runner.environment != 'self-hosted' && !matrix.use-recipe && steps.cache.outputs.cache-hit != 'true' }}
       with:
         path: |
           llvm-project


### PR DESCRIPTION
The ubu24-x86-clang22-llvm22-asan-ubsan matrix row now pulls a prebuilt asan-instrumented LLVM via
compiler-research/ci-workflows' setup-recipe action instead of rebuilding LLVM in this repo's CI. Other rows are unchanged; the existing actions/cache restore + Build_LLVM + cache save trio is gated by !matrix.use-recipe so it doesn't run for the asan row at all — the recipe cache is the only place LLVM comes from.

setup-recipe is invoked with build-on-miss: false. A cache miss here means the publish-recipe pipeline didn't warm the cell we asked for, and rebuilding LLVM inline (~30 min) on every PR run would defeat the point of the cache. The action fails fast with a populate-via-gh-workflow-run hint, letting the operator warm the cell explicitly rather than silently paying the build cost on every consumer.

Downstream Build_and_Test_CppInterOp discovers the tree at $GITHUB_WORKSPACE/llvm-project automatically; no env wiring needed.

setup-recipe is pinned to a ci-workflows commit sha (2959f335445995fff4613bc1fa868171657b7672 — the trim-tightening commit on main). Bump explicitly when consuming new behaviour.

This is the first end-to-end consumer migration. The expectation: the asan row's first PR run hits the published asan asset on compiler-research/ci-workflows' cache release, downloads the ~1-2 GB tree in seconds, and runs Build_and_Test_CppInterOp against it. CI minutes saved per PR: ~30 minutes (the previous in-place asan-LLVM build).

Other rows (cling, Windows, self-hosted CUDA, Linux/macOS non-cling) keep using the local Build_LLVM action for now. Migration to setup-system-llvm for the Linux/macOS non-cling rows depends on the setup-system-llvm action landing in ci-workflows main; tracked as a follow-up branch.
