### PR TITLE
Only inject `-resource-dir` when we actually have a path

### DIFF
--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -4420,8 +4420,9 @@ InterpRef CreateInterpreter(const std::vector<const char*>& Args /*={}*/,
       (T.isOSDarwin() || T.isOSLinux()))
     ResourceDir = DetectResourceDir();
 
-  std::vector<const char*> ClingArgv = {"-resource-dir", ResourceDir.c_str(),
-                                        "-std=c++14"};
+  std::vector<const char*> ClingArgv = {"-std=c++14"};
+  if (!ResourceDir.empty())
+    ClingArgv.insert(ClingArgv.begin(), {"-resource-dir", ResourceDir.c_str()});
   ClingArgv.insert(ClingArgv.begin(), MainExecutableName.c_str());
 #ifdef _WIN32
   // FIXME : Workaround Sema::PushDeclContext assert on windows


### PR DESCRIPTION
Only inject -resource-dir when we actually have a path. An empty value would cause clang to consume the next argument (e.g. "-std=c++14") as the resource-dir value, silently dropping it.

This fixes running the tests in my setup where I use a different Clang version as the default on the system from the one I build CppInterOp against. This makes `DetectResourceDir()` fail because it just uses the `clang` executable. One could imagine also to improve `DetectResourceDir()` to deal with this case, but it's not necessary for now because my setup also works without passing `-resource-dir` at all (using CppInterOp inside ROOT with Cling).