### PR TITLE
[ci] Migrate main.yml cling rows to the llvm-root recipe.

### DIFF
--- a/.github/actions/Build_LLVM/action.yml
+++ b/.github/actions/Build_LLVM/action.yml
@@ -7,204 +7,107 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Build LLVM/Cling if the cache is invalid
+    - name: Build LLVM if the cache is invalid
       if: ${{ inputs.cache-hit != 'true'  && runner.os != 'Windows' }}
       shell: bash
       run: |
-        cling_on=$(echo "${{ matrix.cling }}" | tr '[:lower:]' '[:upper:]')
-        if [[ "${cling_on}" == "ON" ]]; then
-          git clone --depth=1 --branch v${{ matrix.cling-version || env.CLING_VERSION }} https://github.com/root-project/cling.git
-          git clone --depth=1 -b ${{ matrix.root-llvm-tag }} https://github.com/root-project/llvm-project.git
-        else # repl
-          git clone --depth=1 -b release/${{ matrix.clang-runtime }}.x https://github.com/llvm/llvm-project.git
-        fi
+        git clone --depth=1 -b release/${{ matrix.clang-runtime }}.x https://github.com/llvm/llvm-project.git
         cd llvm-project
         # Build
         mkdir build
-        if [[ "${cling_on}" == "ON" ]]; then
-          cd build
-          cmake -DLLVM_ENABLE_PROJECTS="clang" \
-                -DLLVM_EXTERNAL_PROJECTS=cling                     \
-                -DLLVM_EXTERNAL_CLING_SOURCE_DIR=../../cling       \
-                -DLLVM_TARGETS_TO_BUILD="${{ matrix.llvm_targets_to_build || 'host;NVPTX' }}" \
-                -DCMAKE_BUILD_TYPE=Release                         \
-                -DLLVM_ENABLE_ASSERTIONS=ON                        \
-                -DCLANG_ENABLE_STATIC_ANALYZER=OFF                 \
-                -DCLANG_ENABLE_ARCMT=OFF                           \
-                -DCLANG_ENABLE_FORMAT=OFF                          \
-                -DCLANG_ENABLE_BOOTSTRAP=OFF                       \
-                -DLLVM_INCLUDE_BENCHMARKS=OFF                      \
-                -DLLVM_INCLUDE_EXAMPLES=OFF                        \
-                -G Ninja                                           \
-                ../llvm
-          ninja clang -j ${{ env.ncpus }}
-          ninja LLVMOrcDebugging -j ${{ env.ncpus }}
-          # `clangInterpreter` (clang-repl's Interpreter library) is not
-          # a transitive dep of the `clang` driver, and the cling version
-          # we cache (v1.3) doesn't list it in its `LIBS`. ROOT's bundled
-          # `interpreter/cling/lib/Interpreter/CMakeLists.txt:14` does,
-          # so downstream consumers (the ROOT integration job) link
-          # against `libclangInterpreter.a` and fail with `missing and
-          # no known rule to make it` if it isn't in the cached build.
-          # The trim removes top-level `llvm/CMakeLists.txt`, so we can't
-          # ninja it later from the cache -- it has to be built here.
-          ninja clangInterpreter -j ${{ env.ncpus }}
-          ninja clingInterpreter -j ${{ env.ncpus }}
-        else
-          # Non-cling, LLVM >= 22: bundle the OOP-JIT runtime into the
-          # cache. compiler-rt is enabled with everything except the
-          # ORC runtime turned off so the build stays cheap.
-          NEED_OOP=0
-          if [[ "${{ matrix.clang-runtime }}" -ge 22 ]]; then
-            NEED_OOP=1
-          fi
-          if [[ "${NEED_OOP}" == "1" ]]; then
-            PROJECTS="clang;compiler-rt"
-            COMPILER_RT_FLAGS=(
-              -DCOMPILER_RT_BUILD_BUILTINS=OFF
-              -DCOMPILER_RT_BUILD_LIBFUZZER=OFF
-              -DCOMPILER_RT_BUILD_PROFILE=OFF
-              -DCOMPILER_RT_BUILD_MEMPROF=OFF
-              -DCOMPILER_RT_BUILD_SANITIZERS=OFF
-              -DCOMPILER_RT_BUILD_XRAY=OFF
-              -DCOMPILER_RT_BUILD_GWP_ASAN=OFF
-              -DCOMPILER_RT_BUILD_CTX_PROFILE=OFF
-            )
-          else
-            PROJECTS="clang"
-            COMPILER_RT_FLAGS=()
-          fi
-
-          cd build
-          cmake -DLLVM_ENABLE_PROJECTS="${PROJECTS}" \
-                -DLLVM_TARGETS_TO_BUILD="${{ matrix.llvm_targets_to_build || 'host;NVPTX' }}"  \
-                -DCMAKE_BUILD_TYPE=Release                          \
-                -DLLVM_ENABLE_ASSERTIONS=ON                         \
-                -DCLANG_ENABLE_STATIC_ANALYZER=OFF                  \
-                -DCLANG_ENABLE_ARCMT=OFF                            \
-                -DCLANG_ENABLE_FORMAT=OFF                           \
-                -DCLANG_ENABLE_BOOTSTRAP=OFF                        \
-                -G Ninja                                            \
-                -DLLVM_INCLUDE_BENCHMARKS=OFF                   \
-                -DLLVM_USE_SANITIZER="${{ matrix.sanitizer }}"  \
-                -DLLVM_INCLUDE_EXAMPLES=OFF                     \
-                -DLLVM_INCLUDE_TESTS=OFF                        \
-                "${COMPILER_RT_FLAGS[@]}" \
-                ../llvm
-          ninja clang clangInterpreter clangStaticAnalyzerCore
-          if [[ "${NEED_OOP}" == "1" ]]; then
-            # orc_rt's per-target ninja target name varies; find it by
-            # asking ninja for everything matching `orc_rt*`. Building
-            # the executor unconditionally is safe -- it's always a
-            # valid target when compiler-rt is in the build.
-            OOP_TARGETS=$(ninja -t targets all 2>/dev/null | \
-              awk -F: '/^orc_rt[^:]*:/{print $1}' | sort -u | tr '\n' ' ')
-            ninja llvm-jitlink-executor ${OOP_TARGETS} -j ${{ env.ncpus }}
-          fi
-          cd ./tools/
-          rm -rf $(find . -maxdepth 1 ! -name "clang" ! -name ".")
-          cd ..
-          rm compile_commands.json build.ninja
+        # LLVM >= 22: bundle the OOP-JIT runtime into the cache.
+        # compiler-rt is enabled with everything except the ORC
+        # runtime turned off so the build stays cheap.
+        NEED_OOP=0
+        if [[ "${{ matrix.clang-runtime }}" -ge 22 ]]; then
+          NEED_OOP=1
         fi
