### PR TITLE
Use threadsafe death-test style in TracingTests

### DIFF
--- a/unittests/CppInterOp/TracingTests.cpp
+++ b/unittests/CppInterOp/TracingTests.cpp
@@ -32,13 +32,25 @@ static std::string getFullLog() {
 
 class TracingTest : public ::testing::Test {
 protected:
+  static void SetUpTestSuite() {
+    saved_death_test_style_ = ::testing::GTEST_FLAG(death_test_style);
+    GTEST_FLAG_SET(death_test_style, "threadsafe");
+  }
+  static void TearDownTestSuite() {
+    GTEST_FLAG_SET(death_test_style, saved_death_test_style_);
+  }
   void SetUp() override {
     if (TraceInfo::TheTraceInfo)
       TraceInfo::TheTraceInfo->clear();
     TraceInfo::TheTraceInfo = nullptr;
     InitTracing();
   }
+
+private:
+  static std::string saved_death_test_style_;
 };
+
+std::string TracingTest::saved_death_test_style_;
 
 class NoTracingTest : public ::testing::Test {
 protected:


### PR DESCRIPTION
Fixes sporadious failures on macOS26 and mac-beta. On apple systems, gtest's default "fast" death-test style fork()s the child without exec(), so the child inherits parent process state (atfork handlers, dyld closures, stdio locks) which can kill/stall before `EXPECT_DEATH` writes to stderr, so gtest captures an empty buffer and reports "died but not with expected error" with an empty Actualmsg. Seen on ROOT CI.

This is a known issue and the fix as seen in LLVM's compiler-rt sanitizer tests, which set `testing::GTEST_FLAG(death_test_style) = "threadsafe"; `  in their gtest entry points. Also see`gtest-death-test.cc:250` - "Death tests use fork(), which is unsafe particularly in a threaded context", and the project's docs recommend threadsafe for this case.
