### PR TITLE
[Tracing] Format std::vector input args as init lists.

### DIFF
--- a/lib/CppInterOp/Tracing.h
+++ b/lib/CppInterOp/Tracing.h
@@ -261,8 +261,21 @@ struct ReproBuffer {
   void append(double d) { OS << llvm::formatv("{0:f}", d); }
   void append(float f) { OS << llvm::formatv("{0:f}", f); }
 
-  // Containers — not meaningfully printable; emit a placeholder.
-  template <typename T> void append(const std::vector<T>&) { OS << "{...}"; }
+  // Vector input args -- emit a braced init list of recursively-formatted
+  // elements so the reproducer's call-site literal compiles. The previous
+  // `{...}` placeholder leaked through to generated reproducers and made
+  // them un-buildable as soon as a non-OutParam vector was passed in.
+  template <typename T> void append(const std::vector<T>& V) {
+    OS << "{";
+    bool First = true;
+    for (const auto& E : V) {
+      if (!First)
+        OS << ", ";
+      First = false;
+      append(E);
+    }
+    OS << "}";
+  }
 
   // Enums: emit "static_cast<EnumName>(N)" so the reproducer compiles.
   // EnumName comes from the compiler's pretty signature -- no RTTI.

--- a/lib/CppInterOp/Tracing.h
+++ b/lib/CppInterOp/Tracing.h
@@ -262,9 +262,7 @@ struct ReproBuffer {
   void append(float f) { OS << llvm::formatv("{0:f}", f); }
 
   // Vector input args -- emit a braced init list of recursively-formatted
-  // elements so the reproducer's call-site literal compiles. The previous
-  // `{...}` placeholder leaked through to generated reproducers and made
-  // them un-buildable as soon as a non-OutParam vector was passed in.
+  // elements so the reproducer's call-site literal compiles.
   template <typename T> void append(const std::vector<T>& V) {
     OS << "{";
     bool First = true;

--- a/unittests/CppInterOp/TracingTests.cpp
+++ b/unittests/CppInterOp/TracingTests.cpp
@@ -368,18 +368,57 @@ TEST_F(TracingTest, NonPointerReturnNoAnnotation) {
   EXPECT_THAT(output, HasSubstr("Cpp::ReturnInt()"));
 }
 
-// Test: non-streamable types (e.g. std::vector) are formatted as placeholders.
-void FuncTakingVector(const std::vector<const char*>& args) {
+// Vector input args are formatted as braced init lists of
+// recursively-formatted elements -- no longer the `{...}` placeholder
+// that produced uncompilable reproducers.
+void FuncTakingStrVector(const std::vector<const char*>& args) {
   INTEROP_TRACE(args);
   return INTEROP_VOID_RETURN();
 }
 
-TEST_F(TracingTest, ArgFormattingNonStreamable) {
+void FuncTakingIntVector(const std::vector<int>& args) {
+  INTEROP_TRACE(args);
+  return INTEROP_VOID_RETURN();
+}
+
+void FuncTakingNestedVector(const std::vector<std::vector<int>>& args) {
+  INTEROP_TRACE(args);
+  return INTEROP_VOID_RETURN();
+}
+
+TEST_F(TracingTest, ArgFormattingVectorOfStrings) {
+  // Exercises the per-element loop with the `, ` separator (>1 element)
+  // and the const-char* overload of append (plain-quote form).
   std::vector<const char*> v = {"a", "b"};
-  FuncTakingVector(v);
+  FuncTakingStrVector(v);
   auto output = TraceInfo::TheTraceInfo->getLastLogEntry();
-  // Non-streamable types should get a {...} placeholder.
-  EXPECT_THAT(output, HasSubstr("Cpp::FuncTakingVector({...})"));
+  EXPECT_THAT(output, HasSubstr("Cpp::FuncTakingStrVector({\"a\", \"b\"})"));
+}
+
+TEST_F(TracingTest, ArgFormattingVectorOfInts) {
+  // Pins the integer-element path through append(int).
+  std::vector<int> v = {1, 2, 3};
+  FuncTakingIntVector(v);
+  auto output = TraceInfo::TheTraceInfo->getLastLogEntry();
+  EXPECT_THAT(output, HasSubstr("Cpp::FuncTakingIntVector({1, 2, 3})"));
+}
+
+TEST_F(TracingTest, ArgFormattingEmptyVector) {
+  // Empty vector skips the loop -- emit `{}` with no separator. Pins
+  // the First-flag branch where it never flips.
+  std::vector<int> v;
+  FuncTakingIntVector(v);
+  auto output = TraceInfo::TheTraceInfo->getLastLogEntry();
+  EXPECT_THAT(output, HasSubstr("Cpp::FuncTakingIntVector({})"));
+}
+
+TEST_F(TracingTest, ArgFormattingNestedVector) {
+  // Recursive call: append(vector<vector<int>>) dispatches to
+  // append(vector<int>) for each element.
+  std::vector<std::vector<int>> v = {{1, 2}, {3}};
+  FuncTakingNestedVector(v);
+  auto output = TraceInfo::TheTraceInfo->getLastLogEntry();
+  EXPECT_THAT(output, HasSubstr("Cpp::FuncTakingNestedVector({{1, 2}, {3}})"));
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
The reproducer formatter emits `{...}` for any std::vector argument,
which leaks through to generated reproducers and makes them
un-buildable as soon as a non-OutParam vector reaches a Cpp:: call --
e.g. CreateInterpreter's argv/GpuArgs vectors land as
`Cpp::CreateInterpreter({...}, {...})`, which is not valid C++ for
an `std::vector<const char*>` parameter.

Recurse through `append` so each element is formatted by the
existing overload set; the result is a real C++ braced init list
the reproducer can compile (`{1, 2, 3}` for ints,
`{"a", "b"}` for strings, `{{1, 2}, {3}}` for nested vectors). The
traversal is O(N) per vector arg; tracing is a debug path so the
cost is acceptable.

Tests: four new TracingTest cases pin each branch of the formatter
-- empty vector (First-flag never flips), int vector, string vector
(reuses appendRaw via append(const char*)), and nested
vector<vector<int>> (recursive dispatch).

Depends on #969.