### PR TITLE
[ci] Build cling on top of the llvm-root recipe install.

### DIFF
--- a/.github/actions/Miscellaneous/Install_Dependencies/action.yml
+++ b/.github/actions/Miscellaneous/Install_Dependencies/action.yml
@@ -42,7 +42,8 @@ runs:
         sudo apt-get install -y --no-install-recommends \
           cmake ninja-build g++ git python3 \
           valgrind libc6-dbg \
-          libeigen3-dev libboost-dev
+          libeigen3-dev libboost-dev \
+          libedit-dev
         sudo apt-get clean
 
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -138,6 +138,61 @@ jobs:
         arch: ${{ matrix.recipe-arch || 'x86_64' }}
         build-on-miss: 'false'
 
+    # llvm-root recipe ships LLVM+Clang only; install ClingConfig.cmake
+    # into the same prefix. Workarounds for upstream cling bugs (drop
+    # both once root-project/root#22123 lands and root-project/cling
+    # syncs):
+    # * UserInterface gate (2fdcb6d) -- forced via CLING_INCLUDE_TESTS=ON.
+    # * libcling LIBS missing clangInterpreter (0307632f31) -- patched
+    #   inline below.
+    - name: Build cling on top of recipe LLVM
+      if: ${{ runner.environment != 'self-hosted' && matrix.cling == 'On' && matrix.use-recipe == 'llvm-root' && runner.os != 'Windows' }}
+      shell: bash
+      run: |
+        LLVM_PREFIX="$(pwd)/llvm-project"
+        rm -rf cling
+        git clone --depth=1 https://github.com/root-project/cling.git
+        # GNU vs BSD sed: `a\TEXT` is GNU-only; awk is portable.
+        f=cling/tools/libcling/CMakeLists.txt
+        awk '/^  clangEdit$/ {print; print "  clangInterpreter"; next} 1' "$f" > "$f.tmp" && mv "$f.tmp" "$f"
+        mkdir cling/build && cd cling/build
+        cmake .. \
+            -GNinja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DLLVM_DIR="$LLVM_PREFIX/lib/cmake/llvm" \
+            -DClang_DIR="$LLVM_PREFIX/lib/cmake/clang" \
+            -DCMAKE_INSTALL_PREFIX="$LLVM_PREFIX" \
+            -DCLING_INCLUDE_TESTS=ON \
+            -DLLVM_INCLUDE_TESTS=OFF
+        cmake --build . --parallel ${{ env.ncpus }}
+        cmake --install .
+
+    - name: Build cling on top of recipe LLVM (Windows)
+      if: ${{ runner.environment != 'self-hosted' && matrix.cling == 'On' && matrix.use-recipe == 'llvm-root' && runner.os == 'Windows' }}
+      shell: pwsh
+      run: |
+        $LLVM_PREFIX = "$pwd\llvm-project"
+        if (Test-Path cling) { Remove-Item -Recurse -Force cling }
+        git clone --depth=1 https://github.com/root-project/cling.git
+        # Mirror the bash awk: insert clangInterpreter after clangEdit
+        # in tools/libcling/CMakeLists.txt LIBS.
+        $f = "cling\tools\libcling\CMakeLists.txt"
+        (Get-Content $f) | ForEach-Object {
+          $_
+          if ($_ -ceq "  clangEdit") { "  clangInterpreter" }
+        } | Set-Content $f
+        New-Item -ItemType Directory -Path cling\build | Out-Null
+        Set-Location cling\build
+        cmake .. `
+          -DCMAKE_BUILD_TYPE=Release `
+          "-DLLVM_DIR=$LLVM_PREFIX\lib\cmake\llvm" `
+          "-DClang_DIR=$LLVM_PREFIX\lib\cmake\clang" `
+          "-DCMAKE_INSTALL_PREFIX=$LLVM_PREFIX" `
+          -DCLING_INCLUDE_TESTS=ON `
+          -DLLVM_INCLUDE_TESTS=OFF
+        cmake --build . --config Release --parallel ${{ env.ncpus }}
+        cmake --install . --config Release
+
     - name: Cache LLVM-${{ matrix.clang-runtime }} (Clang-REPL) build
       uses: actions/cache/save@v4
       if: ${{ runner.environment != 'self-hosted' && !matrix.use-recipe && steps.cache.outputs.cache-hit != 'true' }}


### PR DESCRIPTION
The llvm-root recipe ships LLVM+Clang only; the cling rows expect ClingConfig.cmake at $LLVM/lib/cmake/cling/. Add a step that clones root-project/cling, builds it against the recipe install and installs back into the same prefix. Build_and_Test_CppInterOp/action.yml then auto-detects the in-prefix ClingConfig.cmake and takes the recipe-install code path.

Two cling cmake bugs leak into a fresh standalone build and have to be worked around inline until the upstream fix lands:

* CLING_INCLUDE_TESTS=ON forces lib/UserInterface to be added (cling 9cdffe0c44 collapsed an `EXISTS textinput OR CLING_INCLUDE_TESTS` gate down to the test flag, leaving the unconditional driver and Jupyter links to clingUserInterface unsatisfied).
* A one-line sed adds clangInterpreter to tools/libcling/CMakeLists .txt's LIBS so libcling.so picks up clang::ReplCodeCompleter, which 0307632f31 introduced as a dependency without updating the link list.

clingUserInterface declares LLVM_LINK_COMPONENTS LineEditor, and the LLVMConfig.cmake that ships with the recipe calls
find_package(LibEdit) at consumer-side configure time -- so the cppinterop runner image needs libedit-dev. Add it to Install_Dependencies on Linux. macOS already provides libedit via libc.

Windows cling row is gated out for now: it needs a separate pwsh handler, out of scope for this commit.

# Description

Please include a summary of changes, motivation and context for this PR.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [ ] I have read the contribution guide recently
