### PR TITLE
Add null-type guards before QualType::getFromOpaquePtr

### DIFF
--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -2100,6 +2100,8 @@ bool IsSameType(TCppType_t type_a, TCppType_t type_b) {
 
 bool IsPointerType(TCppType_t type) {
   INTEROP_TRACE(type);
+  if (!type)
+    return INTEROP_RETURN(false);
   QualType QT = QualType::getFromOpaquePtr(type);
   return INTEROP_RETURN(QT->isPointerType());
 }
@@ -2122,12 +2124,16 @@ TCppType_t GetPointeeType(TCppType_t type) {
 
 bool IsReferenceType(TCppType_t type) {
   INTEROP_TRACE(type);
+  if (!type)
+    return INTEROP_RETURN(nullptr);
   QualType QT = QualType::getFromOpaquePtr(type);
   return INTEROP_RETURN(QT->isReferenceType());
 }
 
 ValueKind GetValueKind(TCppType_t type) {
   INTEROP_TRACE(type);
+  if (!type)
+    return INTEROP_RETURN(nullptr);
   QualType QT = QualType::getFromOpaquePtr(type);
   if (QT->isRValueReferenceType())
     return INTEROP_RETURN(ValueKind::RValue);
@@ -2138,12 +2144,16 @@ ValueKind GetValueKind(TCppType_t type) {
 
 TCppType_t GetPointerType(TCppType_t type) {
   INTEROP_TRACE(type);
+  if (!type)
+    return INTEROP_RETURN(nullptr);
   QualType QT = QualType::getFromOpaquePtr(type);
   return INTEROP_RETURN(getASTContext().getPointerType(QT).getAsOpaquePtr());
 }
 
 TCppType_t GetReferencedType(TCppType_t type, bool rvalue) {
   INTEROP_TRACE(type, rvalue);
+  if (!type)
+    return INTEROP_RETURN(nullptr);
   QualType QT = QualType::getFromOpaquePtr(type);
   if (rvalue)
     return INTEROP_RETURN(
@@ -2183,6 +2193,8 @@ TCppType_t GetUnderlyingType(TCppType_t type) {
 
 std::string GetTypeAsString(TCppType_t var) {
   INTEROP_TRACE(var);
+  if (!var)
+    return INTEROP_RETURN("");
   QualType QT = QualType::getFromOpaquePtr(var);
   PrintingPolicy Policy(getASTContext().getPrintingPolicy());
   Policy.Bool = true;               // Print bool instead of _Bool.
@@ -2393,6 +2405,8 @@ TCppType_t GetType(const std::string& name) {
 
 TCppType_t GetComplexType(TCppType_t type) {
   INTEROP_TRACE(type);
+  if (!type)
+    return INTEROP_RETURN(nullptr);
   QualType QT = QualType::getFromOpaquePtr(type);
 
   return INTEROP_RETURN(getASTContext().getComplexType(QT).getAsOpaquePtr());
@@ -4463,6 +4477,8 @@ std::vector<long int> GetDimensions(TCppType_t type) {
 
 bool IsTypeDerivedFrom(TCppType_t derived, TCppType_t base) {
   INTEROP_TRACE(derived, base);
+  if (!derived || !base)
+    return INTEROP_RETURN(false);
   auto& S = getSema();
   auto fakeLoc = GetValidSLoc(S);
   auto derivedType = clang::QualType::getFromOpaquePtr(derived);


### PR DESCRIPTION
Some of these type-interfaces have  missing null-guard, while others have them. In the ROOT-cppyy migration Ihit one such case with GetReferencedType. I took this opportunity to fond other places wehre this check would be good to have. Along with https://github.com/compiler-research/cppyy-backend/pull/202, this enables 3 new root tests (`stl_vector_iadd`,  `rdataframe_misc gh_20291` and  `distrdf-proxy columninfo`)