### PR TITLE
[ci] Build_and_Test_CppInterOp: make build dir creation idempotent.

### DIFF
--- a/.github/actions/Build_and_Test_CppInterOp/action.yml
+++ b/.github/actions/Build_and_Test_CppInterOp/action.yml
@@ -61,7 +61,13 @@ runs:
         export CPPINTEROP_DIR="$CB_PYTHON_DIR/cppyy_backend"
 
         # Build CppInterOp next to cling and llvm-project.
-        mkdir build && cd build
+        # `rm -rf` guards against a stale build/ from a prior run --
+        # github-hosted runners start with an empty workspace, but
+        # local reproductions via nektos/act reuse the host workspace
+        # (or a persisted container's overlay) where build/ may
+        # already exist; `mkdir build` would otherwise fail with
+        # "File exists" under set -e.
+        rm -rf build && mkdir build && cd build
         export CPPINTEROP_BUILD_DIR=$PWD
         cling_on=$(echo "${{ matrix.cling }}" | tr '[:lower:]' '[:upper:]')
         # Propagate matrix.sanitizer to CppInterOp's cmake. CppInterOp's
@@ -276,6 +282,8 @@ runs:
         echo "CPPINTEROP_DIR=$env:CPPINTEROP_DIR" >> $env:GITHUB_ENV
 
         # Build CppInterOp next to cling and llvm-project.
+        # See bash sites above re: stale build/ on local repro paths.
+        if (Test-Path build) { Remove-Item -Recurse -Force build }
         mkdir build
         cd build
         $env:CPPINTEROP_BUILD_DIR="$env:PWD_DIR"
@@ -343,6 +351,8 @@ runs:
         popd
 
         # Build CppInterOp next to cling and llvm-project.
+        # See native-shared site above re: stale build/ on local repro.
+        rm -rf build
         mkdir build
         cd build
         if [[ "${cling_on}" == "ON" ]]; then
@@ -504,6 +514,8 @@ runs:
         source ./emsdk/emsdk_env.sh
 
         # Build CppInterOp next to cling and llvm-project.
+        # See native-shared site above re: stale build/ on local repro.
+        rm -rf build_static
         mkdir build_static
         cd build_static
         if [[ "${cling_on}" == "ON" ]]; then
@@ -651,6 +663,8 @@ runs:
         popd
 
         # Build CppInterOp next to cling and llvm-project.
+        # See bash sites above re: stale build/ on local repro paths.
+        if (Test-Path build) { Remove-Item -Recurse -Force build }
         mkdir build
         cd build
         if ( "${{ matrix.cling }}" -imatch "On" )
@@ -744,6 +758,8 @@ runs:
         }
 
         # Build CppInterOp next to cling and llvm-project.
+        # See bash sites above re: stale build/ on local repro paths.
+        if (Test-Path build_static) { Remove-Item -Recurse -Force build_static }
         mkdir build_static
         cd build_static
         if ( "${{ matrix.cling }}" -imatch "On" )


### PR DESCRIPTION
The action's six `mkdir build` (or `mkdir build_static`) sites all assumed an empty workspace -- true on github-hosted runners (every job starts with a fresh actions/checkout) but false under nektos/act, which mounts the host workspace or reuses a persisted container's overlay. A stale build/ from any prior run trips `mkdir build` with "File exists"; under `set -e` the script aborts before cmake runs, and the &&-chained `cd build` doesn't happen either, so cmake then fires from the workspace root with `../` resolving to the parent (no CMakeLists.txt) -- the visible error.

Add an `rm -rf <dir>` (bash) / `if (Test-Path <dir>) { Remove-Item -Recurse -Force <dir> }` (powershell) before each mkdir, so the "start from a clean build dir" invariant holds regardless of what the workspace looked like at step start. No-op on github-hosted runners (the dirs never exist there); fixes ci-workflows/bin/repro local CI reproduction.

Mirrors the pattern landed on ci-workflows for setup-recipe (__ci_workflows__ checkout and llvm-project extract).

# Description

Please include a summary of changes, motivation and context for this PR.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [ ] I have read the contribution guide recently
