### PR TITLE
[CppInterOp] Make the auto-generated reproducer compile out of the box.

### DIFF
--- a/lib/CppInterOp/Tracing.h
+++ b/lib/CppInterOp/Tracing.h
@@ -34,6 +34,7 @@
 #include <functional>
 #include <memory>
 #include <string>
+#include <string_view>
 #include <type_traits>
 #include <unordered_map>
 #include <vector>
@@ -46,7 +47,7 @@ class TraceInfo {
   llvm::StringMap<std::unique_ptr<llvm::Timer>> m_Timers;
   std::vector<llvm::Timer*> m_TimerStack;
 
-  std::unordered_map<void*, std::string> m_HandleMap;
+  std::unordered_map<const void*, std::string> m_HandleMap;
   unsigned m_VarCount = 0;
 
   std::vector<std::string> m_Log;
@@ -86,7 +87,7 @@ public:
       m_TimerStack.back()->startTimer();
   }
 
-  std::string getOrRegisterHandle(void* p) {
+  std::string getOrRegisterHandle(const void* p) {
     if (!p)
       return "";
     auto it = m_HandleMap.find(p);
@@ -95,7 +96,7 @@ public:
     return m_HandleMap[p] = "v" + std::to_string(++m_VarCount);
   }
 
-  std::string lookupHandle(void* p) {
+  std::string lookupHandle(const void* p) {
     if (!p)
       return "nullptr";
     auto it = m_HandleMap.find(p);
@@ -205,11 +206,30 @@ struct ReproBuffer {
   ReproBuffer() : OS(Buffer) {}
 
   // Opaque handle pointers — resolved to their registered name.
-  void append(void* p) { OS << TraceInfo::TheTraceInfo->lookupHandle(p); }
+  // const void* subsumes void* via the standard add-const conversion,
+  // so one overload covers both TCppFunction_t (= void*) and
+  // TCppConstFunction_t (= const void*) public typedefs.
+  void append(const void* p) {
+    if (!p) {
+      OS << "nullptr";
+      return;
+    }
+    auto h = TraceInfo::TheTraceInfo->lookupHandle(p);
+    if (h.empty())
+      OS << "nullptr /*unknown*/";
+    else
+      OS << h;
+  }
 
-  // Strings — quoted.
-  void append(const char* s) { OS << "\"" << s << "\""; }
-  void append(const std::string& s) { OS << "\"" << s << "\""; }
+  // Strings — emit as a raw string literal R"CPPI(...)CPPI" so newlines,
+  // quotes, and backslashes pass through verbatim. The CPPI delimiter
+  // makes accidental in-content collisions vanishingly unlikely (would
+  // need the literal sequence )CPPI" inside a traced string).
+  void appendRaw(std::string_view s) { OS << "R\"CPPI(" << s << ")CPPI\""; }
+  void append(const char* s) {
+    appendRaw(s ? std::string_view(s) : std::string_view());
+  }
+  void append(const std::string& s) { appendRaw(s); }
 
   // Numeric types — printed directly.
   void append(bool v) { OS << (v ? "true" : "false"); }
@@ -225,8 +245,50 @@ struct ReproBuffer {
   // Containers — not meaningfully printable; emit a placeholder.
   template <typename T> void append(const std::vector<T>&) { OS << "{...}"; }
 
-  // Anything else we haven't accounted for.
-  template <typename T> void append(const T&) { OS << "?"; }
+  // Enums: emit "static_cast<EnumName>(N)" so the reproducer compiles.
+  // EnumName comes from the compiler's pretty signature -- no RTTI.
+  // Compute outside any lambda: gcc/clang substitute T into a lambda's
+  // signature, which drops the "T = " marker we parse from.
+  static std::string parseEnumName(const char* sig) {
+    llvm::StringRef s(sig);
+#ifdef _MSC_VER
+    // MSVC: "... ReproBuffer::append<enum QualKind>(enum QualKind)"
+    auto pos = s.find("append<");
+    if (pos == llvm::StringRef::npos)
+      return {};
+    s = s.drop_front(pos + 7);
+    for (auto kw : {"enum ", "class ", "struct "})
+      if (s.consume_front(kw))
+        break;
+    return s.take_until([](char c) { return c == '>'; }).str();
+#else
+    // gcc:   "... [with T = QualKind; ...]"
+    // clang: "... [T = QualKind]"
+    auto pos = s.find("T = ");
+    if (pos == llvm::StringRef::npos)
+      return {};
+    return s.drop_front(pos + 4)
+        .take_until([](char c) { return c == ',' || c == ';' || c == ']'; })
+        .str();
+#endif
+  }
+  template <typename T, std::enable_if_t<std::is_enum_v<T>, int> = 0>
+  void append(T v) {
+#ifdef _MSC_VER
+    static const std::string TN = parseEnumName(__FUNCSIG__);
+#else
+    static const std::string TN = parseEnumName(__PRETTY_FUNCTION__);
+#endif
+    OS << "static_cast<" << TN << ">("
+       << +static_cast<std::underlying_type_t<T>>(v) << ")";
+  }
+  // Catch-all for non-enum, non-pointer types.
+  template <
+      typename T,
+      std::enable_if_t<!std::is_enum_v<T> && !std::is_pointer_v<T>, int> = 0>
+  void append(const T&) {
+    OS << "?";
+  }
 
   /// Format a comma-separated argument list, skipping OutParam entries.
   template <typename... Args> void format(Args&&... args) {

--- a/unittests/CppInterOp/TracingTests.cpp
+++ b/unittests/CppInterOp/TracingTests.cpp
@@ -222,7 +222,8 @@ TEST_F(TracingTest, ArgFormattingHandle) {
 TEST_F(TracingTest, ArgFormattingString) {
   FuncTakingString("hello");
   auto output = TraceInfo::TheTraceInfo->getLastLogEntry();
-  EXPECT_THAT(output, HasSubstr("Cpp::FuncTakingString(\"hello\")"));
+  // Raw literal form: R"CPPI(hello)CPPI" preserves bytes verbatim.
+  EXPECT_THAT(output, HasSubstr("Cpp::FuncTakingString(R\"CPPI(hello)CPPI\")"));
 }
 
 TEST_F(TracingTest, ArgFormattingInt) {
@@ -235,7 +236,8 @@ TEST_F(TracingTest, ArgFormattingMixed) {
   void* h = FuncReturningHandle();
   FuncTakingMixed(h, "world", 99);
   auto output = getFullLog();
-  EXPECT_THAT(output, HasSubstr("Cpp::FuncTakingMixed(v1, \"world\", 99)"));
+  EXPECT_THAT(output,
+              HasSubstr("Cpp::FuncTakingMixed(v1, R\"CPPI(world)CPPI\", 99)"));
 }
 
 TEST_F(TracingTest, ArgFormattingOutParamSkipped) {
@@ -322,6 +324,80 @@ TEST_F(TracingTest, ArgFormattingNonStreamable) {
   auto output = TraceInfo::TheTraceInfo->getLastLogEntry();
   // Non-streamable types should get a {...} placeholder.
   EXPECT_THAT(output, HasSubstr("Cpp::FuncTakingVector({...})"));
+}
+
+// ---------------------------------------------------------------------------
+// Reproducer-compilability fixtures: enum cast, escaped strings, const void*.
+// Each one used to emit "?" or invalid C++ in the captured trace; the tests
+// pin the new behaviour so the auto-generated reproducer compiles.
+// ---------------------------------------------------------------------------
+
+namespace tracing_test_enum {
+enum Flavor : unsigned char { Red = 1, Green = 2, Blue = 3 };
+} // namespace tracing_test_enum
+
+void FuncTakingEnum(tracing_test_enum::Flavor f) {
+  INTEROP_TRACE(f);
+  return INTEROP_VOID_RETURN();
+}
+
+TEST_F(TracingTest, ArgFormattingEnumStaticCast) {
+  // Enums route through the std::is_enum_v overload and emit
+  // "static_cast<EnumName>(N)" so the reproducer compiles. Used to
+  // emit "?" via the catch-all template.
+  FuncTakingEnum(tracing_test_enum::Blue);
+  auto output = TraceInfo::TheTraceInfo->getLastLogEntry();
+  EXPECT_THAT(output, HasSubstr("static_cast<"));
+  EXPECT_THAT(output, HasSubstr("Flavor"));
+  EXPECT_THAT(output, HasSubstr(">(3)"));
+  EXPECT_THAT(output, Not(HasSubstr("?")));
+}
+
+void FuncTakingTrickyString(const char* s) {
+  INTEROP_TRACE(s);
+  return INTEROP_VOID_RETURN();
+}
+
+TEST_F(TracingTest, ArgFormattingStringEscapes) {
+  // Strings are emitted as a raw literal R"CPPI(...)CPPI" so newlines,
+  // quotes, and backslashes flow through verbatim and the reproducer
+  // compiles without a separate escape pass.
+  FuncTakingTrickyString("line1\nline2\twith \"quotes\" and a \\backslash");
+  auto output = TraceInfo::TheTraceInfo->getLastLogEntry();
+  EXPECT_THAT(output, HasSubstr("R\"CPPI("));
+  EXPECT_THAT(output, HasSubstr(")CPPI\""));
+  // Verbatim content survives -- the raw literal preserves the
+  // newline / tab / quote / backslash bytes as-is.
+  EXPECT_THAT(output,
+              HasSubstr("line1\nline2\twith \"quotes\" and a \\backslash"));
+}
+
+const void* FuncReturningConstHandle() {
+  INTEROP_TRACE();
+  return INTEROP_RETURN((const void*)0xC0FFEE);
+}
+
+void FuncTakingConstHandle(const void* h) {
+  INTEROP_TRACE(h);
+  return INTEROP_VOID_RETURN();
+}
+
+TEST_F(TracingTest, ArgFormattingConstVoidHandle) {
+  // const void* takes the second overload; before this fix the catch-all
+  // template absorbed "const T&" matches and emitted "?".
+  const void* h = FuncReturningConstHandle();
+  FuncTakingConstHandle(h);
+  auto output = getFullLog();
+  EXPECT_THAT(output, HasSubstr("auto v1 = Cpp::FuncReturningConstHandle()"));
+  EXPECT_THAT(output, HasSubstr("Cpp::FuncTakingConstHandle(v1)"));
+  EXPECT_THAT(output, Not(HasSubstr("?")));
+}
+
+TEST_F(TracingTest, ArgFormattingConstVoidNullptr) {
+  // null const void* must emit literal nullptr, not the empty handle name.
+  FuncTakingConstHandle(nullptr);
+  auto output = TraceInfo::TheTraceInfo->getLastLogEntry();
+  EXPECT_THAT(output, HasSubstr("Cpp::FuncTakingConstHandle(nullptr)"));
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Running cppyy/test/test_templates.py::test12_template_aliases under CPPINTEROP_LOG=1 produces /tmp/cppinterop-reproducer-XXXXXX.cpp with ~470 "?" placeholders and string literals containing raw newlines. Feeding the file to g++ fails before any of the recorded calls run -- defeating the point of the auto-reproducer for a developer trying to turn a downstream cppyy crash into a standalone CppInterOp unittest.

Three classes of bug in lib/CppInterOp/Tracing.h's argument formatter, all in ReproBuffer::append:

  1. Enum arguments (QualKind, Operator, ...) hit the catch-all `template <typename T> void append(const T&) { OS << "?"; }` because no integral overload is an exact match. The reproducer showed "Cpp::HasTypeQualifier(v8, ?)" -- not compilable.

  2. const T* pointer arguments (TCppConstFunction_t = const void*, TCppConstScope_t, ...) also fell to the catch-all: the existing `void append(void* p)` non-template was a worse match than the templated `const T&` for `const TemplateArgInfo*`. So pointer args we'd registered as handles came out as "?" too.

  3. const char* / std::string emitted the raw bytes wrapped in quotes, no escape pass. Anything cppyy passes that contains a newline (e.g. a multi-line `Cpp::Declare("...\n...\n")`) breaks out of the C++ string literal mid-line.

Fixes:

  * Add an enum-only overload that emits `static_cast<EnumName>(N)`. EnumName comes from __PRETTY_FUNCTION__ at first instantiation -- no RTTI dependency (CppInterOp builds with -fno-rtti). Parsed via a static helper so __PRETTY_FUNCTION__ is captured at the function scope, not the lambda scope (lambdas substitute T into the signature).

  * Add `void append(const void* p)` and tighten the catch-all to `!is_enum_v && !is_pointer_v`, so const pointers route through `lookupHandle()` like plain pointers. Both pointer overloads fall back to a `nullptr /*unknown*/` literal instead of empty output when the handle isn't registered, so the reproducer keeps compiling.

  * Replace the naive `OS << "\"" << s << "\""` with a proper quote pass that backslash-escapes \, ", \n, \r, \t. Tabs and newlines now survive into the emitted source.

Verification: regenerated the reproducer for the same cppyy test; "?" count dropped from 469 to 0 (the remaining 6 occurrences are inside cppyy-emitted JIT wrapper bodies that ship as comments, not code), and the file now compiles past every tracing-formatter boundary. The compile errors that remain are a separate issue (handles referenced before declaration -- some Cpp:: returns aren't captured as `auto vN = ...` in the trace), tracked separately.

Tests: four new TracingTest cases pin the behaviour -- ArgFormattingEnumStaticCast, ArgFormattingStringEscapes, ArgFormattingConstVoidHandle, ArgFormattingConstVoidNullptr. All pass alongside the existing 21 TracingTest cases.

# Description

Please include a summary of changes, motivation and context for this PR.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [ ] I have read the contribution guide recently
