### PR TITLE
[Tracing] Track returned std::vector<P*> as named handles.

### DIFF
--- a/lib/CppInterOp/Tracing.h
+++ b/lib/CppInterOp/Tracing.h
@@ -49,6 +49,10 @@ class TraceInfo {
 
   std::unordered_map<const void*, std::string> m_HandleMap;
   unsigned m_VarCount = 0;
+  /// Monotonic suffix for `_retN` placeholders -- one slot per call
+  /// that returns std::vector<P*>. Separate from m_VarCount so the
+  /// vN handle namespace stays dense.
+  unsigned m_RetCount = 0;
 
   std::vector<std::string> m_Log;
   size_t m_RegionStart = 0; ///< Log index where current region began.
@@ -103,6 +107,9 @@ public:
     return (it != m_HandleMap.end()) ? it->second : "nullptr";
   }
 
+  /// Allocate the next `_retN` index for a vector-return placeholder.
+  unsigned nextRetIndex() { return m_RetCount++; }
+
   void appendToLog(const std::string& line) {
     m_Log.push_back(line);
     if (m_InRegion && m_WriteOnStdErr)
@@ -142,6 +149,7 @@ public:
     m_HandleMap.clear();
     m_Log.clear();
     m_VarCount = 0;
+    m_RetCount = 0;
   }
 
   CPPINTEROP_TRACE_API static TraceInfo* TheTraceInfo;
@@ -335,6 +343,16 @@ struct ReproBuffer {
   }
 };
 
+/// Matches std::vector<T*> for any pointer element type. Used by
+/// TraceRegion::record to recognise functions whose return value is a
+/// vector of opaque handles (e.g. GetFunctionsUsingName), so the
+/// reproducer can name the vector and read its elements out by index.
+template <typename T> struct is_pointer_vector : std::false_type {};
+template <typename T>
+struct is_pointer_vector<std::vector<T*>> : std::true_type {};
+template <typename T>
+inline constexpr bool is_pointer_vector_v = is_pointer_vector<T>::value;
+
 /// Holds all the data that is only needed when tracing is active.
 /// Heap-allocated only when TheTraceInfo != nullptr, so disabled tracing
 /// pays zero cost beyond a single pointer + bool on the stack.
@@ -343,6 +361,14 @@ struct TraceData {
   llvm::SmallString<128> ArgStr;
   void* Result = nullptr;
   bool HasPtrResult = false;
+  /// Set when the call returned std::vector<P*>; ~TraceRegion uses this
+  /// to spell `auto _retN = Cpp::Foo(...)` so element decls can read
+  /// `_retN[i]` and the replay sees the original pointers.
+  bool HasRetVec = false;
+  /// Snapshot of the returned vector's pointer elements, taken at
+  /// record() time -- the source vector goes out of scope before
+  /// ~TraceRegion runs.
+  llvm::SmallVector<const void*, 8> RetVecPtrs;
   double StartTime = 0;
   bool Returned = false;
   llvm::SmallVector<std::function<void(TraceInfo&)>, 2> OutCallbacks;
@@ -396,6 +422,25 @@ public:
     for (auto& cb : m_Data->OutCallbacks)
       cb(TI);
 
+    // Allocate a `_retN` slot up-front for vector-of-pointer returns so
+    // the call line spells `auto _retN = ...` and the per-element decls
+    // below can read `_retN[i]` (the replay sees the original
+    // pointers, not literal nulls).
+    int RetIdx = -1;
+    llvm::SmallVector<std::pair<size_t, std::string>, 8> RetDecls;
+    if (m_Data->HasRetVec) {
+      RetIdx = static_cast<int>(TI.nextRetIndex());
+      for (size_t i = 0; i < m_Data->RetVecPtrs.size(); ++i) {
+        const void* p = m_Data->RetVecPtrs[i];
+        if (!p)
+          continue;
+        bool isNew = TI.lookupHandle(p) == "nullptr";
+        std::string Name = TI.getOrRegisterHandle(p);
+        if (isNew)
+          RetDecls.emplace_back(i, std::move(Name));
+      }
+    }
+
     std::string VarPart;
     if (m_Data->Result) {
       bool isNew = TI.lookupHandle(m_Data->Result) == "nullptr";
@@ -404,6 +449,8 @@ public:
           llvm::formatv(isNew ? "auto {0} = " : "/*{0}*/ ", HandleName).str();
     } else if (m_Data->HasPtrResult) {
       VarPart = "/*nullptr*/ ";
+    } else if (RetIdx >= 0) {
+      VarPart = llvm::formatv("auto _ret{0} = ", RetIdx).str();
     }
 
     std::string Call = llvm::formatv("  {0}Cpp::{1}({2}); // [{3} ns]", VarPart,
@@ -411,6 +458,16 @@ public:
 
     // Store in log for the reproducer file.
     TI.appendToLog(Call);
+
+    // Per-element extractions for vector returns. Bounds-guard so the
+    // line is safe even if the replay produces a shorter vector than
+    // the original.
+    for (auto& [Idx, Name] : RetDecls)
+      TI.appendToLog(
+          llvm::formatv(
+              "  void* {0} = _ret{1}.size() > {2} ? _ret{1}[{2}] : nullptr;",
+              Name, RetIdx, Idx)
+              .str());
 
     m_Data.reset();
   }
@@ -434,6 +491,12 @@ public:
       m_Data->Result = const_cast<void*>(static_cast<const void*>(val));
     } else if constexpr (std::is_null_pointer_v<T>) {
       m_Data->HasPtrResult = true;
+    } else if constexpr (is_pointer_vector_v<T>) {
+      // Snapshot the element pointers; the source vector is owned by
+      // the API call site and goes out of scope before ~TraceRegion.
+      m_Data->HasRetVec = true;
+      for (auto* p : val)
+        m_Data->RetVecPtrs.push_back(static_cast<const void*>(p));
     }
     return val;
   }

