### PR TITLE
[CppInterOp] Tracing: emit reproducer-safe string literals.

### DIFF
--- a/lib/CppInterOp/Tracing.h
+++ b/lib/CppInterOp/Tracing.h
@@ -221,11 +221,30 @@ struct ReproBuffer {
       OS << h;
   }
 
-  // Strings — emit as a raw string literal R"CPPI(...)CPPI" so newlines,
-  // quotes, and backslashes pass through verbatim. The CPPI delimiter
-  // makes accidental in-content collisions vanishingly unlikely (would
-  // need the literal sequence )CPPI" inside a traced string).
-  void appendRaw(std::string_view s) { OS << "R\"CPPI(" << s << ")CPPI\""; }
+  // Strings -- emit a plain `"..."` literal when the content is
+  // printable ASCII without `"`, `\`, or control chars; otherwise
+  // fall back to `R"CPPI(...)CPPI"`, which passes the bytes through
+  // verbatim. The raw form is reserved for the cases that actually
+  // need it (quotes, backslashes, newlines from Cpp::Process /
+  // Cpp::Declare source blocks); plain literals keep the trace lines
+  // short and human-readable for the common case (identifiers,
+  // paths, simple expressions).
+  void appendRaw(std::string_view s) {
+    bool NeedsRaw = false;
+    for (char c : s) {
+      auto u = static_cast<unsigned char>(c);
+      // 0x20 is space: anything below it is a C0 control char (incl. \n,
+      // \t, \r) that would break a plain quoted literal; 0x7f is DEL.
+      if (c == '"' || c == '\\' || u < 0x20 || u == 0x7f) {
+        NeedsRaw = true;
+        break;
+      }
+    }
+    if (NeedsRaw)
+      OS << "R\"CPPI(" << s << ")CPPI\"";
+    else
+      OS << '"' << s << '"';
+  }
   void append(const char* s) {
     appendRaw(s ? std::string_view(s) : std::string_view());
   }

