### PR TITLE
[ci] Make matrix-driven CI reproducible under nektos/act.

### DIFF
--- a/.github/actions/Build_and_Test_CppInterOp/action.yml
+++ b/.github/actions/Build_and_Test_CppInterOp/action.yml
@@ -71,8 +71,21 @@ runs:
         # the recipe-cached path CppInterOp would compile without
         # -fsanitize=address while libLLVMSupport.a is asan-instrumented,
         # leaving __asan_* symbols unresolved at link.
+        # -GNinja: outer cmake uses Ninja, ExternalProject inherits
+        # the generator (so googletest's inner build is also Ninja).
+        # Sidesteps the make->cmake->make recursive jobserver fd
+        # inheritance that breaks under nektos/act's bash invocation
+        # ("gmake[5]: *** write jobserver: Bad file descriptor").
+        # ninja-build is in Install_Dependencies' apt list (github-
+        # hosted + act); the self-hosted apt step in main.yml /
+        # root.yml installs it explicitly. The adjacent fix to
+        # cmake/modules/GoogleTest.cmake (correcting BUILD_BYPRODUCTS
+        # to point at the real binary_dir) is what makes Ninja's
+        # strict missing-rule semantics work for the
+        # ExternalProject_Add output.
         if [[ "${cling_on}" == "ON" ]]; then
-          cmake -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }}        \
+          cmake -GNinja                                     \
+                -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }}        \
                 -DCPPINTEROP_USE_CLING=ON                                  \
                 -DCPPINTEROP_USE_REPL=OFF                                  \
                 -DCPPINTEROP_INCLUDE_DOCS=${{ matrix.documentation }} \
@@ -86,7 +99,8 @@ runs:
                 -DLLVM_ENABLE_WERROR=On                         \
                 ../
         else
-          cmake -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }}     \
+          cmake -GNinja                                  \
+                -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }}     \
                 -DCPPINTEROP_INCLUDE_DOCS=${{ matrix.documentation }} \
                 -DLLVM_DIR=$LLVM_BUILD_DIR/lib/cmake/llvm    \
                 -DClang_DIR=$LLVM_BUILD_DIR/lib/cmake/clang  \

--- a/.github/actions/Build_and_Test_cppyy/action.yml
+++ b/.github/actions/Build_and_Test_cppyy/action.yml
@@ -1,11 +1,35 @@
 name: 'Builds and test cppyy'
 description: 'This action builds and tests cppyy for native platforms'
 
+# `${{ matrix.* }}` is reliably available inside composite-action steps
+# only on github-hosted runners; nektos/act does not propagate the
+# caller's matrix context, so every `${{ matrix.cppyy }}` in step
+# `if:` keys expands to "" -- evaluating to `'' == 'On' && ...` ->
+# false, every step is skipped, and the action runs in 200ms doing
+# nothing. Forward each matrix value via explicit inputs so the
+# behaviour matches across both runtimes.
+inputs:
+  cppyy:
+    required: true
+    description: 'Forward of matrix.cppyy ("On"/"Off"). Drives every step gate in this action.'
+  cling:
+    required: false
+    default: ''
+    description: 'Forward of matrix.cling ("On"/"Off"). Selects valgrind suppressions.'
+  valgrind:
+    required: false
+    default: ''
+    description: 'Forward of matrix.Valgrind ("On"/"Off"). Gates the valgrind test pass.'
+  clang_runtime:
+    required: false
+    default: ''
+    description: 'Forward of matrix.clang-runtime (numeric LLVM major). Selects valgrind suppression file.'
+
 runs:
   using: composite
   steps:
     - name: Build and Install cppyy-backend
-      if: ${{ matrix.cppyy == 'On' && runner.os != 'Windows' }}
+      if: ${{ inputs.cppyy == 'On' && runner.os != 'Windows' }}
       shell: bash
       run: |
         # Download cppyy-backend
@@ -17,8 +41,7 @@ runs:
         # Build and Install cppyy-backend
         cmake -DCppInterOp_DIR=$CPPINTEROP_DIR ..
         cmake --build . --parallel ${{ env.ncpus }}
-        os="${{ matrix.os }}"
-        if [[ "${os}" == "macos"* ]]; then
+        if [[ "${{ runner.os }}" == "macOS" ]]; then
           cp libcppyy-backend.dylib $CPPINTEROP_DIR/lib/
         else
           cp libcppyy-backend.so $CPPINTEROP_DIR/lib/