--- a/unittests/CppInterOp/TracingTests.cpp
+++ b/unittests/CppInterOp/TracingTests.cpp
@@ -422,6 +422,100 @@ TEST_F(TracingTest, ArgFormattingNestedVector) {
 }
 
 // ---------------------------------------------------------------------------
+// Tests: returned std::vector<P*> -- elements registered as handles
+// ---------------------------------------------------------------------------
+
+std::vector<void*> ReturnPointerVector() {
+  INTEROP_TRACE();
+  std::vector<void*> v;
+  v.push_back((void*)0x101);
+  v.push_back((void*)0x202);
+  return INTEROP_RETURN(v);
+}
+
+std::vector<void*> ReturnEmptyPointerVector() {
+  INTEROP_TRACE();
+  std::vector<void*> v;
+  return INTEROP_RETURN(v);
+}
+
+std::vector<void*> ReturnVectorWithNullElement() {
+  INTEROP_TRACE();
+  std::vector<void*> v;
+  v.push_back((void*)0x303);
+  v.push_back(nullptr);
+  v.push_back((void*)0x404);
+  return INTEROP_RETURN(v);
+}
+
+TEST_F(TracingTest, ReturnedPointerVectorProducerAndConsumer) {
+  // Producer side: `auto _retN = ...` prelude + bounds-guarded
+  // `_retN[i]` per element. Consumer side: a subsequent call taking
+  // one of those pointers prints it by the same handle name (vN), so
+  // the reproducer's producing line and the consumer's argument refer
+  // to the same binding.
+  TraceInfo& TI = *TraceInfo::TheTraceInfo;
+  auto v = ReturnPointerVector();
+  std::string h0 = TI.lookupHandle(v[0]);
+  std::string h1 = TI.lookupHandle(v[1]);
+  ASSERT_NE(h0, "nullptr");
+  ASSERT_NE(h1, "nullptr");
+
+  FuncTakingHandle(v[0]);
+  auto output = getFullLog();
+  EXPECT_THAT(output, HasSubstr("auto _ret0 = Cpp::ReturnPointerVector()"));
+  EXPECT_THAT(output,
+              HasSubstr("void* " + h0 + " = _ret0.size() > 0 ? _ret0[0]"));
+  EXPECT_THAT(output,
+              HasSubstr("void* " + h1 + " = _ret0.size() > 1 ? _ret0[1]"));
+  EXPECT_THAT(output, HasSubstr("Cpp::FuncTakingHandle(" + h0 + ")"));
+}
+
+TEST_F(TracingTest, ReturnedPointerVectorEmptyEmitsNoDecls) {
+  // Empty vector returns the placeholder + zero element decls. The
+  // RetDecls loop never appends, so the only log line for this call is
+  // the call itself.
+  size_t before = TraceInfo::TheTraceInfo->getLog().size();
+  ReturnEmptyPointerVector();
+  size_t after = TraceInfo::TheTraceInfo->getLog().size();
+  EXPECT_EQ(after - before, 1u)
+      << "Empty vector return should emit only the call line, no element decls";
+  auto output = TraceInfo::TheTraceInfo->getLastLogEntry();
+  EXPECT_THAT(output,
+              HasSubstr("auto _ret0 = Cpp::ReturnEmptyPointerVector()"));
+}
+
+TEST_F(TracingTest, ReturnedPointerVectorDuplicateElementSkipsDecl) {
+  // If two returned vectors share an element pointer, only the first
+  // call registers (and emits a decl for) it; the second skips
+  // because lookupHandle no longer says "nullptr".
+  ReturnPointerVector();
+  ReturnPointerVector();
+  auto output = getFullLog();
+  // First call's decls are present; the second call's decls are
+  // suppressed (the elements already have names).
+  EXPECT_THAT(output, HasSubstr("auto _ret0 = Cpp::ReturnPointerVector()"));
+  EXPECT_THAT(output, HasSubstr("auto _ret1 = Cpp::ReturnPointerVector()"));
+  // _ret1 should have no `void* vN = _ret1[i]` lines for elements that
+  // were already registered.
+  EXPECT_THAT(output, Not(HasSubstr("_ret1.size() > 0 ? _ret1[0]")));
+}
+
+TEST_F(TracingTest, ReturnedPointerVectorNullElementSkipsDecl) {
+  // Null elements are skipped (`if (!p) continue;`) so the reproducer
+  // doesn't emit a decl that would shadow the global `nullptr`. The
+  // surrounding non-null elements still get their decls at their
+  // original indices.
+  ReturnVectorWithNullElement();
+  auto output = getFullLog();
+  EXPECT_THAT(output,
+              HasSubstr("auto _ret0 = Cpp::ReturnVectorWithNullElement()"));
+  EXPECT_THAT(output, HasSubstr("_ret0.size() > 0 ? _ret0[0] : nullptr"));
+  EXPECT_THAT(output, Not(HasSubstr("_ret0.size() > 1 ? _ret0[1]")));
+  EXPECT_THAT(output, HasSubstr("_ret0.size() > 2 ? _ret0[2] : nullptr"));
+}
+
+// ---------------------------------------------------------------------------
 // Reproducer-compilability fixtures: enum cast, escaped strings, const void*.
 // Each one used to emit "?" or invalid C++ in the captured trace; the tests
 // pin the new behaviour so the auto-generated reproducer compiles.