+        if [[ "${NEED_OOP}" == "1" ]]; then
+          PROJECTS="clang;compiler-rt"
+          COMPILER_RT_FLAGS=(
+            -DCOMPILER_RT_BUILD_BUILTINS=OFF
+            -DCOMPILER_RT_BUILD_LIBFUZZER=OFF
+            -DCOMPILER_RT_BUILD_PROFILE=OFF
+            -DCOMPILER_RT_BUILD_MEMPROF=OFF
+            -DCOMPILER_RT_BUILD_SANITIZERS=OFF
+            -DCOMPILER_RT_BUILD_XRAY=OFF
+            -DCOMPILER_RT_BUILD_GWP_ASAN=OFF
+            -DCOMPILER_RT_BUILD_CTX_PROFILE=OFF
+          )
+        else
+          PROJECTS="clang"
+          COMPILER_RT_FLAGS=()
+        fi
+
+        cd build
+        cmake -DLLVM_ENABLE_PROJECTS="${PROJECTS}" \
+              -DLLVM_TARGETS_TO_BUILD="${{ matrix.llvm_targets_to_build || 'host;NVPTX' }}"  \
+              -DCMAKE_BUILD_TYPE=Release                          \
+              -DLLVM_ENABLE_ASSERTIONS=ON                         \
+              -DCLANG_ENABLE_STATIC_ANALYZER=OFF                  \
+              -DCLANG_ENABLE_ARCMT=OFF                            \
+              -DCLANG_ENABLE_FORMAT=OFF                           \
+              -DCLANG_ENABLE_BOOTSTRAP=OFF                        \
+              -G Ninja                                            \
+              -DLLVM_INCLUDE_BENCHMARKS=OFF                   \
+              -DLLVM_USE_SANITIZER="${{ matrix.sanitizer }}"  \
+              -DLLVM_INCLUDE_EXAMPLES=OFF                     \
+              -DLLVM_INCLUDE_TESTS=OFF                        \
+              "${COMPILER_RT_FLAGS[@]}" \
+              ../llvm
+        ninja clang clangInterpreter clangStaticAnalyzerCore
+        if [[ "${NEED_OOP}" == "1" ]]; then
+          # orc_rt's per-target ninja target name varies; find it by
+          # asking ninja for everything matching `orc_rt*`. Building
+          # the executor unconditionally is safe -- it's always a
+          # valid target when compiler-rt is in the build.
+          OOP_TARGETS=$(ninja -t targets all 2>/dev/null | \
+            awk -F: '/^orc_rt[^:]*:/{print $1}' | sort -u | tr '\n' ' ')
+          ninja llvm-jitlink-executor ${OOP_TARGETS} -j ${{ env.ncpus }}
+        fi
+        cd ./tools/
+        rm -rf $(find . -maxdepth 1 ! -name "clang" ! -name ".")
+        cd ..
+        rm compile_commands.json build.ninja
         cd ../
         rm -rf $(find . -maxdepth 1 ! -name "build" ! -name "llvm" ! -name "clang" ! -name ".")
         # Source-tree `lib/` dirs hold .cpp already linked into
         # build/lib/*.a. CppInterOp consumers reference llvm/include and
         # clang/include via CPLUS_INCLUDE_PATH, never the source `lib/`