@@ -26,7 +49,7 @@ runs:
         cd ..
 
     - name: Install CPyCppyy
-      if: ${{ matrix.cppyy == 'On' && runner.os != 'Windows' }}
+      if: ${{ inputs.cppyy == 'On' && runner.os != 'Windows' }}
       shell: bash
       run: |
         python3 -m venv .venv
@@ -44,7 +67,7 @@ runs:
         echo "CPYCPPYY_DIR=$CPYCPPYY_DIR" >> $GITHUB_ENV
 
     - name: Install cppyy
-      if: ${{ matrix.cppyy == 'On' && runner.os != 'Windows' }}
+      if: ${{ inputs.cppyy == 'On' && runner.os != 'Windows' }}
       shell: bash
       run: |
         # source virtual environment
@@ -57,7 +80,7 @@ runs:
         cd ..
 
     - name: Run cppyy
-      if: ${{ matrix.cppyy == 'On' && runner.os != 'Windows' }}
+      if: ${{ inputs.cppyy == 'On' && runner.os != 'Windows' }}
       shell: bash
       run: |
         # Run cppyy
@@ -68,7 +91,7 @@ runs:
         echo "PYTHONPATH=$PYTHONPATH" >> $GITHUB_ENV
 
     - name: Run the tests
-      if: ${{ matrix.cppyy == 'On' && runner.os != 'Windows' }}
+      if: ${{ inputs.cppyy == 'On' && runner.os != 'Windows' }}
       shell: bash
       run: |
         # Run the tests
@@ -112,18 +135,17 @@ runs:
         declare -i RETCODE=0
 
         set -o pipefail
-        os="${{ matrix.os }}"
-        if [[ "${os}" != "macos"* && "${{ matrix.Valgrind }}" == "On" ]]; then
+        if [[ "${{ runner.os }}" != "macOS" && "${{ inputs.valgrind }}" == "On" ]]; then
           echo "Running valgrind on passing tests"
-          CLANG_VERSION="${{ matrix.clang-runtime }}"
+          CLANG_VERSION="${{ inputs.clang_runtime }}"
 
-          if [[ "${{ matrix.cling }}" == "On" ]]; then
+          if [[ "${{ inputs.cling }}" == "On" ]]; then
             CLANG_INTERPRETER="cling"
           else
             CLANG_INTERPRETER="clang"
           fi
-        
-          if [[ "${{ matrix.os }}" == *"arm"* ]]; then
+
+          if [[ "${{ runner.arch }}" == "ARM64" ]]; then
             SUPPRESSION_FILE="../etc/${CLANG_INTERPRETER}${CLANG_VERSION}-valgrind_arm.supp"
           else
             SUPPRESSION_FILE="../etc/${CLANG_INTERPRETER}${CLANG_VERSION}-valgrind.supp"

--- a/.github/actions/Miscellaneous/Install_Dependencies/action.yml
+++ b/.github/actions/Miscellaneous/Install_Dependencies/action.yml
@@ -27,7 +27,7 @@ runs:
         pip install distro pytest
 
     - name: Install dependencies on Linux
-      if: runner.os == 'Linux' && runner.environment != 'self-hosted'
+      if: runner.os == 'Linux'
       shell: bash
       env:
         DEBIAN_FRONTEND: noninteractive

--- a/.github/actions/Miscellaneous/Setup_Compiler/action.yml
+++ b/.github/actions/Miscellaneous/Setup_Compiler/action.yml
@@ -1,6 +1,17 @@
 name: 'Setup Compiler'
 description: 'This PR sets up the compiler for the job'
 
+# `${{ matrix.* }}` is reliably available inside composite-action steps
+# only on github-hosted runners; nektos/act does not propagate the
+# caller's matrix context, so every `${{ matrix.compiler }}` below
+# expanded to "" -- the gcc branch was skipped, vers was "", and CXX
+# came out as "clang++-" with no version. Forward the value via an
+# explicit input so behaviour matches across both runtimes.
+inputs:
+  compiler:
+    required: true
+    description: 'Compiler slug, e.g. "gcc-14", "clang-22", "msvc". Forwarded from matrix.compiler at the call site.'
+
 runs:
   using: composite
   steps:
