### PR TITLE
Honor using-directives via unqualified lookup in GetNamed.

### DIFF
--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -1015,6 +1015,112 @@ TCppScope_t GetScopeFromCompleteName(const std::string& name) {
   return INTEROP_RETURN(GetScope(name.substr(start, end), curr_scope));
 }
 
+// Sema::CurScope is private, but we need to reseat it briefly to drive
+// Sema::LookupName at a synthesized point inside `Within`. The
+// ALLOW_ACCESS/ACCESS pair from Sins.h gets us there without patching
+// clang.
+ALLOW_ACCESS(clang::Sema, CurScope, clang::Scope*);
+
+namespace {
+// Mirror DC's enclosing namespace nesting as a chain of clang::Scope*
+// rooted at S.TUScope, each Scope's entity set to the matching
+// DeclContext. Sema::CppLookupName walks this chain via getParent() and
+// reads using-directives off each entity's NamespaceDecl, so this is
+// enough to make unqualified lookup honour `using namespace ...;`
+// declared inside DC.
+clang::Scope* BuildSyntheticScopeChain(clang::Sema& S, clang::DeclContext* DC) {
+  if (!DC || DC->isTranslationUnit())
+    return S.TUScope;
+  auto* Parent = BuildSyntheticScopeChain(S, DC->getParent());
+  auto* Mine = new clang::Scope(Parent, clang::Scope::DeclScope, S.Diags);
+  Mine->setEntity(DC);
+  return Mine;
+}
+
+// RAII: build a synthetic scope chain for `Within`, install it as
+// Sema::CurScope, restore + delete on destruction. CppLookupName is
+// read-only on Scope/Sema state (only getParent/getEntity/
+// getLookupEntity/isDeclScope reads, plus a stack-local
+// UnqualUsingDirectiveSet); freeing the synthetic scopes is the
+// entire teardown — no ActOnPopScope needed because we never pushed
+// any decl onto these scopes.
+class SyntheticScopeChain {
+public:
+  SyntheticScopeChain(clang::Sema& Sema, clang::DeclContext* Within)
+      : S(Sema), Innermost(BuildSyntheticScopeChain(Sema, Within)),
+        Saved(ACCESS(Sema, CurScope)) {
+    ACCESS(S, CurScope) = Innermost;
+  }
+  ~SyntheticScopeChain() {
+    ACCESS(S, CurScope) = Saved;
+    while (Innermost && Innermost != S.TUScope) {
+      auto* Next = Innermost->getParent();
+      delete Innermost;
+      Innermost = Next;
+    }
+  }
+  SyntheticScopeChain(const SyntheticScopeChain&) = delete;
+  SyntheticScopeChain& operator=(const SyntheticScopeChain&) = delete;
+
+  clang::Scope* get() const { return Innermost; }
+
+private:
+  clang::Sema& S;
+  clang::Scope* Innermost;
+  clang::Scope* Saved;
+};
+
+// Unqualified lookup of `Name` from a synthesized point inside `Within`
+// ([basic.lookup.unqual]). Honours using-directives reachable from
+// Within, which Sema::LookupQualifiedName does not.
+//
+// FIXME: longer-term we want two distinct routes — one wrapping
+// LookupQualifiedName and one this — exposed as separate operations so
+// callers can pick the C++ semantics they actually want. For now
+// GetNamed gates this behind a qualified-lookup-miss + reachable
+// using-directive check, so the common case stays on the cheap path.
+clang::NamedDecl* LookupUnqualified(clang::Sema& S,
+                                    const clang::DeclarationName& Name,
+                                    clang::DeclContext* Within) {
+  SyntheticScopeChain Chain(S, Within);
+  // NotForRedeclaration: ForVisibleRedeclaration causes Sema::CppLookupName
+  // to return as soon as the innermost namespace doesn't directly contain
+  // the name (SemaLookup.cpp:1545), which prevents using-directives from
+  // an enclosing common-ancestor namespace from firing. We're doing
+  // ordinary name lookup, not collecting redeclarations.
+  clang::LookupResult R(S, Name, clang::SourceLocation(),
+                        clang::Sema::LookupOrdinaryName,
+                        RedeclarationKind::NotForRedeclaration);
+  R.suppressDiagnostics();
+  S.LookupName(R, Chain.get());
+  // Match LookupResult2Decl from CppInterOpInterpreter.h (clang-repl-only
+  // header, not included in CPPINTEROP_USE_CLING builds). Empty -> null;
+  // single -> found decl; multi -> (D*)-1 sentinel that GetNamed treats
+  // as "ambiguous, give up".
+  if (R.empty())
+    return nullptr;
+  R.resolveKind();
+  if (R.isSingleResult())
+    return llvm::dyn_cast<clang::NamedDecl>(R.getFoundDecl());
+  return (clang::NamedDecl*)-1;
+}
+
+// Cheap probe: does any namespace from `DC` up to TU carry at least
+// one using-directive? Gates the synthetic-scope-chain build below so
+// the common case (no using-directives anywhere on the path) doesn't
+// pay the heap-allocation tax.
+bool HasReachableUsingDirective(const clang::DeclContext* DC) {
+  for (; DC && !DC->isTranslationUnit(); DC = DC->getParent()) {
+    if (const auto* NS = llvm::dyn_cast<clang::NamespaceDecl>(DC)) {
+      auto UDs = NS->using_directives();
+      if (UDs.begin() != UDs.end())
+        return true;
+    }
+  }
+  return false;
+}
+} // namespace
+
 TCppScope_t GetNamed(const std::string& name,
                      TCppScope_t parent /*= nullptr*/) {
   INTEROP_TRACE(name, parent);
@@ -1029,10 +1135,26 @@ TCppScope_t GetNamed(const std::string& name,
     Within->getPrimaryContext()->buildLookup();
 #endif
   compat::SynthesizingCodeRAII RAII(&getInterp());
+
+  // Fast path: qualified lookup. Cheap, no scope-chain allocation, and
+  // resolves every name not brought into `Within` via a using-directive.
+  // Lookup::Named falls back to LookupName(R, TUScope) when Within is
+  // null, so TU-level using-directives are already handled there.
   auto* ND = CppInternal::utils::Lookup::Named(&getSema(), name, Within);
-  if (ND && ND != (clang::NamedDecl*)-1) {
+  if (ND && ND != (clang::NamedDecl*)-1)
     return INTEROP_RETURN((TCppScope_t)(ND->getCanonicalDecl()));
-  }
+
+  // Slow path: only when qualified lookup missed AND `Within` is a
+  // namespace whose enclosing chain carries at least one using-directive
+  // (the only reason qualified-vs-unqualified disagree at namespace
+  // scope per [basic.lookup.unqual] vs [basic.lookup.qual]).
+  if (!Within || !llvm::isa<clang::NamespaceDecl>(Within) ||
+      !HasReachableUsingDirective(Within))
+    return INTEROP_RETURN(nullptr);
+  clang::DeclarationName DName = &getSema().Context.Idents.get(name);
+  ND = LookupUnqualified(getSema(), DName, Within);
+  if (ND && ND != (clang::NamedDecl*)-1)
+    return INTEROP_RETURN((TCppScope_t)(ND->getCanonicalDecl()));
 
   return INTEROP_RETURN(nullptr);
 }

--- a/unittests/CppInterOp/ScopeReflectionTest.cpp
+++ b/unittests/CppInterOp/ScopeReflectionTest.cpp
@@ -704,6 +704,97 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, ScopeReflection_GetNamed) {
   EXPECT_EQ(Cpp::GetQualifiedName(std_string_npos_var), "std::basic_string<char>::npos");
 }
 