-        # (see Build_and_Test_CppInterOp/action.yml). cling/lib stays --
-        # ROOT and downstream consumers may pick up cling header internals
-        # from there.
-        if [[ "${cling_on}" == "ON" ]]; then
-          cd ./llvm/
-          rm -rf $(find . -maxdepth 1 ! -name "include" ! -name "cmake" ! -name "utils" ! -name ".")
-          cd ../clang/
-          rm -rf $(find . -maxdepth 1 ! -name "include" ! -name "cmake" ! -name "utils" ! -name ".")
-          cd ../../cling/
-          rm -rf $(find . -maxdepth 1 ! -name "include" ! -name "lib" ! -name "cmake" ! -name ".")
-        else # repl
-          cd ./llvm/
-          rm -rf $(find . -maxdepth 1 ! -name "include" ! -name "cmake" ! -name ".")
-          cd ../clang/
-          rm -rf $(find . -maxdepth 1 ! -name "include" ! -name "cmake" ! -name ".")
-          cd ../..
-        fi
+        # (see Build_and_Test_CppInterOp/action.yml).
+        cd ./llvm/
+        rm -rf $(find . -maxdepth 1 ! -name "include" ! -name "cmake" ! -name ".")
+        cd ../clang/
+        rm -rf $(find . -maxdepth 1 ! -name "include" ! -name "cmake" ! -name ".")
+        cd ../..
 
 
-    - name: Build LLVM/Cling on Windows systems if the cache is invalid
+    - name: Build LLVM on Windows systems if the cache is invalid
       if: ${{ inputs.cache-hit != 'true'  && runner.os == 'Windows' }}
       shell: powershell
       run: |
-
-        if ( "${{ matrix.cling }}" -imatch "On" )
-        {
-          git clone --depth=1 --branch v${{ matrix.cling-version || env.CLING_VERSION }} https://github.com/root-project/cling.git
-          git clone --depth=1 -b ${{ matrix.root-llvm-tag }} https://github.com/root-project/llvm-project.git
-          $env:PWD_DIR= $PWD.Path
-          $env:CLING_DIR="$env:PWD_DIR\cling"
-          echo "CLING_DIR=$env:CLING_DIR"
-        }
-        else
-        {
-          git clone --depth=1 -b release/${{ matrix.clang-runtime }}.x https://github.com/llvm/llvm-project.git
-        }
+        git clone --depth=1 -b release/${{ matrix.clang-runtime }}.x https://github.com/llvm/llvm-project.git
 
         cd llvm-project
         # Build
         mkdir build
