### PR TITLE
[Tracing] Distinguish unregistered pointers from nullptr in arg output.

### DIFF
--- a/lib/CppInterOp/Tracing.h
+++ b/lib/CppInterOp/Tracing.h
@@ -100,11 +100,18 @@ public:
     return m_HandleMap[p] = "v" + std::to_string(++m_VarCount);
   }
 
+  /// Resolve a pointer to a printable form.
+  /// - "nullptr" for an actual null pointer.
+  /// - "vN" for a pointer registered via getOrRegisterHandle.
+  /// - "" (empty) for a non-null pointer never seen by the tracer --
+  ///   the caller decides how to render the unknown case (e.g.
+  ///   `nullptr /*unknown*/` in argument lists, "is this new?" in the
+  ///   producer-side `auto vN = ...` gating logic).
   std::string lookupHandle(const void* p) {
     if (!p)
       return "nullptr";
     auto it = m_HandleMap.find(p);
-    return (it != m_HandleMap.end()) ? it->second : "nullptr";
+    return (it != m_HandleMap.end()) ? it->second : "";
   }
 
   /// Allocate the next `_retN` index for a vector-return placeholder.
@@ -434,7 +441,7 @@ public:
         const void* p = m_Data->RetVecPtrs[i];
         if (!p)
           continue;
-        bool isNew = TI.lookupHandle(p) == "nullptr";
+        bool isNew = TI.lookupHandle(p).empty();
         std::string Name = TI.getOrRegisterHandle(p);
         if (isNew)
           RetDecls.emplace_back(i, std::move(Name));
@@ -443,7 +450,7 @@ public:
 
     std::string VarPart;
     if (m_Data->Result) {
-      bool isNew = TI.lookupHandle(m_Data->Result) == "nullptr";
+      bool isNew = TI.lookupHandle(m_Data->Result).empty();
       std::string HandleName = TI.getOrRegisterHandle(m_Data->Result);
       VarPart =
           llvm::formatv(isNew ? "auto {0} = " : "/*{0}*/ ", HandleName).str();

--- a/unittests/CppInterOp/TracingTests.cpp
+++ b/unittests/CppInterOp/TracingTests.cpp
@@ -7,6 +7,7 @@
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/raw_ostream.h"
 
+#include <cstdint>
 #include <fstream>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -217,6 +218,29 @@ TEST_F(TracingTest, ArgFormattingHandle) {
   // The handle should be registered as v1, then reused.
   EXPECT_THAT(output, HasSubstr("auto v1 = Cpp::FuncReturningHandle()"));
   EXPECT_THAT(output, HasSubstr("Cpp::FuncTakingHandle(v1)"));
+}
+
+TEST_F(TracingTest, ArgFormattingUnregisteredHandleAnnotated) {
+  // A non-null pointer the tracer never produced -- the call is the
+  // first reference to it. The reproducer cannot bind it to a name,
+  // so flag the gap with `nullptr /*unknown*/` rather than silently
+  // collapsing to a bare `nullptr` (the previously-dead branch in
+  // ReproBuffer::append; lookupHandle now returns "" for unregistered).
+  // 0xDEADBEEF is unsigned int (>= 2^31) -- cast through uintptr_t
+  // to keep MSVC's C4312 silent on 64-bit, where void* is wider.
+  FuncTakingHandle(reinterpret_cast<void*>(static_cast<uintptr_t>(0xDEADBEEF)));
+  auto output = TraceInfo::TheTraceInfo->getLastLogEntry();
+  EXPECT_THAT(output, HasSubstr("Cpp::FuncTakingHandle(nullptr /*unknown*/)"));
+}
+
+TEST_F(TracingTest, ArgFormattingNullHandlePlain) {
+  // Genuine null renders as plain `nullptr` -- never carries the
+  // /*unknown*/ annotation, which is reserved for unregistered
+  // non-null pointers.
+  FuncTakingHandle(nullptr);
+  auto output = TraceInfo::TheTraceInfo->getLastLogEntry();
+  EXPECT_THAT(output, HasSubstr("Cpp::FuncTakingHandle(nullptr)"));
+  EXPECT_THAT(output, Not(HasSubstr("/*unknown*/")));
 }
 
 TEST_F(TracingTest, ArgFormattingString) {
@@ -610,6 +634,12 @@ TEST_F(TracingTest, HandleRegistry) {
   EXPECT_EQ(TI.lookupHandle(ptr2), v2);
 
   EXPECT_EQ(TI.lookupHandle(nullptr), "nullptr");
+
+  // An unregistered non-null pointer returns "" so callers can tell
+  // "the tracer has no handle for this" from "this is the literal
+  // nullptr". The two cases used to collide on "nullptr" and the
+  // distinction is what lets ReproBuffer annotate unknown args.
+  EXPECT_EQ(TI.lookupHandle((const void*)0xBADADD), "");
 
   // getOrRegisterHandle(nullptr) should return empty, not register.
   EXPECT_EQ(TI.getOrRegisterHandle(nullptr), "");


### PR DESCRIPTION
ReproBuffer::append already had a branch meant to flag unregistered non-null pointers as "nullptr /*unknown*/", but the branch was dead. lookupHandle returned the literal string "nullptr" for both actual null and unregistered pointers, so h.empty() never fired and any unrecognised pointer collapsed silently to a bare nullptr -- the reproducer reads as if the original program passed null at that call, masking the missing producing line.

Tighten lookupHandle's contract: "nullptr" only for an actual null pointer, "" for a non-null pointer the tracer never saw, "vN" for a registered handle. The two ~TraceRegion callers that gated their "auto vN = ..." prelude on lookupHandle == "nullptr" now check .empty() instead, matching the "we have no name yet" semantics. The previously-dead "nullptr /*unknown*/" annotation in append now fires for the unregistered case.

Tests: extend HandleRegistry to pin the empty-string return for an unregistered non-null pointer; add ArgFormattingUnregisteredHandle- Annotated (the previously-dead branch is now reached) and ArgFormattingNullHandlePlain (genuine null still renders without the annotation, so the two cases are visibly distinct in the trace).

Depends on #974