### PR TITLE
[ci] Extract prepare-dell into ci-workflows/actions/wake-on-lan.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,54 +15,10 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  prepare-dell:
-    name: Activate self-host infrastructure
-    runs-on: [self-hosted, spotter]
-    steps:
-      - name: Send Magic Packet
-        env:
-          TARGET_IP: 192.168.100.30
-          MAC_ADDR: a4:bb:6d:51:d5:d2
-          # The container has no ping, emulate it.
-        run: |
-          # Mask the IP and potential broadcast to keep logs clean
-          echo "::add-mask::$MAC_ADDR"
-          echo "::add-mask::$BROADCAST"
-          echo "::add-mask::$TARGET_IP"
-          BROADCAST=$(echo $TARGET_IP | sed 's/\.[0-9]*$/ .255/' | tr -d ' ')
-          PING="timeout 1 bash -c 'cat < /dev/null > /dev/tcp/$TARGET_IP/22' 2>/dev/null"
-
-          # Install tool silently
-          sudo apt-get update -qq && sudo apt-get install -y -qq wakeonlan > /dev/null
-
-          # Check if already awake (using the Bash TCP PING variable)
-          if eval "$PING"; then
-            echo "Target machine is already awake. Exiting."
-            exit 0
-          fi
-
-          # If offline, send WoL
-          echo "Machine is offline. Sending WoL..."
-          wakeonlan -i $BROADCAST $MAC_ADDR > /dev/null
-
-          # Wait & Verify Loop (checks every 10s for 4 minutes)
-          echo "Waiting for response (checking Port 22)..."
-          for i in {1..24}; do
-            if eval "$PING"; then
-              echo "Machine is online and SSH is ready."
-              exit 0
-            fi
-            sleep 10
-          done
-
-          echo "Error: Target hardware did not respond within the timeout period."
-          exit 1
-
   build:
-    needs: prepare-dell
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
-    env:
+    env: &build_env
       # Default cling version for cling rows; override per-row if a bump is
       # needed. The matching root-llvm-tag is pinned via a YAML anchor
       # (&root_llvm_tag) on the first cling row and referenced via
@@ -93,11 +49,8 @@ jobs:
           - { name: ubu24-x86-gcc12-llvm21-cppyy-vg, os: ubuntu-24.04, compiler: gcc-12, clang-runtime: '21', cppyy: On, Valgrind: On }
           - { name: ubu24-x86-gcc12-llvm22-cppyy, os: ubuntu-24.04, compiler: gcc-12, clang-runtime: '22', cppyy: On }
           - { name: ubu24-x86-gcc14-cling-llvm20-cppyy, os: ubuntu-24.04, compiler: gcc-14, clang-runtime: '20', cling: 'On', cppyy: On, root-llvm-tag: &root_llvm_tag 'ROOT-llvm20-20260408-01' }
-          - name: selfh-ubu22-x86-gcc12-llvm22-cuda
-            os: [self-hosted, cuda, heavy]
-            compiler: gcc-12
-            clang-runtime: '22'
-            coverage: true
+          # selfh-ubu22-x86-gcc12-llvm22-cuda lives in `build-selfhost`
+          # below; it's the only row that needs the dell awake.
           - name: ubu24-x86-gcc12-llvm22-vg
             os: ubuntu-24.04
             compiler: gcc-12
@@ -115,7 +68,7 @@ jobs:
           - { name: win2025-msvc-llvm22, os: windows-2025, compiler: msvc, clang-runtime: '22' }
           - { name: win2025-msvc-cling-llvm20, os: windows-2025, compiler: msvc, clang-runtime: '20', cling: 'On', root-llvm-tag: *root_llvm_tag }
 
-    steps:
+    steps: &build_steps
     - uses: actions/checkout@v6
 
     - name: Set up Python