-        if ( "${{ matrix.cling }}" -imatch "On" )
-        {
-          cd build
-          cmake -DLLVM_ENABLE_PROJECTS="clang" `
-                -DLLVM_EXTERNAL_PROJECTS=cling                `
-                -DLLVM_EXTERNAL_CLING_SOURCE_DIR="$env:CLING_DIR"   `
-                -DLLVM_TARGETS_TO_BUILD="${{ matrix.llvm_targets_to_build || 'host;NVPTX' }}" `
-                -DCMAKE_BUILD_TYPE=Release                         `
-                -DLLVM_ENABLE_ASSERTIONS=ON                        `
-                -DCLANG_ENABLE_STATIC_ANALYZER=OFF                 `
-                -DCLANG_ENABLE_ARCMT=OFF                           `
-                -DCLANG_ENABLE_FORMAT=OFF                          `
-                -DCLANG_ENABLE_BOOTSTRAP=OFF                       `
-                -DLLVM_INCLUDE_BENCHMARKS=OFF                      `
-                -DLLVM_INCLUDE_EXAMPLES=OFF                        `
-                ..\llvm
-          cmake --build . --config Release --target clang --parallel ${{ env.ncpus }}
-          cmake --build . --config Release --target LLVMOrcDebugging --parallel ${{ env.ncpus }}
-          # See Linux block above for why clangInterpreter is built here.
-          cmake --build . --config Release --target clangInterpreter --parallel ${{ env.ncpus }}
-          cmake --build . --config Release --target clingInterpreter --parallel ${{ env.ncpus }}
-        }
-        else
-        {
-          cd build
-          echo "Apply clang${{ matrix.clang-runtime }}-*.patch patches:"
-          cmake -DLLVM_ENABLE_PROJECTS="clang"                   `
-                -DLLVM_TARGETS_TO_BUILD="${{ matrix.llvm_targets_to_build || 'host;NVPTX' }}"          `
-                -DCMAKE_BUILD_TYPE=Release                          `
-                -DLLVM_ENABLE_ASSERTIONS=ON                         `
-                -DCLANG_ENABLE_STATIC_ANALYZER=OFF                  `
-                -DCLANG_ENABLE_ARCMT=OFF                            `
-                -DCLANG_ENABLE_FORMAT=OFF                           `
-                -DCLANG_ENABLE_BOOTSTRAP=OFF                        `
-                ..\llvm
-          cmake --build . --config Release --target clang clangInterpreter clangStaticAnalyzerCore --parallel ${{ env.ncpus }}
-        }
+        cd build
+        echo "Apply clang${{ matrix.clang-runtime }}-*.patch patches:"
+        cmake -DLLVM_ENABLE_PROJECTS="clang"                   `
+              -DLLVM_TARGETS_TO_BUILD="${{ matrix.llvm_targets_to_build || 'host;NVPTX' }}"          `
+              -DCMAKE_BUILD_TYPE=Release                          `
+              -DLLVM_ENABLE_ASSERTIONS=ON                         `
+              -DCLANG_ENABLE_STATIC_ANALYZER=OFF                  `
+              -DCLANG_ENABLE_ARCMT=OFF                            `
+              -DCLANG_ENABLE_FORMAT=OFF                           `
+              -DCLANG_ENABLE_BOOTSTRAP=OFF                        `
+              ..\llvm
+        cmake --build . --config Release --target clang clangInterpreter clangStaticAnalyzerCore --parallel ${{ env.ncpus }}
         cd ..\
         rm -r -force $(find.exe . -maxdepth 1 ! -name "build" ! -name "llvm" ! -name "clang" ! -name ".")
         # See Linux block above for why source `lib/` is dropped.
-        if ( "${{ matrix.cling }}" -imatch "On" )
-        {
-          cd .\llvm\
-          rm -r -force $(find.exe . -maxdepth 1 ! -name "include" ! -name "cmake" ! -name "utils" ! -name ".")
-          cd ..\clang\
-          rm -r -force $(find.exe . -maxdepth 1 ! -name "include" ! -name "cmake" ! -name "utils" ! -name ".")
-          cd ..\..\cling\
-          rm -r -force $(find.exe . -maxdepth 1 ! -name "include" ! -name "lib" ! -name "cmake" ! -name ".")
-        }
-        else
-        {
-          cd .\llvm\
-          rm -r -force $(find.exe . -maxdepth 1 ! -name "include" ! -name "cmake" ! -name ".")
-          cd ..\clang\
-          rm -r -force $(find.exe . -maxdepth 1 ! -name "include" ! -name "cmake"  ! -name ".")
-          cd ..\..
-        }
+        cd .\llvm\
+        rm -r -force $(find.exe . -maxdepth 1 ! -name "include" ! -name "cmake" ! -name ".")
+        cd ..\clang\
+        rm -r -force $(find.exe . -maxdepth 1 ! -name "include" ! -name "cmake"  ! -name ".")
+        cd ..\..

--- a/.github/actions/Build_and_Test_CppInterOp/action.yml
+++ b/.github/actions/Build_and_Test_CppInterOp/action.yml
@@ -39,9 +39,19 @@ runs:
           # ${LLVM_DIR}/{llvm,clang}/include and ${LLVM_BUILD_DIR}/{include,tools/clang/include}
           # are the build-tree split. Non-existent paths in the union are harmless.
           if [[ "${cling_on}" == "ON" ]]; then
