### PR TITLE
[ci] Cap ncpus by cgroup cpu.max on self-hosted runners.

### DIFF
--- a/.github/actions/Build_LLVM_WASM/action.yml
+++ b/.github/actions/Build_LLVM_WASM/action.yml
@@ -29,7 +29,7 @@ runs:
         mkdir native_build
         (cd native_build && \
             cmake -DLLVM_ENABLE_PROJECTS=clang -DLLVM_TARGETS_TO_BUILD=host -DCMAKE_BUILD_TYPE=Release ../llvm/ && \
-            cmake --build . --target llvm-tblgen clang-tblgen --parallel $(nproc --all))
+            cmake --build . --target llvm-tblgen clang-tblgen --parallel ${{ env.ncpus }})
         export NATIVE_DIR=$PWD/native_build/bin/
 
         # Apply repl-only emscripten patches; cling has its own patch flow above.
@@ -119,7 +119,7 @@ runs:
         mkdir native_build | Out-Null
         Push-Location native_build
         cmake -DLLVM_ENABLE_PROJECTS=clang -DLLVM_TARGETS_TO_BUILD=host -DCMAKE_BUILD_TYPE=Release -G Ninja ../llvm/
-        cmake --build . --target llvm-tblgen clang-tblgen --parallel $(nproc --all)
+        cmake --build . --target llvm-tblgen clang-tblgen --parallel ${{ env.ncpus }}
         $env:NATIVE_DIR = Join-Path $PWD.Path "bin"
         Pop-Location
 

--- a/.github/actions/Miscellaneous/Select_Default_Build_Type/action.yml
+++ b/.github/actions/Miscellaneous/Select_Default_Build_Type/action.yml
@@ -10,11 +10,21 @@ runs:
       run: |
         echo "BUILD_TYPE=Release" >> $GITHUB_ENV
         echo "CODE_COVERAGE=0" >> $GITHUB_ENV
-        if [[ "${{ matrix.os }}" != "macos"* ]]; then
-          echo "ncpus=$(nproc --all)" >> $GITHUB_ENV
+        if [[ "${{ runner.os }}" == "macOS" ]]; then
+          ncpus=$(sysctl -n hw.ncpu)
         else
-          echo "ncpus=$(sysctl -n hw.ncpu)" >> $GITHUB_ENV
+          ncpus=$(nproc)
+          if [[ -r /sys/fs/cgroup/cpu.max ]]; then
+            read -r quota period < /sys/fs/cgroup/cpu.max || true
+            if [[ "${quota:-max}" != "max" && "${period:-0}" -gt 0 ]]; then
+              capped=$(( (quota + period - 1) / period ))
+              if [[ "$capped" -ge 1 && "$capped" -lt "$ncpus" ]]; then
+                ncpus="$capped"
+              fi
+            fi
+          fi
         fi
+        echo "ncpus=$ncpus" >> $GITHUB_ENV
 
     - name: Select default build type on Windows
       if: runner.os == 'Windows'

--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -54,7 +54,7 @@ jobs:
             cmake . -B tblgen_build -DCMAKE_BUILD_TYPE=Release
             -DLLVM_DIR=$SYSTEM_LLVM_DIR
             -DCPPINTEROP_BUILD_TABLEGEN_ONLY=ON &&
-            cmake --build tblgen_build --target cppinterop-tblgen --parallel $(nproc --all) &&
+            cmake --build tblgen_build --target cppinterop-tblgen --parallel $(nproc) &&
             TBLGEN_EXE=$(find $(pwd)/tblgen_build -name cppinterop-tblgen -type f | head -1) &&
             cmake . -B build -DCMAKE_BUILD_TYPE="Release"
             -DCMAKE_C_COMPILER="$GITHUB_WORKSPACE/llvm/bin/clang"
@@ -64,8 +64,8 @@ jobs:
             -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
             -DCPPINTEROP_TABLEGEN_EXE=$TBLGEN_EXE &&
             cd build &&
-            cmake --build . --target CppInterOpTableGen --parallel $(nproc --all) &&
-            cmake --build . --target googletest --parallel $(nproc --all)
+            cmake --build . --target CppInterOpTableGen --parallel $(nproc) &&
+            cmake --build . --target googletest --parallel $(nproc)
 
       - name: Upload artifacts
         uses: ZedThree/clang-tidy-review/upload@v0.21.0


### PR DESCRIPTION
Self-hosted runners run inside a docker compose container with `cpus: '3.0'`, which cgroup v2 encodes as
cpu.max="300000 100000" (3-core CFS quota). `nproc --all` reports the 16-core host count regardless; plain `nproc` reads sched_getaffinity which respects cpuset.cpus but NOT the CFS quota, so it also returns 16 there. With ncpus=16, `cmake --build . --parallel 16` over-provisions cc1plus into OOM despite the parallel `memory: 32gb` cap.

Read /sys/fs/cgroup/cpu.max in Select_Default_Build_Type and cap ncpus by ceil(quota / period). No-op on github-hosted (cpu.max missing or quota=='max'). Verified inside the affected container:

    $ cat /sys/fs/cgroup/cpu.max
    300000 100000
    $ nproc
    16
    $ <new logic>
    ncpus=3

Drop `nproc --all` everywhere it bypassed env.ncpus:

  Build_LLVM_WASM/action.yml -> use ${{ env.ncpus }}, since both
    callers (emscripten.yml and deploy-pages.yml) call
    Select_Default_Build_Type before invoking this action.
  clang-tidy-review.yml -> drop --all (this workflow runs on
    github-hosted ubuntu-22.04 only with no cgroup cap, so the
    behavior is unchanged; kept aligned with the new direction).

Same Select_Default_Build_Type edit: switch the macOS branch selector from `${{ matrix.os }}` to `${{ runner.os }}`. Composite actions don't reliably get the `matrix.*` context under nektos/act (the `${{ matrix.os }}` literal expands to ""), and `runner.os` is documented as available everywhere -- works the same on github-hosted, fixes the macOS detection under act.

# Description

Please include a summary of changes, motivation and context for this PR.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [ ] I have read the contribution guide recently
