### PR TITLE
[Tracing] Declare _outN buffers and alias them at OUT-param call sites.

### DIFF
--- a/lib/CppInterOp/Tracing.h
+++ b/lib/CppInterOp/Tracing.h
@@ -53,6 +53,8 @@ class TraceInfo {
   /// that returns std::vector<P*>. Separate from m_VarCount so the
   /// vN handle namespace stays dense.
   unsigned m_RetCount = 0;
+  /// Monotonic suffix for `_outN` -- one slot per OUT pointer-container.
+  unsigned m_OutCount = 0;
 
   std::vector<std::string> m_Log;
   size_t m_RegionStart = 0; ///< Log index where current region began.
@@ -117,6 +119,10 @@ public:
   /// Allocate the next `_retN` index for a vector-return placeholder.
   unsigned nextRetIndex() { return m_RetCount++; }
 
+  /// Allocate the next `_outN` index. One per OUT argument, not per
+  /// call -- two OUT pointer-containers in one call get _out0/_out1.
+  unsigned nextOutIndex() { return m_OutCount++; }
+
   void appendToLog(const std::string& line) {
     m_Log.push_back(line);
     if (m_InRegion && m_WriteOnStdErr)
@@ -157,6 +163,7 @@ public:
     m_Log.clear();
     m_VarCount = 0;
     m_RetCount = 0;
+    m_OutCount = 0;
   }
 
   CPPINTEROP_TRACE_API static TraceInfo* TheTraceInfo;
@@ -194,9 +201,15 @@ inline void StopTracing(const std::string& Version = "") {
 /// all downstream code (ReproBuffer, TraceRegion) works with a single
 /// concrete type — no template specializations or detection traits needed.
 struct OutParam {
-  /// Callback that registers the container's pointer elements as handles.
-  /// Null when the container doesn't hold pointers (e.g. vector<string>).
-  std::function<void(TraceInfo&)> RegisterHandles;
+  /// Register the container's pointer elements as handles and emit
+  /// one `void* vN = _outN[i] : nullptr;` decl per newly-registered
+  /// element so a later call referencing the registered name finds a
+  /// real binding.
+  std::function<void(TraceInfo&, unsigned OutIdx)> RegisterHandles;
+  /// Drives the `_outN` preamble + alias path. Non-pointer containers
+  /// stay on the legacy "skip in arg list" rendering -- their type is
+  /// not erasable to void*, so the preamble decl would not type-check.
+  bool IsPointerContainer = false;
 };
 
 /// Create an OutParam for any container. Only sets up handle registration
@@ -205,9 +218,22 @@ template <typename Container> OutParam MakeOutParam(const Container& C) {
   OutParam OP;
   using Value = typename Container::value_type;
   if constexpr (std::is_pointer_v<Value>) {
-    OP.RegisterHandles = [&C](TraceInfo& TI) {
-      for (const auto& Elem : C)
-        TI.getOrRegisterHandle(reinterpret_cast<void*>(Elem));
+    OP.IsPointerContainer = true;
+    OP.RegisterHandles = [&C](TraceInfo& TI, unsigned OutIdx) {
+      size_t I = 0;
+      for (const auto& Elem : C) {
+        const void* P = static_cast<const void*>(Elem);
+        bool isNew = TI.lookupHandle(P).empty();
+        std::string Name = TI.getOrRegisterHandle(P);
+        // Bounds-guard with `.size() > i` for replays where the
+        // function fills fewer elements than the original call did.
+        if (isNew && P)
+          TI.appendToLog(llvm::formatv("  void* {0} = _out{1}.size() > {2} ? "
+                                       "_out{1}[{2}] : nullptr;",
+                                       Name, OutIdx, I)
+                             .str());
+        ++I;
+      }
     };
   }
   return OP;
@@ -335,11 +361,23 @@ struct ReproBuffer {
     OS << "?";
   }
 
-  /// Format a comma-separated argument list, skipping OutParam entries.
-  template <typename... Args> void format(Args&&... args) {
+  /// Format a comma-separated argument list. Pointer-container OUTs
+  /// emit `_outN` (next index from \p OutIndices); non-pointer OUTs
+  /// are skipped, matching the legacy rendering.
+  template <typename... Args>
+  void format(llvm::ArrayRef<unsigned> OutIndices, Args&&... args) {
     bool first = true;
+    size_t nextOut = 0;
     auto appendOne = [&](auto&& val) {
-      if constexpr (!std::is_same_v<std::decay_t<decltype(val)>, OutParam>) {
+      using V = std::decay_t<decltype(val)>;
+      if constexpr (std::is_same_v<V, OutParam>) {
+        if (val.IsPointerContainer) {
+          if (!first)
+            OS << ", ";
+          first = false;
+          OS << "_out" << OutIndices[nextOut++];
+        }
+      } else {
         if (!first)
           OS << ", ";
         first = false;
@@ -378,14 +416,22 @@ struct TraceData {
   llvm::SmallVector<const void*, 8> RetVecPtrs;
   double StartTime = 0;
   bool Returned = false;
-  llvm::SmallVector<std::function<void(TraceInfo&)>, 2> OutCallbacks;
+  llvm::SmallVector<std::function<void(TraceInfo&, unsigned)>, 2> OutCallbacks;
+  /// `_outN` indices for this call's OUT pointer-containers, in
+  /// left-to-right order. Consumed by format() at the call site and
+  /// by ~TraceRegion to emit the preamble decls.
+  llvm::SmallVector<unsigned, 2> OutIndices;
 };
 
 class TraceRegion {
   std::unique_ptr<TraceData> m_Data;
 
-  // Capture an OutParam's handle-registration callback; ignore everything else.
+  /// Allocate the OUT pointer-container's `_outN` index here, before
+  /// format() runs and consumes them. Non-pointer containers allocate
+  /// no index and fall through to the legacy skip rendering.
   void captureArg(OutParam&& op) {
+    if (op.IsPointerContainer)
+      m_Data->OutIndices.push_back(TraceInfo::TheTraceInfo->nextOutIndex());
     if (op.RegisterHandles)
       m_Data->OutCallbacks.push_back(std::move(op.RegisterHandles));
   }
@@ -397,10 +443,12 @@ public:
       return;
     m_Data = std::make_unique<TraceData>();
     m_Data->Name = Name;
+    // captureArg before format(): it fills OutIndices that format()
+    // consumes.
     (captureArg(std::forward<Args>(args)), ...);
     if constexpr (sizeof...(args) > 0) {
       ReproBuffer RB;
-      RB.format(std::forward<Args>(args)...);
+      RB.format(m_Data->OutIndices, std::forward<Args>(args)...);
       m_Data->ArgStr = RB.Buffer;
     }
     TraceInfo& TI = *TraceInfo::TheTraceInfo;
@@ -424,10 +472,6 @@ public:
     auto Dur = static_cast<long long>((EndTime - m_Data->StartTime) * 1e9);
     TraceInfo& TI = *TraceInfo::TheTraceInfo;
     TI.popTimer();
-
-    // Register out-param handles now that the function has filled them.
-    for (auto& cb : m_Data->OutCallbacks)
-      cb(TI);
 
     // Allocate a `_retN` slot up-front for vector-of-pointer returns so
     // the call line spells `auto _retN = ...` and the per-element decls
@@ -460,11 +504,23 @@ public:
       VarPart = llvm::formatv("auto _ret{0} = ", RetIdx).str();
     }
 
+    // Preamble: declare a fresh buffer per OUT pointer-container.
+    // void* element type matches the public API's erasure of
+    // TCpp*Scope_t et al.
+    for (unsigned Idx : m_Data->OutIndices)
+      TI.appendToLog(llvm::formatv("  std::vector<void*> _out{0};", Idx).str());
+
     std::string Call = llvm::formatv("  {0}Cpp::{1}({2}); // [{3} ns]", VarPart,
                                      m_Data->Name, m_Data->ArgStr, Dur);
 
     // Store in log for the reproducer file.
     TI.appendToLog(Call);
+
+    // After the call: register OUT-element handles and emit one
+    // `void* vN = _outN[i] : nullptr;` decl per newly-seen element so a
+    // later call referencing the registered name finds a real binding.
+    for (size_t i = 0; i < m_Data->OutCallbacks.size(); ++i)
+      m_Data->OutCallbacks[i](TI, m_Data->OutIndices[i]);
 
     // Per-element extractions for vector returns. Bounds-guard so the
     // line is safe even if the replay produces a shorter vector than

--- a/unittests/CppInterOp/TracingTests.cpp
+++ b/unittests/CppInterOp/TracingTests.cpp
@@ -168,11 +168,12 @@ TEST_F(TracingTest, TraceWithNoArgs) {
 }
 
 TEST_F(TracingTest, TraceWithOutParamArg) {
+  // OUT pointer-container: preamble decl + alias at the call site.
   std::vector<void*> v;
   WithOutParamTrace(v);
-  auto output = TraceInfo::TheTraceInfo->getLastLogEntry();
-  // OutParam should not appear in the arg list.
-  EXPECT_THAT(output, HasSubstr("Cpp::WithOutParamTrace();"));
+  auto output = getFullLog();
+  EXPECT_THAT(output, HasSubstr("std::vector<void*> _out0;"));
+  EXPECT_THAT(output, HasSubstr("Cpp::WithOutParamTrace(_out0);"));
   EXPECT_EQ(v.size(), 1u);
 }
 
@@ -320,15 +321,64 @@ TEST_F(TracingTest, ArgFormattingMixed) {
               HasSubstr("Cpp::FuncTakingMixed(v1, \"world\", 99)"));
 }
 
-TEST_F(TracingTest, ArgFormattingOutParamSkipped) {
-  // OutParam should not appear in the formatted args,
-  // but regular args before it should.
+TEST_F(TracingTest, ArgFormattingOutParamAliased) {
+  // OUT alias preserves left-to-right argument order: (v1, _out0).
   void* h = FuncReturningHandle();
   std::vector<void*> out;
   FuncWithHandleAndOut(h, out);
   auto output = getFullLog();
-  // Should show only the handle arg, not the OutParam.
-  EXPECT_THAT(output, HasSubstr("Cpp::FuncWithHandleAndOut(v1)"));
+  EXPECT_THAT(output, HasSubstr("std::vector<void*> _out0;"));
+  EXPECT_THAT(output, HasSubstr("Cpp::FuncWithHandleAndOut(v1, _out0);"));
+}
+
+void FuncWithTwoOuts(std::vector<void*>& a, std::vector<void*>& b) {
+  INTEROP_TRACE(INTEROP_OUT(a), INTEROP_OUT(b));
+  a.push_back((void*)0x11);
+  b.push_back((void*)0x22);
+  return INTEROP_VOID_RETURN();
+}
+
+TEST_F(TracingTest, ArgFormattingTwoOutParamsGetDistinctIndices) {
+  // Two OUTs on one call get distinct indices in arg order.
+  std::vector<void*> a, b;
+  FuncWithTwoOuts(a, b);
+  auto output = getFullLog();
+  EXPECT_THAT(output, HasSubstr("std::vector<void*> _out0;"));
+  EXPECT_THAT(output, HasSubstr("std::vector<void*> _out1;"));
+  EXPECT_THAT(output, HasSubstr("Cpp::FuncWithTwoOuts(_out0, _out1);"));
+}
+
+TEST_F(TracingTest, ArgFormattingOutParamIndicesAreMonotonic) {
+  // The counter is region-global, not per-call -- two calls each with
+  // one OUT do not collide on _out0 (C++ redefinition error). Reusing
+  // the same source vector across calls still yields a fresh _outN
+  // each time, since the reproducer's buffers are independent.
+  std::vector<void*> v;
+  WithOutParamTrace(v);
+  WithOutParamTrace(v);
+  auto output = getFullLog();
+  EXPECT_THAT(output, HasSubstr("Cpp::WithOutParamTrace(_out0);"));
+  EXPECT_THAT(output, HasSubstr("Cpp::WithOutParamTrace(_out1);"));
+}
+
+TEST_F(TracingTest, OutParamElementUsableInLaterCall) {
+  // The OUT-param element decl makes the handle bind in the
+  // reproducer: a downstream call that takes one of the elements as
+  // input renders to a name that's actually declared earlier.
+  void* h = FuncReturningHandle();
+  std::vector<void*> out;
+  FuncWithHandleAndOut(h, out);
+  ASSERT_FALSE(out.empty());
+  FuncTakingHandle(out[0]);
+  auto output = getFullLog();
+  // The element's decl reads `_out0[0]` and binds a handle name (vN);
+  // the downstream call references the same name.
+  TraceInfo& TI = *TraceInfo::TheTraceInfo;
+  std::string elem = TI.lookupHandle(out[0]);
+  ASSERT_FALSE(elem.empty());
+  EXPECT_THAT(output,
+              HasSubstr("void* " + elem + " = _out0.size() > 0 ? _out0[0]"));
+  EXPECT_THAT(output, HasSubstr("Cpp::FuncTakingHandle(" + elem + ")"));
 }
 
 // Test: when two functions return the same pointer, the second should not
@@ -790,14 +840,17 @@ void FillStrings(std::vector<std::string>& out) {
 }
 
 TEST_F(TracingTest, OutParamNonPointerElementType) {
+  // Non-pointer OUTs stay on the legacy skip path -- no `_outN`
+  // preamble is emitted and the call has zero args.
   std::vector<std::string> results;
   FillStrings(results);
-  auto output = TraceInfo::TheTraceInfo->getLastLogEntry();
+  auto output = getFullLog();
 
   EXPECT_EQ(results.size(), 2u);
   EXPECT_EQ(results[0], "hello");
   EXPECT_EQ(results[1], "world");
   EXPECT_THAT(output, HasSubstr("Cpp::FillStrings();"));
+  EXPECT_THAT(output, Not(HasSubstr("_out0")));
 }
 
 TEST_F(NoTracingTest, OutParamNonPointerDisabled) {
@@ -851,7 +904,9 @@ TEST_F(TracingTest, WriteToFileContainsOutParamCalls) {
   std::string content((std::istreambuf_iterator<char>(ifs)),
                       std::istreambuf_iterator<char>());
 
-  EXPECT_THAT(content, HasSubstr("Cpp::FillHandles();"));
+  // Persisted reproducer mirrors the in-memory log.
+  EXPECT_THAT(content, HasSubstr("std::vector<void*> _out0;"));
+  EXPECT_THAT(content, HasSubstr("Cpp::FillHandles(_out0);"));
 
   llvm::sys::fs::remove(Path);
 }


### PR DESCRIPTION
INTEROP_OUT-marked arguments were dropped from the formatted call line entirely. The reproducer doesn't have the buffer in scope, so "Cpp::FillHandles();" is ill-formed against the real signature "Cpp::FillHandles(std::vector<void*>&)" and the auto-generated reproducer fails to compile every time an OUT pointer-container appears.

Allocate a fresh "_outN" index per OUT pointer-container at captureArg time and emit two reproducer-side artefacts in ~TraceRegion: a "std::vector<void*> _outN;" preamble line before the call, and an alias to that buffer at the OUT argument's position in the call's argument list. The element type is hard-coded to void* because the public API erases pointer-element OUT containers to that type. Non-pointer OUT containers (e.g. vector<string>) keep the legacy skip rendering -- their type is not erasable to void*, so a generic preamble would not type-check; that case waits on type-name capture.

# Description

Please include a summary of changes, motivation and context for this PR.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [ ] I have read the contribution guide recently