-            CLING_DIR="$(pwd)/cling"
-            CLING_BUILD_DIR="$(pwd)/cling/build"
-            CPLUS_INCLUDE_PATH="${CLING_DIR}/tools/cling/include:${CLING_BUILD_DIR}/include:${LLVM_DIR}/include:${LLVM_DIR}/llvm/include:${LLVM_DIR}/clang/include:${LLVM_BUILD_DIR}/include:${LLVM_BUILD_DIR}/tools/clang/include:$PWD/include"
+            if [[ -f "$LLVM_DIR/lib/cmake/cling/ClingConfig.cmake" ]]; then
+              # Recipe install tree: cling integrated under llvm-project,
+              # cmake config at lib/cmake/cling/, headers under include/cling/.
+              CLING_DIR="$LLVM_DIR"
+              CLING_CMAKE_DIR="$LLVM_DIR/lib/cmake/cling"
+              CPLUS_INCLUDE_PATH="${LLVM_DIR}/include:$PWD/include"
+            else
+              # Build tree: cling lives in a sibling checkout.
+              CLING_DIR="$(pwd)/cling"
+              CLING_BUILD_DIR="$(pwd)/cling/build"
+              CLING_CMAKE_DIR="$LLVM_BUILD_DIR/tools/cling"
+              CPLUS_INCLUDE_PATH="${CLING_DIR}/tools/cling/include:${CLING_BUILD_DIR}/include:${LLVM_DIR}/include:${LLVM_DIR}/llvm/include:${LLVM_DIR}/clang/include:${LLVM_BUILD_DIR}/include:${LLVM_BUILD_DIR}/tools/clang/include:$PWD/include"
+            fi
           else
             CPLUS_INCLUDE_PATH="${LLVM_DIR}/include:${LLVM_DIR}/llvm/include:${LLVM_DIR}/clang/include:${LLVM_BUILD_DIR}/include:${LLVM_BUILD_DIR}/tools/clang/include:$PWD/include"
           fi
@@ -66,7 +76,7 @@ runs:
                 -DCPPINTEROP_USE_CLING=ON                                  \
                 -DCPPINTEROP_USE_REPL=OFF                                  \
                 -DCPPINTEROP_INCLUDE_DOCS=${{ matrix.documentation }} \
-                -DCling_DIR=$LLVM_BUILD_DIR/tools/cling         \
+                -DCling_DIR=$CLING_CMAKE_DIR                    \
                 -DLLVM_DIR=$LLVM_BUILD_DIR/lib/cmake/llvm       \
                 -DClang_DIR=$LLVM_BUILD_DIR/lib/cmake/clang     \
                 -DLLVM_USE_SANITIZER="${{ matrix.sanitizer }}"  \
@@ -207,22 +217,33 @@ runs:
         echo "LLVM_DIR=$env:LLVM_DIR"
         echo "LLVM_DIR=$env:LLVM_DIR" >> $env:GITHUB_ENV
 
-        $env:LLVM_BUILD_DIR="$env:PWD_DIR\llvm-project\build"
+        # Probe install vs build tree (mirrors the bash branch above):
+        # recipe install trees ship LLVMConfig.cmake at lib/cmake/llvm
+        # directly; source builds leave a build/ subdir.
+        if ( Test-Path "$env:LLVM_DIR\lib\cmake\llvm" ) {
+          $env:LLVM_BUILD_DIR="$env:LLVM_DIR"
+        } else {
+          $env:LLVM_BUILD_DIR="$env:PWD_DIR\llvm-project\build"
+        }
         echo "LLVM_BUILD_DIR=$env:LLVM_BUILD_DIR"
         echo "LLVM_BUILD_DIR=$env:LLVM_BUILD_DIR" >> $env:GITHUB_ENV
 
         if ( "${{ matrix.cling }}" -imatch "On" )
         {
-          $env:CLING_DIR="$env:PWD_DIR\cling"
-          echo "CLING_DIR=$env:CLING_DIR"
+          if ( Test-Path "$env:LLVM_DIR\lib\cmake\cling\ClingConfig.cmake" ) {
+            # Recipe install tree: cling integrated under llvm-project.
+            $env:CLING_DIR="$env:LLVM_DIR"
+            $env:CLING_CMAKE_DIR="$env:LLVM_DIR\lib\cmake\cling"
+            $env:CPLUS_INCLUDE_PATH="$env:LLVM_DIR\include;$env:PWD_DIR\include;"
+          } else {
+            $env:CLING_DIR="$env:PWD_DIR\cling"
+            $env:CLING_BUILD_DIR="$env:PWD_DIR\cling\build"
+            $env:CLING_CMAKE_DIR="$env:LLVM_BUILD_DIR\tools\cling"
+            $env:CPLUS_INCLUDE_PATH="$env:CLING_DIR\tools\cling\include;$env:CLING_BUILD_DIR\include;$env:LLVM_DIR\llvm\include;$env:LLVM_DIR\clang\include;$env:LLVM_BUILD_DIR\include;$env:LLVM_BUILD_DIR\tools\clang\include;$env:PWD_DIR\include;"
+            echo "CLING_BUILD_DIR=$env:CLING_BUILD_DIR" >> $env:GITHUB_ENV
+          }
           echo "CLING_DIR=$env:CLING_DIR" >> $env:GITHUB_ENV
-
-          $env:CLING_BUILD_DIR="$env:PWD_DIR\cling\build"
-          echo "CLING_BUILD_DIR=$env:CLING_BUILD_DIR"
-          echo "CLING_BUILD_DIR=$env:CLING_BUILD_DIR" >> $env:GITHUB_ENV
-
-          $env:CPLUS_INCLUDE_PATH="$env:CLING_DIR\tools\cling\include;$env:CLING_BUILD_DIR\include;$env:LLVM_DIR\llvm\include;$env:LLVM_DIR\clang\include;$env:LLVM_BUILD_DIR\include;$env:LLVM_BUILD_DIR\tools\clang\include;$env:PWD_DIR\include;"
-          echo "CPLUS_INCLUDE_PATH=$env:CPLUS_INCLUDE_PATH"
+          echo "CLING_CMAKE_DIR=$env:CLING_CMAKE_DIR" >> $env:GITHUB_ENV
           echo "CPLUS_INCLUDE_PATH=$env:CPLUS_INCLUDE_PATH" >> $env:GITHUB_ENV
         }
         else