+TYPED_TEST(CPPINTEROP_TEST_MODE, ScopeReflection_GetNamedWithUsing) {
+  // Each subcase covers one form of [namespace.udecl] / [namespace.udir].
+  // GetNamed must look through the alias and return the original decl,
+  // identified by canonical-decl identity.
+  std::string code = R"(
+    namespace N {
+      class C {};
+      int x;
+      void f();
+    }
+    namespace M {
+      using N::C;          // using-declaration: type
+      using N::x;          // using-declaration: variable
+      using N::f;          // using-declaration: function
+    }
+    namespace P {
+      using namespace N;   // using-directive
+    }
+  )";
+
+  TestFixture::CreateInterpreter();
+  Interp->declare(code);
+
+  Cpp::TCppScope_t ns_N = Cpp::GetNamed("N");
+  Cpp::TCppScope_t ns_M = Cpp::GetNamed("M");
+  Cpp::TCppScope_t ns_P = Cpp::GetNamed("P");
+  ASSERT_TRUE(ns_N);
+  ASSERT_TRUE(ns_M);
+  ASSERT_TRUE(ns_P);
+
+  Cpp::TCppScope_t N_C = Cpp::GetNamed("C", ns_N);
+  Cpp::TCppScope_t N_x = Cpp::GetNamed("x", ns_N);
+  Cpp::TCppScope_t N_f = Cpp::GetNamed("f", ns_N);
+  ASSERT_TRUE(N_C);
+  ASSERT_TRUE(N_x);
+  ASSERT_TRUE(N_f);
+
+  // using-declaration: GetNamed inside M should resolve through the
+  // UsingShadowDecl to the original target in N.
+  EXPECT_EQ(Cpp::GetNamed("C", ns_M), N_C)
+      << "using N::C; GetNamed(\"C\", M) should return N::C";
+  EXPECT_EQ(Cpp::GetNamed("x", ns_M), N_x)
+      << "using N::x; GetNamed(\"x\", M) should return N::x";
+  EXPECT_EQ(Cpp::GetNamed("f", ns_M), N_f)
+      << "using N::f; GetNamed(\"f\", M) should return N::f";
+
+  // using-directive: names in N are visible inside P; GetNamed should
+  // surface them as the canonical decls in N.
+  EXPECT_EQ(Cpp::GetNamed("C", ns_P), N_C)
+      << "using namespace N; GetNamed(\"C\", P) should return N::C";
+  EXPECT_EQ(Cpp::GetNamed("x", ns_P), N_x)
+      << "using namespace N; GetNamed(\"x\", P) should return N::x";
+  EXPECT_EQ(Cpp::GetNamed("f", ns_P), N_f)
+      << "using namespace N; GetNamed(\"f\", P) should return N::f";
+
+  // Transitive using-directive ([namespace.udir]p3): names visible via
+  // the closure of using-directives, not just the first hop. Exercises
+  // UnqualUsingDirectiveSet::addUsingDirectives' transitive walk.
+  Interp->declare(R"(
+    namespace P2 { using namespace N; }
+    namespace Q  { using namespace P2; }
+  )");
+  Cpp::TCppScope_t ns_Q = Cpp::GetNamed("Q");
+  ASSERT_TRUE(ns_Q);
+  EXPECT_EQ(Cpp::GetNamed("C", ns_Q), N_C)
+      << "using namespace P2 (which uses N); GetNamed(\"C\", Q) "
+         "should chase Q -> P2 -> N::C";
+
+  // Ambiguous using-directives: two namespaces define the same name,
+  // both made visible by sibling using-directives. GetNamed must
+  // collapse the ambiguity to nullptr (LookupResult2Decl returns -1
+  // for non-single results, GetNamed turns that into nullptr).
+  Interp->declare(R"(
+    namespace N3 { class C {}; }
+    namespace AmbU { using namespace N; using namespace N3; }
+  )");
+  Cpp::TCppScope_t ns_Amb = Cpp::GetNamed("AmbU");
+  ASSERT_TRUE(ns_Amb);
+  EXPECT_EQ(Cpp::GetNamed("C", ns_Amb), nullptr)
+      << "ambiguous using-directives must return nullptr, not silently "
+         "pick one";
+
+  // Anonymous-namespace member visible at TU scope: Within=nullptr
+  // takes the TUScope short-circuit, which already runs unqualified
+  // lookup. Pin that the short-circuit still finds the name (the
+  // synthetic-scope path never runs here).
+  Interp->declare("namespace { int hidden_y = 42; }");
+  EXPECT_TRUE(Cpp::GetNamed("hidden_y"))
+      << "anonymous-namespace member should be visible at TU scope";
+}
+
 TYPED_TEST(CPPINTEROP_TEST_MODE, ScopeReflection_GetParentScope) {
   std::string code = R"(namespace N1 {
                         namespace N2 {


### PR DESCRIPTION
Cpp::GetNamed("name", parent) used Sema::LookupQualifiedName, which deliberately ignores using-directives held by the queried namespace ([basic.lookup.unqual] vs [basic.lookup.qual]). So GetNamed("X", P) with `namespace P { using namespace N; }` returned nullptr even when N::X was the only thing P made visible -- surfacing in cppyy as map iterators returning bare values instead of (key, value) pairs (test_stltypes test01_builtin_map_type) and template-arg lookups failing on `using` aliases (test_templates
test33_using_template_argument).

Route through Sema::LookupName with a synthetic Scope chain mirroring parent's enclosing namespace nesting; CppLookupName then walks the chain and consults using-directives stored on each NamespaceDecl, matching parser-time semantics. Two-tier dispatch keeps the common case zero-cost: qualified lookup first, synthetic-scope path only when qualified missed AND the namespace chain carries at least one using-directive. Synthetic Scopes never receive pushed decls, so RAII delete + Sema::CurScope restore is the entire teardown -- no ActOnPopScope.

Tests in ScopeReflection_GetNamedWithUsing cover three using- declaration forms, single-hop and transitive using-directives, ambiguous using-directives, and the anonymous-namespace TU short- circuit. FIXME left to expose LookupQualified / LookupUnqualified as distinct operations once the other Lookup::Named callers are audited.

# Description

Please include a summary of changes, motivation and context for this PR.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [ ] I have read the contribution guide recently