### PR DESCRIPTION
Functions that return std::vector<P*> (e.g. GetFunctionsUsingName, GetClassMethods) hand the caller a list of opaque clang Decl*. The trace records the call but discards the elements, so the reproducer sees `Cpp::GetFunctionsUsingName(...)` with no producing line for any pointer the caller subsequently passes to other Cpp:: APIs -- those sites print as `nullptr`, and the auto-generated reproducer no longer matches the original control flow.

Snapshot the element pointers in `record()` (the source vector is moved-from before `~TraceRegion` runs, so we copy the addresses out). The destructor allocates a `_retN` slot, names the call site `auto _retN = Cpp::Foo(...)`, and emits one `void* vK = _retN[i]` extraction per newly-registered element with a `.size() > i` bounds guard so the reproducer is safe even when the replay yields a shorter vector. Null elements are skipped so the decl list does not shadow the global `nullptr`. The `_retN` index lives in its own counter, not `m_VarCount`, so the `vN` handle namespace stays dense for the single-pointer-return case.

Tests: five new TracingTest cases pin each branch -- happy path (elements registered + decls emitted), downstream consumer (vN by name), empty vector (no decls), duplicate element across calls (no re-decl), and null element in the middle (skipped, surrounding indices preserved).

# Description

Please include a summary of changes, motivation and context for this PR.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [ ] I have read the contribution guide recently