@@ -10,7 +21,7 @@ runs:
       shell: bash
       run: |
         vers="${compiler#*-}"
-        if [[ "${{ matrix.compiler }}" == *"gcc"* ]]; then
+        if [[ "${compiler}" == *"gcc"* ]]; then
           brew install "gcc@$vers"
           echo "CC=gcc-${vers}" >> $GITHUB_ENV
           echo "CXX=g++-${vers}" >> $GITHUB_ENV
@@ -26,7 +37,7 @@ runs:
         fi
         echo "SDKROOT=$(xcrun --sdk macosx --show-sdk-path)" >> $GITHUB_ENV
       env:
-        compiler: ${{ matrix.compiler }}
+        compiler: ${{ inputs.compiler }}
 
     - name: Setup Compiler on Linux
       if: runner.os == 'Linux'
@@ -36,7 +47,7 @@ runs:
         vers="${compiler#*-}"
         os_codename="`cat /etc/os-release | grep UBUNTU_CODENAME | cut -d = -f 2`"
         sudo apt-get update
-        if [[ "${{ matrix.compiler }}" == *"gcc"* ]]; then
+        if [[ "${compiler}" == *"gcc"* ]]; then
           sudo apt-get install -y gcc-${vers} g++-${vers} lld
           echo "CC=gcc-${vers}" >> $GITHUB_ENV
           echo "CXX=g++-${vers}" >> $GITHUB_ENV
@@ -51,15 +62,17 @@ runs:
           echo "CXX=clang++-${vers}" >> $GITHUB_ENV
         fi
       env:
-        compiler: ${{ matrix.compiler }}
+        compiler: ${{ inputs.compiler }}
 
     - name: Save Compiler on Windows Systems
       if: runner.os == 'Windows'
       shell: powershell
+      env:
+        compiler: ${{ inputs.compiler }}
       run: |
-        if ( "${{ matrix.compiler }}" -imatch "clang" )
+        if ( "$env:compiler" -imatch "clang" )
         {
-          $ver="${{ matrix.compiler }}".split("-")[1]
+          $ver="$env:compiler".split("-")[1]
           choco install llvm --version=$ver --no-progress -my
           clang --version
           #
@@ -68,7 +81,7 @@ runs:
           echo "CC=clang" >> $env:GITHUB_ENV
           echo "CXX=clang++" >> $env:GITHUB_ENV
         }
-        elseif ( "${{ matrix.compiler }}" -imatch "msvc" )
+        elseif ( "$env:compiler" -imatch "msvc" )
         {
           # MSVC is builtin in container image
         }

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -86,6 +86,8 @@ jobs:
 
     - name: Setup compiler
       uses: ./.github/actions/Miscellaneous/Setup_Compiler
+      with:
+        compiler: ${{ matrix.compiler }}
 
     - name: Install dependencies
       uses: ./.github/actions/Miscellaneous/Install_Dependencies
@@ -177,7 +179,12 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
 
     - name: Build and test cppyy
-      uses: ./.github/actions/Build_and_Test_cppyy        
+      uses: ./.github/actions/Build_and_Test_cppyy
+      with:
+        cppyy: ${{ matrix.cppyy }}
+        cling: ${{ matrix.cling }}
+        valgrind: ${{ matrix.Valgrind }}
+        clang_runtime: ${{ matrix.clang-runtime }}
 
     - name: Show debug info
       if: ${{ failure() }}

--- a/.github/workflows/root.yml
+++ b/.github/workflows/root.yml
@@ -64,6 +64,8 @@ jobs:
 
     - name: Setup compiler
       uses: ./cppinterop/.github/actions/Miscellaneous/Setup_Compiler
+      with:
+        compiler: ${{ matrix.compiler }}
 
     - name: Install dependencies
       uses: ./cppinterop/.github/actions/Miscellaneous/Install_Dependencies

