### PR TITLE
[cmake] Gate install and LLVM BUILDTREE_ONLY  for non-standalone builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -485,34 +485,39 @@ configure_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/cmake/CppInterOp/CppInterOpConfigVersion.cmake.in
   ${CMAKE_CURRENT_BINARY_DIR}/lib/cmake/CppInterOp/CppInterOpConfigVersion.cmake
   @ONLY)
-install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib/cmake/CppInterOp/
-  DESTINATION lib/cmake/CppInterOp
-  FILES_MATCHING
-  PATTERN "*.cmake"
-  )
+
+# Skip install rules when CppInterOp is consumed via add_subdirectory() in an external project,
+# In ROOT, headers and the cmake config are installed through libCling's own layout
+if(CPPINTEROP_BUILT_STANDALONE OR NOT CPPINTEROP_USE_CLING)
+  install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/lib/cmake/CppInterOp/
+    DESTINATION lib/cmake/CppInterOp
+    FILES_MATCHING
+    PATTERN "*.cmake"
+    )
 
 
-install(DIRECTORY include/
-  DESTINATION include
-  FILES_MATCHING
-  PATTERN "*.def"
-  PATTERN "*.h"
-  PATTERN "*.inc"
-  PATTERN ".svn" EXCLUDE
-  )
+  install(DIRECTORY include/
+    DESTINATION include
+    FILES_MATCHING
+    PATTERN "*.def"
+    PATTERN "*.h"
+    PATTERN "*.inc"
+    PATTERN ".svn" EXCLUDE
+    )
 
-install(DIRECTORY tools/
-  DESTINATION include/CppInterOp/tools
-  FILES_MATCHING
-  PATTERN "*.h"
-)
+  install(DIRECTORY tools/
+    DESTINATION include/CppInterOp/tools
+    FILES_MATCHING
+    PATTERN "*.h"
+    )
 
-install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/include/
-  DESTINATION include
-  FILES_MATCHING
-  PATTERN "CMakeFiles" EXCLUDE
-  PATTERN "*.inc"
-  )
+  install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/include/
+    DESTINATION include
+    FILES_MATCHING
+    PATTERN "CMakeFiles" EXCLUDE
+    PATTERN "*.inc"
+    )
+endif()
 
 add_definitions( -D_GNU_SOURCE )
 

--- a/lib/CppInterOp/CMakeLists.txt
+++ b/lib/CppInterOp/CMakeLists.txt
@@ -155,7 +155,15 @@ else()
     "cppinterop-tblgen binary when cross-compiling.")
 endif()
 
-add_llvm_library(clangCppInterOp
+# When CppInterOp is embedded in ROOT, the symbols are folded into
+# libCling rather than shipped as a standalone library, so AddLLVM
+# must not register/export the target. BUILDTREE_ONLY suppresses both.
+set(_clangCppInterOp_extra_args)
+if(NOT CPPINTEROP_BUILT_STANDALONE AND CPPINTEROP_USE_CLING)
+  list(APPEND _clangCppInterOp_extra_args BUILDTREE_ONLY)
+endif()
+
+add_llvm_library(clangCppInterOp ${_clangCppInterOp_extra_args}
   DISABLE_LLVM_LINK_LLVM_DYLIB
   CppInterOp.cpp
   CppInterOpDispatch.cpp


### PR DESCRIPTION
When CppInterOp is consumed via add_subdirectory() in an external project like ROOT, we previously had to carry two small CMake patches on top of upstream:

 - clangCppInterOp must be BUILDTREE_ONLY so AddLLVM does not register/export it, ROOT folds the symbols into libCling rather than shipping a separate library.
 - The standalone install() rules for the cmake config, headers, tools and build-tree include/ should not be default behaviour, ROOT installs through libCling's own layout