@@ -251,7 +272,7 @@ runs:
           cmake -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }}    `
                 -DCPPINTEROP_USE_CLING=ON                                  `
                 -DCPPINTEROP_USE_REPL=OFF                                  `
-                -DCling_DIR="$env:LLVM_BUILD_DIR\tools\cling"   `
+                -DCling_DIR="$env:CLING_CMAKE_DIR"   `
                 -DLLVM_DIR="$env:LLVM_BUILD_DIR" `
                 -DLLVM_ENABLE_WERROR=On                          `
                 -DClang_DIR="$env:LLVM_BUILD_DIR"  -DCODE_COVERAGE=${{ env.CODE_COVERAGE }} -DCMAKE_INSTALL_PREFIX="$env:CPPINTEROP_DIR"  ..\

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,19 +19,11 @@ jobs:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     env: &build_env
-      # Default cling version for cling rows; override per-row if a bump is
-      # needed. The matching root-llvm-tag is pinned via a YAML anchor
-      # (&root_llvm_tag) on the first cling row and referenced via
-      # *root_llvm_tag on the rest: the cache key on this job literally
-      # reads matrix.root-llvm-tag, so the tag must live on the row. The
-      # tag points at root-project/llvm-project's `ROOT-llvm20-...`
-      # branch -- a superset of `cling-llvm20-...` (cling's patches plus
-      # the additional clang patches ROOT's `core/metacling` consumes,
-      # e.g. `clang::Sema::DelayedInfoRAII` and
-      # `GlobalModuleIndex::FileNameHitSet`). cling-only consumers don't
-      # use the ROOT-only patches, so the superset builds and runs cling
-      # unchanged, letting cling rows here and the ROOT integration row
-      # in `root.yml` share a single LLVM cache entry.
+      # Default cling version for cling rows; override per-row if a bump
+      # is needed. cling rows now consume the llvm-root recipe, which
+      # bakes the ROOT-llvm20 / cling-llvm20 source branches into the
+      # recipe.yaml -- the date-stamped tag no longer lives in this
+      # matrix.
       CLING_VERSION: '1.3'
     strategy:
       fail-fast: false
@@ -48,7 +40,7 @@ jobs:
           - { name: ubu24-x86-clang22-llvm22-asan-ubsan, os: ubuntu-24.04, compiler: clang-22, clang-runtime: '22', sanitizer: "Address;Undefined", use-recipe: 'llvm-asan' }
           - { name: ubu24-x86-gcc12-llvm21-cppyy-vg, os: ubuntu-24.04, compiler: gcc-12, clang-runtime: '21', cppyy: On, Valgrind: On }
           - { name: ubu24-x86-gcc12-llvm22-cppyy, os: ubuntu-24.04, compiler: gcc-12, clang-runtime: '22', cppyy: On }
-          - { name: ubu24-x86-gcc14-cling-llvm20-cppyy, os: ubuntu-24.04, compiler: gcc-14, clang-runtime: '20', cling: 'On', cppyy: On, root-llvm-tag: &root_llvm_tag 'ROOT-llvm20-20260408-01' }
+          - { name: ubu24-x86-gcc14-cling-llvm20-cppyy, os: ubuntu-24.04, compiler: gcc-14, clang-runtime: '20', cling: 'On', cppyy: On, use-recipe: 'llvm-root', recipe-version: 'cling-llvm20' }
           # selfh-ubu22-x86-gcc12-llvm22-cuda lives in `build-selfhost`
           # below; it's the only row that needs the dell awake.
           - name: ubu24-x86-gcc12-llvm22-vg
@@ -59,14 +51,14 @@ jobs:
           # MacOS Arm
           - { name: osx26-arm-clang-llvm22, os: macos-26, compiler: clang, clang-runtime: '22', llvm_targets_to_build: host }
           - { name: osx26-arm-clang-llvm21-cppyy, os: macos-26, compiler: clang, clang-runtime: '21', cppyy: On, llvm_targets_to_build: host }
-          - { name: osx26-arm-clang-cling-llvm20-cppyy, os: macos-26, compiler: clang, clang-runtime: '20', cling: 'On', cppyy: On, root-llvm-tag: *root_llvm_tag }
+          - { name: osx26-arm-clang-cling-llvm20-cppyy, os: macos-26, compiler: clang, clang-runtime: '20', cling: 'On', cppyy: On, use-recipe: 'llvm-root', recipe-version: 'ROOT-llvm20', recipe-arch: 'arm64' }
           # MacOS X86
           - { name: osx26-x86-clang-llvm21-cppyy, os: macos-26-intel, compiler: clang, clang-runtime: '21', cppyy: On, llvm_targets_to_build: host }
-          - { name: osx26-x86-clang-cling-llvm20-cppyy, os: macos-26-intel, compiler: clang, clang-runtime: '20', cling: 'On', cppyy: On, root-llvm-tag: *root_llvm_tag }
+          - { name: osx26-x86-clang-cling-llvm20-cppyy, os: macos-26-intel, compiler: clang, clang-runtime: '20', cling: 'On', cppyy: On, use-recipe: 'llvm-root', recipe-version: 'ROOT-llvm20' }
           # Windows
           - { name: win11-msvc-llvm22, os: windows-11-arm, compiler: msvc, clang-runtime: '22' }
           - { name: win2025-msvc-llvm22, os: windows-2025, compiler: msvc, clang-runtime: '22' }
-          - { name: win2025-msvc-cling-llvm20, os: windows-2025, compiler: msvc, clang-runtime: '20', cling: 'On', root-llvm-tag: *root_llvm_tag }
+          - { name: win2025-msvc-cling-llvm20, os: windows-2025, compiler: msvc, clang-runtime: '20', cling: 'On', use-recipe: 'llvm-root', recipe-version: 'ROOT-llvm20' }
 
     steps: &build_steps
     - uses: actions/checkout@v6
@@ -79,15 +71,16 @@ jobs:
     - name: Save PR Info
       uses: ./.github/actions/Miscellaneous/Save_PR_Info
 
-    - name: Restore cached LLVM-${{ matrix.clang-runtime }} and ${{ matrix.cling == 'On' && 'Cling' || 'Clang-REPL' }} build
+    - name: Restore cached LLVM-${{ matrix.clang-runtime }} (Clang-REPL) build
       if: ${{ runner.environment != 'self-hosted' && !matrix.use-recipe }}
       uses: actions/cache/restore@v4
       id: cache
       with:
-        path: |
-          llvm-project
-          ${{ matrix.cling=='On' && 'cling' || '' }}
-        key: ${{ env.CLING_HASH }}-${{ runner.os }}-${{ matrix.os }}-${{ matrix.compiler }}-clang-${{ matrix.clang-runtime }}-${{ matrix.root-llvm-tag || 'none' }}.x-patch-${{ hashFiles(format('patches/llvm/clang{0}-*.patch', matrix.clang-runtime)) || 'none' }}${{ matrix.sanitizer || '' }}
+        path: llvm-project
+        # `-none.x-patch-` is the historical key segment from when the
+        # cache key carried `matrix.root-llvm-tag` (always 'none' for
+        # non-cling rows). Kept verbatim so existing entries match.
+        key: ${{ env.CLING_HASH }}-${{ runner.os }}-${{ matrix.os }}-${{ matrix.compiler }}-clang-${{ matrix.clang-runtime }}-none.x-patch-${{ hashFiles(format('patches/llvm/clang{0}-*.patch', matrix.clang-runtime)) || 'none' }}${{ matrix.sanitizer || '' }}
     - name: Setup default Build Type
       uses: ./.github/actions/Miscellaneous/Select_Default_Build_Type
 
@@ -107,7 +100,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y llvm-${{ matrix.clang-runtime }}-dev libclang-${{ matrix.clang-runtime }}-dev clang-${{ matrix.clang-runtime }} libpolly-${{ matrix.clang-runtime }}-dev libzstd-dev
 
-    - name: Build LLVM-${{ matrix.clang-runtime }} and ${{ matrix.cling == 'On' && 'Cling' || 'Clang-REPL' }}
+    - name: Build LLVM-${{ matrix.clang-runtime }} (Clang-REPL)
       if: ${{ runner.environment != 'self-hosted' && !matrix.use-recipe }}
       uses: ./.github/actions/Build_LLVM
       with:
@@ -121,34 +114,33 @@ jobs:
     # Build_and_Test_* discovers the tree at
     # $GITHUB_WORKSPACE/llvm-project automatically.
     #
-    # build-on-miss: false — refuse to rebuild LLVM inline on a cache
+    # build-on-miss: false -- refuse to rebuild LLVM inline on a cache
     # miss. A miss here means the publish-recipe pipeline didn't warm
     # the cell we asked for; rebuilding inline (~30 min) on every PR
     # run would defeat the point of the cache. Fail fast with a
     # populate-via-gh-workflow-run hint instead, and let the operator
     # warm the cell explicitly.
     #
-    # Pinned to a ci-workflows commit sha for reproducibility; bump
-    # explicitly when consuming new behaviour. arch is hard-coded to
-    # x86_64 since the only use-recipe row today is the ubuntu-24.04
-    # asan one — generalise to runner.arch when more rows migrate.
+    # version: asan rows reuse matrix.clang-runtime ('22'); cling rows
+    # pass an explicit recipe-version flavor ('cling-llvm20' Linux,
+    # 'ROOT-llvm20' mac/win) since llvm-root keys on flavor, not on
+    # numeric clang-runtime.
+    # arch: defaults to x86_64; mac arm passes recipe-arch: arm64.
     - name: Setup recipe ${{ matrix.use-recipe }} (LLVM ${{ matrix.clang-runtime }})
       if: ${{ runner.environment != 'self-hosted' && matrix.use-recipe }}
       uses: compiler-research/ci-workflows/actions/setup-recipe@main
       with:
         recipe: ${{ matrix.use-recipe }}
-        version: ${{ matrix.clang-runtime }}
+        version: ${{ matrix.recipe-version || matrix.clang-runtime }}
         os: ${{ matrix.os }}
-        arch: x86_64
+        arch: ${{ matrix.recipe-arch || 'x86_64' }}
         build-on-miss: 'false'
 
-    - name: Cache LLVM-${{ matrix.clang-runtime }} and ${{ matrix.cling == 'On' && 'Cling' || 'Clang-REPL' }} build
+    - name: Cache LLVM-${{ matrix.clang-runtime }} (Clang-REPL) build
       uses: actions/cache/save@v4
       if: ${{ runner.environment != 'self-hosted' && !matrix.use-recipe && steps.cache.outputs.cache-hit != 'true' }}
       with:
-        path: |
-          llvm-project
-          ${{ matrix.cling=='On' && 'cling' || '' }}
+        path: llvm-project
         key: ${{ steps.cache.outputs.cache-primary-key }}
 
     - name: Setup code coverage


### PR DESCRIPTION
Replace `actions/cache/restore` + `Build_LLVM` for the 4 cling rows with `setup-recipe` (`llvm-root`; `cling-llvm20` on Linux, `ROOT-llvm20` on mac/windows, `arm64` for the mac-arm cell). The setup-recipe step gains matrix-driven defaults so asan and cling share it:

  version: ${{ matrix.recipe-version || matrix.clang-runtime }}
  arch:    ${{ matrix.recipe-arch    || 'x86_64' }}

`Build_and_Test_CppInterOp` learns the install-tree cling layout: when `$LLVM_DIR/lib/cmake/cling/ClingConfig.cmake` exists, `CLING_DIR=$LLVM_DIR`, `CLING_CMAKE_DIR=$LLVM_DIR/lib/cmake/cling`, and CPLUS_INCLUDE_PATH collapses to `$LLVM_DIR/include`. The build-tree fork stays for `deploy-pages.yml` and `emscripten.yml`.

Cleanup of bits no row triggers post-migration:
  - matrix.root-llvm-tag + the &root_llvm_tag anchor.
  - cache-restore/save's `path: cling` and the matching cling term in the cache key + step names.
  - `Build_LLVM`'s cling code (clone, LLVM_EXTERNAL_PROJECTS=cling, clingInterpreter ninja, cling source-tree trim).

`Build_LLVM` itself stays: ~10 vanilla-LLVM rows still build from `release/<N>.x` on cache miss. Retiring it needs an `llvm-vanilla` recipe (in flight on ci-workflows' add-llvm-vanilla-recipe branch). `patches/llvm/cling1.2-LookupHelper.patch` stays too: still applied by `Build_LLVM_WASM` for Emscripten cling rows.

Depends on ci-workflows install-cling-cmake-exports landing first so the republished cells ship `ClingConfig.cmake` -- without it the install-tree probe in `Build_and_Test_CppInterOp` finds no config and the configure fails.