--- a/unittests/CppInterOp/TracingTests.cpp
+++ b/unittests/CppInterOp/TracingTests.cpp
@@ -220,10 +220,66 @@ TEST_F(TracingTest, ArgFormattingHandle) {
 }
 
 TEST_F(TracingTest, ArgFormattingString) {
+  // Plain printable-ASCII content takes the `"..."` branch -- the
+  // raw-literal form is reserved for content that would mis-encode as
+  // a plain literal (see ArgFormattingString* tests below).
   FuncTakingString("hello");
   auto output = TraceInfo::TheTraceInfo->getLastLogEntry();
-  // Raw literal form: R"CPPI(hello)CPPI" preserves bytes verbatim.
-  EXPECT_THAT(output, HasSubstr("Cpp::FuncTakingString(R\"CPPI(hello)CPPI\")"));
+  EXPECT_THAT(output, HasSubstr("Cpp::FuncTakingString(\"hello\")"));
+}
+
+TEST_F(TracingTest, ArgFormattingEmptyStringIsPlain) {
+  // Empty string takes the no-special-char branch -- emit `""` rather
+  // than `R"CPPI()CPPI"`.
+  FuncTakingString("");
+  auto output = TraceInfo::TheTraceInfo->getLastLogEntry();
+  EXPECT_THAT(output, HasSubstr("Cpp::FuncTakingString(\"\")"));
+  EXPECT_THAT(output, Not(HasSubstr("R\"CPPI(")));
+}
+
+TEST_F(TracingTest, ArgFormattingStringWithEmbeddedDoubleQuote) {
+  // Double quote forces the raw-literal fallback -- a plain `"..."`
+  // would terminate the string at the embedded quote.
+  FuncTakingString("a\"b");
+  auto output = TraceInfo::TheTraceInfo->getLastLogEntry();
+  EXPECT_THAT(output, HasSubstr("R\"CPPI(a\"b)CPPI\""));
+}
+
+TEST_F(TracingTest, ArgFormattingStringWithEmbeddedBackslash) {
+  // Backslash forces raw-literal -- in a plain literal it would start
+  // an escape sequence.
+  FuncTakingString("a\\b");
+  auto output = TraceInfo::TheTraceInfo->getLastLogEntry();
+  EXPECT_THAT(output, HasSubstr("R\"CPPI(a\\b)CPPI\""));
+}
+
+TEST_F(TracingTest, ArgFormattingStringWithControlChar) {
+  // Newline (a control char, < 0x20) forces raw-literal so the line
+  // doesn't get split mid-string in the reproducer.
+  FuncTakingString("a\nb");
+  auto output = TraceInfo::TheTraceInfo->getLastLogEntry();
+  EXPECT_THAT(output, HasSubstr("R\"CPPI(a\nb)CPPI\""));
+}
+
+TEST_F(TracingTest, ArgFormattingMultiLineStringUsesRawLiteral) {
+  // Multi-line source blocks (typical of Cpp::Declare / Cpp::Process)
+  // have several embedded newlines; raw-literal preserves the layout
+  // verbatim so the reproducer compiles unchanged.
+  FuncTakingString("void f() {\n  return 42;\n}\n");
+  auto output = TraceInfo::TheTraceInfo->getLastLogEntry();
+  EXPECT_THAT(output,
+              HasSubstr("R\"CPPI(void f() {\n  return 42;\n}\n)CPPI\""));
+}
+
+TEST_F(TracingTest, ArgFormattingStringWithHighBitStaysPlain) {
+  // High-bit (UTF-8) bytes are >= 0x20 and != 0x7f, so they keep the
+  // plain-literal path -- the source bytes pass through unchanged and
+  // the reproducer compiles with the same encoding.
+  FuncTakingString("r\xc3\xa9sum\xc3\xa9"); // "résumé" in UTF-8
+  auto output = TraceInfo::TheTraceInfo->getLastLogEntry();
+  EXPECT_THAT(output,
+              HasSubstr("Cpp::FuncTakingString(\"r\xc3\xa9sum\xc3\xa9\")"));
+  EXPECT_THAT(output, Not(HasSubstr("R\"CPPI(")));
 }
 
 TEST_F(TracingTest, ArgFormattingInt) {
@@ -237,7 +293,7 @@ TEST_F(TracingTest, ArgFormattingMixed) {
   FuncTakingMixed(h, "world", 99);
   auto output = getFullLog();
   EXPECT_THAT(output,
-              HasSubstr("Cpp::FuncTakingMixed(v1, R\"CPPI(world)CPPI\", 99)"));
+              HasSubstr("Cpp::FuncTakingMixed(v1, \"world\", 99)"));
 }
 
 TEST_F(TracingTest, ArgFormattingOutParamSkipped) {


### PR DESCRIPTION
ReproBuffer's append(const char*) and append(const std::string&) currently wrap the bytes in a plain "..." literal with no escape pass. Any string the traced API receives that contains ", \, or a control byte -- most commonly the newline embedded in Cpp::Process / Cpp::Declare source blocks -- breaks out of the C++ literal mid- content, and the auto-generated reproducer fails to compile before any traced call has a chance to run.

Pick the literal form by content: scan once for ", \, control bytes (< 0x20), and 0x7f; emit "..." when none are present, otherwise R"CPPI(...)CPPI" (which passes bytes through verbatim without an escape pass). The plain form keeps trace lines short for the common case (identifiers, paths, simple expressions); the raw form catches the rest. A traced string containing the literal sequence )CPPI" would still break the raw form -- a vanishingly unlikely collision that is the standard CPPI-delimiter trade-off, not addressed here.

Tests: five new TracingTest cases pin both branches -- empty string takes plain, embedded ", \, and \n each route to the raw form, and a UTF-8 high-bit string stays on the plain path.