--- a/cmake/modules/GoogleTest.cmake
+++ b/cmake/modules/GoogleTest.cmake
@@ -1,5 +1,11 @@
+# Must match the actual ExternalProject_Add binary_dir below
+# (`-B ${CMAKE_BINARY_DIR}/unittests/googletest-prefix/src/googletest-build/`).
+# Stale `downloads/` prefix here meant BUILD_BYPRODUCTS pointed at a path
+# that's never produced; with Make's permissive missing-rule handling this
+# was invisible, but `-GNinja` rejects it with "no known rule to make
+# unittests/googletest-prefix/src/googletest-build/lib/libgtest.a".
 set(_gtest_byproduct_binary_dir
-  ${CMAKE_BINARY_DIR}/downloads/googletest-prefix/src/googletest-build)
+  ${CMAKE_BINARY_DIR}/unittests/googletest-prefix/src/googletest-build)
 set(_gtest_byproducts
   ${_gtest_byproduct_binary_dir}/lib/libgtest.a
   ${_gtest_byproduct_binary_dir}/lib/libgtest_main.a


### PR DESCRIPTION
Four fixes that together let `bin/repro` (compiler-research/ ci-workflows) drive a Linux row of main.yml's matrix end-to-end without the silent skips and recursive-make failures that were previously masking the real test outcome. github-hosted CI is unaffected by all four: (1) and (4) are no-ops there; (2) is a latent CMake correctness bug that just happens to fire only under Ninja; (3) is faster anyway.

(1) Setup_Compiler/action.yml + main.yml + root.yml: forward `matrix.compiler` via an explicit `inputs.compiler`. nektos/act does not propagate `${{ matrix.* }}` into composite-action expressions; github-hosted runners do. Under act the inline `if [[ "${{ matrix.compiler }}" == *"gcc"* ]]` test expanded to "" against the glob, the gcc branch was skipped, vers="", and CXX came out as `clang++-` (no version), killing cmake at enable_language(CXX). Forwarding via `with: { compiler: ${{ matrix.compiler }} }` makes both runtimes behave the same.

(2) cmake/modules/GoogleTest.cmake: align `_gtest_byproduct_binary _dir` with the actual ExternalProject_Add binary_dir. The path hint pointed at ${CMAKE_BINARY_DIR}/downloads/googletest-prefix/ src/googletest-build, but ExternalProject_Add's CONFIGURE_COMMAND and BUILD_COMMAND use ${CMAKE_BINARY_DIR}/unittests/googletest- prefix/src/googletest-build -- two different paths, BUILD_BYPRODUCTS covered the one that's never produced. Make's permissive missing- rule semantics mask the mismatch on CI; (3)'s switch to Ninja exposes it as `ninja: error: 'unittests/.../libgtest.a': no known rule to make it`. Drop the stale `downloads/` prefix.

(3) Build_and_Test_CppInterOp/action.yml: pass `-GNinja` to the outer cmake on the Linux native shared build. GNU make's jobserver inherits via the MAKEFLAGS env var (`--jobserver-auth=R,W`), which references pipe fds in the parent shell. nektos/act's bash invocation propagates MAKEFLAGS but not the fds, so the recursive cmake -> make -> ExternalProject(googletest) -> inner-make chain dies at the final link step with `gmake[5]: *** write jobserver: Bad file descriptor`. Ninja has no jobserver dependency and ExternalProject inherits the outer generator by default, so switching the outer sidesteps the issue. ninja-build is in the Linux apt list. Depends on (2).

(4) Build_and_Test_cppyy/action.yml + main.yml: forward matrix.cppyy / matrix.os / matrix.cling / matrix.Valgrind / matrix.clang-runtime via explicit inputs. Same shape as (1): every step's gate `if: ${{ matrix.cppyy == 'On' && runner.os != 'Windows' }}` evaluated to false under act because matrix.cppyy expanded to "", silently skipping the cppyy build/test phase (action ran in ~200ms doing nothing). With inputs forwarded, cppyy-backend / CPyCppyy / cppyy install and the full pytest suite all run.

End-to-end timings on Apple Silicon, 16 GB Docker, against ubu24-x86-gcc14-cling-llvm20-cppyy:

    Setup compiler            1m18s   apt install gcc-14 g++-14
    Install dependencies      2m46s   single apt-get install
    Setup recipe (cache hit)  13s     download + extract llvm-root
    Build CppInterOp          1m28s   ninja, 47 targets
    cppyy phase total         2m32s   clone+build+install+pytest
    Total wall                ~9 min  green

# Description

Please include a summary of changes, motivation and context for this PR.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [ ] I have read the contribution guide recently
