### PR TITLE
Accept an optional parent scope in GetType.

### DIFF
--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -2382,13 +2382,13 @@ static std::optional<QualType> GetTypeInternal(Decl* D) {
   return {};
 }
 
-TCppType_t GetType(const std::string& name) {
-  INTEROP_TRACE(name);
+TCppType_t GetType(const std::string& name, TCppScope_t parent /*= nullptr*/) {
+  INTEROP_TRACE(name, parent);
   QualType builtin = findBuiltinType(name, getASTContext());
   if (!builtin.isNull())
     return INTEROP_RETURN(builtin.getAsOpaquePtr());
 
-  return INTEROP_RETURN(GetTypeFromScope(GetNamed(name, /*parent=*/nullptr)));
+  return INTEROP_RETURN(GetTypeFromScope(GetNamed(name, parent)));
 }
 
 TCppType_t GetComplexType(TCppType_t type) {

--- a/lib/CppInterOp/CppInterOp.td
+++ b/lib/CppInterOp/CppInterOp.td
@@ -126,10 +126,13 @@ def IsClass : CppInterOpAPI {
 
 def GetType : CppInterOpAPI {
   let Doc = [{Used to either get the built-in type of the provided string, or
-use the name to lookup the actual type.}];
+use the name to lookup the actual type. When `parent` is non-null, scoped
+lookup honours using-directives and type aliases declared inside it; passing
+`nullptr` (the default) limits lookup to TU scope.}];
 
   let ReturnType = "TCppType_t";
-  let Args = [Arg<"const std::string&", "name">];
+  let Args = [Arg<"const std::string&", "name">,
+              Arg<"TCppScope_t", "parent", "nullptr">];
 }
 
 def GetTypeFromScope : CppInterOpAPI {

--- a/unittests/CppInterOp/TypeReflectionTest.cpp
+++ b/unittests/CppInterOp/TypeReflectionTest.cpp
@@ -133,6 +133,52 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, TypeReflection_GetType) {
   EXPECT_EQ(Cpp::GetTypeAsString(Cpp::GetType("struct")),"NULL TYPE");
 }
 
+TYPED_TEST(CPPINTEROP_TEST_MODE, TypeReflection_GetTypeWithParent) {
+  TestFixture::CreateInterpreter();
+
+  Interp->declare(R"(
+    namespace NS {
+      struct Test {};
+      using testptr = Test*;       // alias whose target is Test*, not Test
+      using testref = Test&;       // alias whose target is a reference
+      typedef Test testtd;         // classic typedef to a class
+      class Member {};
+    }
+  )");
+
+  Cpp::TCppScope_t ns = Cpp::GetNamed("NS");
+  ASSERT_TRUE(ns);
+
+  // Builtin fast-path is independent of parent: `int` resolves
+  // identically with and without a scope.
+  EXPECT_EQ(Cpp::GetType("int"), Cpp::GetType("int", ns));
+  EXPECT_EQ(Cpp::GetTypeAsString(Cpp::GetType("int", ns)), "int");
+
+  // Direct-member lookup via parent.
+  EXPECT_EQ(Cpp::GetTypeAsString(Cpp::GetType("Test", ns)), "NS::Test");
+  EXPECT_EQ(Cpp::GetTypeAsString(Cpp::GetType("Member", ns)), "NS::Member");
+
+  // The motivating case: a type alias whose underlying QualType carries
+  // a pointer must round-trip with the pointer intact. GetTypeFromScope
+  // routes TypeAliasDecl through TND->getUnderlyingType(), preserving
+  // pointer / reference / cv qualifiers.
+  EXPECT_EQ(Cpp::GetTypeAsString(Cpp::GetType("testptr", ns)), "NS::Test *");
+  EXPECT_EQ(Cpp::GetTypeAsString(Cpp::GetType("testref", ns)), "NS::Test &");
+  EXPECT_EQ(Cpp::GetTypeAsString(Cpp::GetType("testtd", ns)), "NS::Test");
+
+  // TU-only lookup (no parent) does NOT see members of NS.
+  EXPECT_EQ(Cpp::GetType("testptr"), nullptr)
+      << "GetType(name) without a parent must not reach NS members";
+
+  // Negative: name not declared in the parent scope returns nullptr.
+  EXPECT_EQ(Cpp::GetType("nope", ns), nullptr);
+
+  // parent==nullptr is the historical behavior: TU-scope lookup,
+  // builtins still resolved.
+  EXPECT_EQ(Cpp::GetType("int", nullptr), Cpp::GetType("int"));
+  EXPECT_EQ(Cpp::GetType("testptr", nullptr), nullptr);
+}
+
 TYPED_TEST(CPPINTEROP_TEST_MODE, TypeReflection_IsRecordType) {
   std::vector<Decl *> Decls;
 


### PR DESCRIPTION
Cppyy's `is_identifier` fast-path in cppyy-backend resolves a bare identifier like "testptr" to a TCppType_t via Cppyy::GetType, which ultimately calls Cpp::GetType(name). Without a scope argument, Cpp:: GetType looks up the name at TU only -- so a type alias declared inside a namespace (`using testptr = Test*;`) is invisible to that fast-path even when the caller knows the enclosing scope. The slow template-trampoline path used to recover this case via `__typeof__`, but a recent cppyy optimisation short-circuits identifier inputs before reaching it.

Add an optional `parent` argument to Cpp::GetType, defaulted to nullptr to keep existing call sites stable. The new path mirrors the existing one: builtin-type fast-out first (`findBuiltinType`), then GetTypeFromScope(GetNamed(name, parent)). GetNamed already handles parent==nullptr as TU lookup, so a single `Cpp::GetType(name, parent)` call covers builtin + TU + scoped resolution from the consumer side -- exactly what the cppyy fast-path needs.

# Description

Please include a summary of changes, motivation and context for this PR.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [ ] I have read the contribution guide recently
