### PR TITLE
[Tracing] Format TemplateArgInfo as a brace-init constructor call. 

### DIFF
--- a/lib/CppInterOp/Tracing.h
+++ b/lib/CppInterOp/Tracing.h
@@ -23,6 +23,8 @@
 #define CPPINTEROP_TRACE_API
 #endif
 
+#include "CppInterOp/CppInterOpTypes.h"
+
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringMap.h"
@@ -338,6 +340,22 @@ struct ReproBuffer {
       First = false;
       append(E);
     }
+    OS << "}";
+  }
+
+  // TemplateArgInfo: brace-init through the (TCppScope_t, const char*)
+  // ctor so the reproducer compiles. m_Type takes the void* path
+  // (renders as vN); nullptr m_IntegralValue must render as `nullptr`
+  // (the ctor's default), not the empty string the const char* path
+  // would produce.
+  void append(const CppImpl::TemplateArgInfo& tai) {
+    OS << "Cpp::TemplateArgInfo{";
+    append(static_cast<const void*>(tai.m_Type));
+    OS << ", ";
+    if (tai.m_IntegralValue == nullptr)
+      OS << "nullptr";
+    else
+      appendRaw(tai.m_IntegralValue);
     OS << "}";
   }
 

--- a/unittests/CppInterOp/TracingTests.cpp
+++ b/unittests/CppInterOp/TracingTests.cpp
@@ -677,6 +677,35 @@ TEST_F(TracingTest, ArgFormattingConstVoidNullptr) {
   EXPECT_THAT(output, HasSubstr("Cpp::FuncTakingConstHandle(nullptr)"));
 }
 
+void FuncTakingTemplateArg(Cpp::TemplateArgInfo tai) {
+  INTEROP_TRACE(tai);
+  return INTEROP_VOID_RETURN();
+}
+
+TEST_F(TracingTest, ArgFormattingTemplateArgInfoTypeAndIntegralValue) {
+  // m_Type renders as the registered handle name; m_IntegralValue
+  // takes the raw-string path.
+  TraceInfo& TI = *TraceInfo::TheTraceInfo;
+  void* tp = reinterpret_cast<void*>(static_cast<uintptr_t>(0x12340000));
+  std::string h = TI.getOrRegisterHandle(tp);
+  Cpp::TemplateArgInfo tai{tp, "5"};
+  FuncTakingTemplateArg(tai);
+  auto output = TraceInfo::TheTraceInfo->getLastLogEntry();
+  EXPECT_THAT(output, HasSubstr("Cpp::FuncTakingTemplateArg(Cpp::"
+                                "TemplateArgInfo{" +
+                                h + ", \"5\"})"));
+}
+
+TEST_F(TracingTest, ArgFormattingTemplateArgInfoNullFields) {
+  // Null m_IntegralValue must round-trip to `nullptr` (the
+  // constructor's default), not the empty string `""`.
+  Cpp::TemplateArgInfo tai{nullptr, nullptr};
+  FuncTakingTemplateArg(tai);
+  auto output = TraceInfo::TheTraceInfo->getLastLogEntry();
+  EXPECT_THAT(output, HasSubstr("Cpp::FuncTakingTemplateArg(Cpp::"
+                                "TemplateArgInfo{nullptr, nullptr})"));
+}
+
 // ---------------------------------------------------------------------------
 // Tests: handle registry
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
The catch-all template renders any non-enum, non-pointer arg as `?`, which would silently swallow a TemplateArgInfo passed by value: the m_Type pointer disappears and a reproducer cannot bind the type back to its registered handle.

Add a ReproBuffer::append(const TemplateArgInfo&) overload that emits `Cpp::TemplateArgInfo{<m_Type>, <m_IntegralValue>}`. m_Type goes through the void* path so the registered name (vN) replaces the raw address; nullptr m_IntegralValue renders as the literal `nullptr` (the constructor's default) rather than the empty string the const char* path would otherwise produce. Tests pin both branches of the integral-value path and the registered-handle substitution for m_Type.

Depends on #978