@@ -181,7 +134,7 @@ jobs:
     # asan one — generalise to runner.arch when more rows migrate.
     - name: Setup recipe ${{ matrix.use-recipe }} (LLVM ${{ matrix.clang-runtime }})
       if: ${{ runner.environment != 'self-hosted' && matrix.use-recipe }}
-      uses: compiler-research/ci-workflows/actions/setup-recipe@2959f335445995fff4613bc1fa868171657b7672
+      uses: compiler-research/ci-workflows/actions/setup-recipe@main
       with:
         recipe: ${{ matrix.use-recipe }}
         version: ${{ matrix.clang-runtime }}
@@ -246,6 +199,28 @@ jobs:
       # When debugging increase to a suitable value!
       timeout-minutes: 30
 
+  # The dell sleeps between runs; wake it before build-selfhost
+  # dispatches to it.
+  prepare-dell:
+    runs-on: [self-hosted, spotter]
+    steps:
+      - uses: compiler-research/ci-workflows/actions/wake-on-lan@main
+        with:
+          mac: a4:bb:6d:51:d5:d2
+          target-host: 192.168.100.30
 
-
-
+  build-selfhost:
+    needs: prepare-dell
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    env: *build_env
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: selfh-ubu22-x86-gcc12-llvm22-cuda
+            os: [self-hosted, cuda, heavy]
+            compiler: gcc-12
+            clang-runtime: '22'
+            coverage: true
+    steps: *build_steps


### PR DESCRIPTION
The 38-line inline `Send Magic Packet` step is straight-line wake-on- LAN logic that has nothing CppInterOp-specific in it: send a magic packet to a runner's MAC, wait for SSH to come back, fail after a timeout. Other compiler-research repos that drive a self-hosted runner the same way (clad and cppyy will, eventually) reimplement the same step. Hoist it into a single composite action in ci-workflows so each consumer becomes a four-line `uses:` plus inputs.

Diff:

  - 38 lines of inline `sudo apt-get install wakeonlan` + bash TCP probe + magic-packet send + retry loop.
  + 4-line `uses: ci-workflows/actions/wake-on-lan@main` with mac and target-host inputs.

Behaviour parity with the inline step (verified by reading both side-by-side):

  - Mask MAC / IP / broadcast in run logs                kept
  - TCP /dev/tcp/$host/22 readiness probe                kept
    (action defaults target-port=22)
  - Pre-check: skip magic packet if already responsive   kept
  - Send magic packet                                    kept
  - Retry loop: 10 s x 24 = 4 min                        kept
    (action: timeout-seconds=240, default)
  - Broadcast derived from IPv4 (a.b.c.d -> a.b.c.255)   kept
    (action computes when broadcast input is empty)

Behaviour upgrades (free as part of the migration):

  - No `apt-get install wakeonlan` -- the action sends the magic packet via pure-stdlib python3, which is on every GHA runner. Saves ~2 s per run on the wake step.
  - No `sudo` -- UDP sendto on an arbitrary destination port doesn't require privileges. The previous `sudo wakeonlan` was only needed because the wakeonlan binary opens a raw socket in some implementations.
  - env.ACT skip on every step. Under act (bin/repro / plain act), the action is a no-op success and `build`'s `needs: prepare- dell` chain is satisfied without an `if: success() || env.ACT` on build itself.
  - Conditional `runs-on` on prepare-dell: production GHA still uses `[self-hosted, spotter]` (only the spotter shares a LAN with the dell); under act, the job runs on ubuntu-latest -- a runner act knows how to map -- and the action no-ops.

The MAC / target-host stay inline here for now (matches the prior state -- they were inline before too). Following the action's docstring, a future PR can move them to repo secrets / vars (`secrets.DELL_MAC`, `vars.DELL_IP`) without touching the action.

The wake-on-lan action is added by a sibling PR to ci-workflows (`add-wake-on-lan-action` branch). After that lands and the `@main` ref here points to it, this CppInterOp PR is mergeable.
