### PR TITLE
[Tracing] Deprecate pointer/size InstantiateTemplate, add vector form.

### DIFF
--- a/include/CppInterOp/CppInterOpTypes.h
+++ b/include/CppInterOp/CppInterOpTypes.h
@@ -33,6 +33,17 @@
 #endif
 #endif
 
+// Cross-platform deprecation attribute. Older Clang versions (Cling)
+// mis-parse C++11 `[[deprecated]]` near the return type, so we use
+// the vendor-specific spelling on each compiler.
+#if defined(_MSC_VER)
+#define CPPINTEROP_DEPRECATED(msg) __declspec(deprecated(msg))
+#elif defined(__GNUC__) || defined(__clang__)
+#define CPPINTEROP_DEPRECATED(msg) __attribute__((deprecated(msg)))
+#else
+#define CPPINTEROP_DEPRECATED(msg)
+#endif
+
 namespace CppImpl {
 using TCppIndex_t = size_t;
 using TCppScope_t = void*;

--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -4464,6 +4464,18 @@ TCppScope_t InstantiateTemplate(TCppScope_t tmpl,
       getInterp(), tmpl, template_args, template_args_size, instantiate_body));
 }
 
+TCppScope_t
+InstantiateTemplate(TCppScope_t tmpl,
+                    const std::vector<TemplateArgInfo>& template_args,
+                    bool instantiate_body) {
+  INTEROP_TRACE(tmpl, template_args, instantiate_body);
+  // Forward to the static helper directly (not the deprecated public
+  // overload) to avoid a nested INTEROP_TRACE.
+  return INTEROP_RETURN(
+      InstantiateTemplate(getInterp(), tmpl, template_args.data(),
+                          template_args.size(), instantiate_body));
+}
+
 void GetClassTemplateInstantiationArgs(TCppScope_t templ_instance,
                                        std::vector<TemplateArgInfo>& args) {
   INTEROP_TRACE(templ_instance, INTEROP_OUT(args));

--- a/lib/CppInterOp/CppInterOp.td
+++ b/lib/CppInterOp/CppInterOp.td
@@ -451,6 +451,22 @@ variable templates
     Arg<"size_t", "template_args_size">,
     Arg<"bool", "instantiate_body", "false">
   ];
+  let Deprecated = "use the const std::vector<TemplateArgInfo>& overload";
+}
+
+def InstantiateTemplateVec : CppInterOpAPI {
+  let Doc = [{Convenience overload of \c InstantiateTemplate that takes the
+template argument list by const reference. Equivalent to calling the
+pointer+size overload with \c template_args.data() and
+\c template_args.size().}];
+
+  let CppName = "InstantiateTemplate";
+  let ReturnType = "TCppScope_t";
+  let Args = [
+    Arg<"TCppScope_t", "tmpl">,
+    Arg<"const std::vector<TemplateArgInfo>&", "template_args">,
+    Arg<"bool", "instantiate_body", "false">
+  ];
 }
 
 def GetParentScope : CppInterOpAPI {

--- a/lib/CppInterOp/CppInterOpAPI.td
+++ b/lib/CppInterOp/CppInterOpAPI.td
@@ -56,4 +56,6 @@ class CppInterOpAPI {
   APITypeKind ReturnKind = NoKind;
   // Doxygen documentation string (may contain newlines).
   string Doc = "";
+  // If non-empty, emit `[[deprecated(message)]]` on the declaration.
+  string Deprecated = "";
 }

--- a/lib/CppInterOp/CppInterOpDispatch.cpp
+++ b/lib/CppInterOp/CppInterOpDispatch.cpp
@@ -13,11 +13,25 @@ using namespace CppImpl;
 using CppFnPtrTy = void (*)();
 
 // NOLINTBEGIN(cppcoreguidelines-pro-type-cstyle-cast)
+// Suppress deprecation: the dispatch table intentionally exposes all
+// overloads, including those marked [[deprecated]] in the public API.
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#elif defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable : 4996)
+#endif
 static const std::unordered_map<std::string_view, CppFnPtrTy> DispatchMap = {
 #define CPPINTEROP_API_FUNC(DN, CN, Ret, DeclArgs, CallArgs, RawTypes)         \
   {#DN, (CppFnPtrTy) static_cast<Ret(*) RawTypes>(&CppImpl::CN)},
 #include "CppInterOp/CppInterOpAPI.inc"
 };
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic pop
+#elif defined(_MSC_VER)
+#pragma warning(pop)
+#endif
 // NOLINTEND(cppcoreguidelines-pro-type-cstyle-cast)
 
 extern "C" CPPINTEROP_API CppFnPtrTy CppGetProcAddress(const char* funcName) {

--- a/unittests/CppInterOp/FunctionReflectionTest.cpp
+++ b/unittests/CppInterOp/FunctionReflectionTest.cpp
@@ -490,7 +490,7 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_GetFunctionReturnType) {
 
   std::vector<Cpp::TemplateArgInfo> args2 = {C.DoubleTy.getAsOpaquePtr()};
   EXPECT_EQ(Cpp::GetTypeAsString(Cpp::GetFunctionReturnType(Cpp::GetNamed(
-                "func", Cpp::InstantiateTemplate(Decls[15], args2.data(), 1)))),
+                "func", Cpp::InstantiateTemplate(Decls[15], args2)))),
             "double");
 }
 
@@ -722,8 +722,7 @@ template<typename T> T TrivialFnTemplate() { return T(); }
   ASTContext& C = Interp->getCI()->getASTContext();
 
   std::vector<Cpp::TemplateArgInfo> args1 = {C.IntTy.getAsOpaquePtr()};
-  auto Instance1 = Cpp::InstantiateTemplate(Decls[0], args1.data(),
-                                            /*type_size*/ args1.size());
+  auto Instance1 = Cpp::InstantiateTemplate(Decls[0], args1);
   EXPECT_TRUE(isa<FunctionDecl>((Decl*)Instance1));
   FunctionDecl* FD = cast<FunctionDecl>((Decl*)Instance1);
   FunctionDecl* FnTD1 = FD->getTemplateInstantiationPattern();
@@ -750,8 +749,7 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_InstantiateTemplateMethod) {
   ASTContext& C = Interp->getCI()->getASTContext();
 
   std::vector<Cpp::TemplateArgInfo> args1 = {C.IntTy.getAsOpaquePtr()};
-  auto Instance1 = Cpp::InstantiateTemplate(Decls[1], args1.data(),
-                                            /*type_size*/ args1.size());
+  auto Instance1 = Cpp::InstantiateTemplate(Decls[1], args1);
   EXPECT_TRUE(isa<FunctionDecl>((Decl*)Instance1));
   FunctionDecl* FD = cast<FunctionDecl>((Decl*)Instance1);
   FunctionDecl* FnTD1 = FD->getTemplateInstantiationPattern();
@@ -928,8 +926,7 @@ TYPED_TEST(CPPINTEROP_TEST_MODE,
 
   std::vector<Cpp::TemplateArgInfo> args1 = {C.DoubleTy.getAsOpaquePtr(),
                                              C.IntTy.getAsOpaquePtr()};
-  auto Instance1 = Cpp::InstantiateTemplate(Decls[1], args1.data(),
-                                            /*type_size*/ args1.size());
+  auto Instance1 = Cpp::InstantiateTemplate(Decls[1], args1);
   EXPECT_TRUE(Cpp::IsTemplatedFunction(Instance1));
   EXPECT_EQ(Cpp::GetFunctionSignature(Instance1),
             "template<> void VariadicFn<<double, int>>(double args, int args)");
@@ -951,8 +948,7 @@ TYPED_TEST(CPPINTEROP_TEST_MODE,
                                              C.DoubleTy.getAsOpaquePtr()};
 
   // instantiate VariadicFnExtended
-  auto Instance2 =
-      Cpp::InstantiateTemplate(Decls[2], args2.data(), args2.size(), true);
+  auto Instance2 = Cpp::InstantiateTemplate(Decls[2], args2, true);
   EXPECT_TRUE(Cpp::IsTemplatedFunction(Instance2));
 
   FunctionDecl* FD2 = cast<FunctionDecl>((Decl*)Instance2);
@@ -1016,12 +1012,10 @@ TYPED_TEST(CPPINTEROP_TEST_MODE,
   fn = Cpp::BestOverloadFunctionMatch(candidates, explicit_args2, args0);
   EXPECT_EQ(fn, fn0);
 
-  fn = Cpp::InstantiateTemplate(Decls[0], explicit_args1.data(),
-                                explicit_args1.size());
+  fn = Cpp::InstantiateTemplate(Decls[0], explicit_args1);
   EXPECT_EQ(fn, fn0);
 
-  fn = Cpp::InstantiateTemplate(Decls[0], explicit_args2.data(),
-                                explicit_args2.size());
+  fn = Cpp::InstantiateTemplate(Decls[0], explicit_args2);
   EXPECT_EQ(fn, fn0);
 }
 
@@ -1351,8 +1345,7 @@ TYPED_TEST(CPPINTEROP_TEST_MODE,
       C.IntTy.getAsOpaquePtr(),
   };
 
-  Cpp::TCppScope_t callme = Cpp::InstantiateTemplate(
-      Decls[0], explicit_params.data(), explicit_params.size());
+  Cpp::TCppScope_t callme = Cpp::InstantiateTemplate(Decls[0], explicit_params);
   EXPECT_TRUE(callme);
 
   std::vector<Cpp::TemplateArgInfo> arg_types = {
@@ -1582,8 +1575,7 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_GetFunctionAddress) {
 
   ASTContext& C = Interp->getCI()->getASTContext();
   std::vector<Cpp::TemplateArgInfo> argument = {C.DoubleTy.getAsOpaquePtr()};
-  Cpp::TCppScope_t add1_double =
-      Cpp::InstantiateTemplate(funcs[0], argument.data(), argument.size());
+  Cpp::TCppScope_t add1_double = Cpp::InstantiateTemplate(funcs[0], argument);
   EXPECT_TRUE(add1_double);
 
   EXPECT_TRUE(Cpp::GetFunctionAddress(add1_double));
@@ -1880,8 +1872,7 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_GetFunctionCallWrapper) {
   ASTContext& C = Interp->getCI()->getASTContext();
 
   std::vector<Cpp::TemplateArgInfo> argument = {C.IntTy.getAsOpaquePtr()};
-  auto Instance1 = Cpp::InstantiateTemplate(Decls1[0], argument.data(),
-                                            /*type_size*/ argument.size());
+  auto Instance1 = Cpp::InstantiateTemplate(Decls1[0], argument);
   EXPECT_TRUE(isa<ClassTemplateSpecializationDecl>((Decl*)Instance1));
   auto* CTSD1 = static_cast<ClassTemplateSpecializationDecl*>(Instance1);
   auto* Add_D = Cpp::GetNamed("Add", CTSD1);
@@ -1962,7 +1953,7 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_GetFunctionCallWrapper) {
 
   Cpp::TCppScope_t op_templated = operators[0];
   auto TAI = Cpp::TemplateArgInfo(Cpp::GetType("int"));
-  Cpp::TCppScope_t op = Cpp::InstantiateTemplate(op_templated, &TAI, 1);
+  Cpp::TCppScope_t op = Cpp::InstantiateTemplate(op_templated, {TAI});
   auto FCI_op = Cpp::MakeFunctionCallable(op);
   bool boolean = false;
   FCI_op.Invoke((void*)&boolean, {args, /*args_size=*/1}, toperator);
@@ -2224,11 +2215,11 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_GetFunctionCallWrapper) {
   EXPECT_TRUE(KlassProduct);
 
   Cpp::TCppScope_t KlassProduct_int =
-      Cpp::InstantiateTemplate(KlassProduct, &TAI, 1);
+      Cpp::InstantiateTemplate(KlassProduct, {TAI});
   EXPECT_TRUE(KlassProduct_int);
   TAI = Cpp::TemplateArgInfo(Cpp::GetType("float"));
   Cpp::TCppScope_t KlassProduct_float =
-      Cpp::InstantiateTemplate(KlassProduct, &TAI, 1);
+      Cpp::InstantiateTemplate(KlassProduct, {TAI});
   EXPECT_TRUE(KlassProduct_float);
 
   operators.clear();
@@ -2260,7 +2251,7 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_GetFunctionCallWrapper) {
   auto TAI_enum =
       Cpp::TemplateArgInfo(Cpp::GetTypeFromScope(Cpp::GetNamed("MyEnum")), "1");
   Cpp::TCppScope_t TemplatedEnum_instantiated =
-      Cpp::InstantiateTemplate(TemplatedEnum, &TAI_enum, 1);
+      Cpp::InstantiateTemplate(TemplatedEnum, {TAI_enum});
   EXPECT_TRUE(TemplatedEnum_instantiated);
 
   Cpp::TCppObject_t obj = Cpp::Construct(TemplatedEnum_instantiated);
@@ -2276,7 +2267,7 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_GetFunctionCallWrapper) {
                                       "MyEnum", Cpp::GetScope("MyNameSpace"))),
                                   "1");
   Cpp::TCppScope_t MyNameSpace_TemplatedEnum_instantiated =
-      Cpp::InstantiateTemplate(MyNameSpace_TemplatedEnum, &TAI_enum, 1);
+      Cpp::InstantiateTemplate(MyNameSpace_TemplatedEnum, {TAI_enum});
   EXPECT_TRUE(TemplatedEnum_instantiated);
 
   obj = Cpp::Construct(MyNameSpace_TemplatedEnum_instantiated);
@@ -2406,9 +2397,9 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_GetFunctionArgDefault) {
   EXPECT_EQ(Cpp::GetFunctionArgDefault(Decls[4], 3), "0.");
 
   ASTContext& C = Interp->getCI()->getASTContext();
-  Cpp::TemplateArgInfo template_args[1] = {C.IntTy.getAsOpaquePtr()};
+  std::vector<Cpp::TemplateArgInfo> template_args = {C.IntTy.getAsOpaquePtr()};
   Cpp::TCppScope_t my_struct =
-      Cpp::InstantiateTemplate(Decls[6], &template_args[0], 1);
+      Cpp::InstantiateTemplate(Decls[6], template_args);
   EXPECT_TRUE(my_struct);
 
   std::vector<Cpp::TCppFunction_t> fns =
@@ -2875,8 +2866,8 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_FailingTest1) {
   Cpp::GetClassTemplatedMethods("is_equal", Cpp::GetGlobalScope(), fns);
   EXPECT_EQ(fns.size(), 1);
 
-  Cpp::TemplateArgInfo args[2] = {{o1}, {o2}};
-  Cpp::TCppScope_t fn = Cpp::InstantiateTemplate(fns[0], &args[0], 2);
+  std::vector<Cpp::TemplateArgInfo> args = {{o1}, {o2}};
+  Cpp::TCppScope_t fn = Cpp::InstantiateTemplate(fns[0], args);
   EXPECT_TRUE(fn);
 
   Cpp::JitCall jit_call = Cpp::MakeFunctionCallable(fn);

--- a/unittests/CppInterOp/ScopeReflectionTest.cpp
+++ b/unittests/CppInterOp/ScopeReflectionTest.cpp
@@ -509,9 +509,9 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, ScopeReflection_GetCompleteName) {
   EXPECT_EQ(Cpp::GetCompleteName(nullptr), "<unnamed>");
 
   ASTContext& C = Interp->getCI()->getASTContext();
-  Cpp::TemplateArgInfo template_args[2] = {C.IntTy.getAsOpaquePtr(),
-                                           C.DoubleTy.getAsOpaquePtr()};
-  Cpp::TCppScope_t fn = Cpp::InstantiateTemplate(Decls[11], template_args, 2);
+  std::vector<Cpp::TemplateArgInfo> template_args = {
+      C.IntTy.getAsOpaquePtr(), C.DoubleTy.getAsOpaquePtr()};
+  Cpp::TCppScope_t fn = Cpp::InstantiateTemplate(Decls[11], template_args);
   EXPECT_TRUE(fn);
   EXPECT_EQ(Cpp::GetCompleteName(fn), "fn<int, double>");
 }
@@ -1098,8 +1098,7 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, ScopeReflection_InstantiateNNTPClassTemplate) {
   ASTContext &C = Interp->getCI()->getASTContext();
   Cpp::TCppType_t IntTy = C.IntTy.getAsOpaquePtr();
   std::vector<Cpp::TemplateArgInfo> args1 = {{IntTy, "5"}};
-  EXPECT_TRUE(Cpp::InstantiateTemplate(Decls[0], args1.data(),
-                                       /*type_size*/ args1.size()));
+  EXPECT_TRUE(Cpp::InstantiateTemplate(Decls[0], args1));
 
   // C API
   auto* I = clang_createInterpreterFromRawPtr(Cpp::GetInterpreter());
@@ -1123,8 +1122,7 @@ template<class T> constexpr T pi = T(3.1415926535897932385L);
   ASTContext& C = Interp->getCI()->getASTContext();
 
   std::vector<Cpp::TemplateArgInfo> args1 = {C.IntTy.getAsOpaquePtr()};
-  auto* Instance1 = Cpp::InstantiateTemplate(Decls[0], args1.data(),
-                                             /*type_size*/ args1.size());
+  auto* Instance1 = Cpp::InstantiateTemplate(Decls[0], args1);
   EXPECT_TRUE(isa<VarDecl>(static_cast<Decl*>(Instance1)));
   auto* VD = cast<VarTemplateSpecializationDecl>(static_cast<Decl*>(Instance1));
   VarTemplateDecl* VDTD1 = VD->getSpecializedTemplate();
@@ -1143,8 +1141,7 @@ template<typename T> T TrivialFnTemplate() { return T(); }
   ASTContext& C = Interp->getCI()->getASTContext();
 
   std::vector<Cpp::TemplateArgInfo> args1 = {C.IntTy.getAsOpaquePtr()};
-  auto* Instance1 = Cpp::InstantiateTemplate(Decls[0], args1.data(),
-                                             /*type_size*/ args1.size());
+  auto* Instance1 = Cpp::InstantiateTemplate(Decls[0], args1);
   EXPECT_TRUE(isa<FunctionDecl>(static_cast<Decl*>(Instance1)));
   FunctionDecl* FD = cast<FunctionDecl>(static_cast<Decl*>(Instance1));
   FunctionDecl* FnTD1 = FD->getTemplateInstantiationPattern();
@@ -1209,8 +1206,7 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, ScopeReflection_InstantiateTemplate) {
   ASTContext &C = Interp->getCI()->getASTContext();
 
   std::vector<Cpp::TemplateArgInfo> args1 = {C.IntTy.getAsOpaquePtr()};
-  auto* Instance1 = Cpp::InstantiateTemplate(Decls[0], args1.data(),
-                                             /*type_size*/ args1.size());
+  auto* Instance1 = Cpp::InstantiateTemplate(Decls[0], args1);
   EXPECT_TRUE(
       isa<ClassTemplateSpecializationDecl>(static_cast<Decl*>(Instance1)));
   auto *CTSD1 = static_cast<ClassTemplateSpecializationDecl*>(Instance1);
@@ -1219,8 +1215,7 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, ScopeReflection_InstantiateTemplate) {
   EXPECT_TRUE(TA1.getAsType()->isIntegerType());
   EXPECT_TRUE(CTSD1->hasDefinition());
 
-  auto Instance2 = Cpp::InstantiateTemplate(Decls[1], nullptr,
-                                            /*type_size*/ 0);
+  auto Instance2 = Cpp::InstantiateTemplate(Decls[1], {});
   EXPECT_TRUE(
       isa<ClassTemplateSpecializationDecl>(static_cast<Decl*>(Instance2)));
   auto *CTSD2 = static_cast<ClassTemplateSpecializationDecl*>(Instance2);
@@ -1229,8 +1224,7 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, ScopeReflection_InstantiateTemplate) {
   EXPECT_TRUE(TA2.getAsType()->isIntegerType());
 
   std::vector<Cpp::TemplateArgInfo> args3 = {C.IntTy.getAsOpaquePtr()};
-  auto* Instance3 = Cpp::InstantiateTemplate(Decls[2], args3.data(),
-                                             /*type_size*/ args3.size());
+  auto* Instance3 = Cpp::InstantiateTemplate(Decls[2], args3);
   EXPECT_TRUE(
       isa<ClassTemplateSpecializationDecl>(static_cast<Decl*>(Instance3)));
   auto *CTSD3 = static_cast<ClassTemplateSpecializationDecl*>(Instance3);
@@ -1247,8 +1241,7 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, ScopeReflection_InstantiateTemplate) {
 
   std::vector<Cpp::TemplateArgInfo> args4 = {C.IntTy.getAsOpaquePtr(),
                                                {C.IntTy.getAsOpaquePtr(), "3"}};
-  auto* Instance4 = Cpp::InstantiateTemplate(Decls[3], args4.data(),
-                                             /*type_size*/ args4.size());
+  auto* Instance4 = Cpp::InstantiateTemplate(Decls[3], args4);
 
   EXPECT_TRUE(
       isa<ClassTemplateSpecializationDecl>(static_cast<Decl*>(Instance4)));

--- a/unittests/CppInterOp/VariableReflectionTest.cpp
+++ b/unittests/CppInterOp/VariableReflectionTest.cpp
@@ -331,8 +331,8 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, VariableReflection_GetVariableOffset) {
   ASTContext& C = Interp->getCI()->getASTContext();
   std::vector<Cpp::TemplateArgInfo> template_args = {
       {C.IntTy.getAsOpaquePtr()}};
-  Cpp::TCppScope_t klass_instantiated = Cpp::InstantiateTemplate(
-      klass, template_args.data(), template_args.size());
+  Cpp::TCppScope_t klass_instantiated =
+      Cpp::InstantiateTemplate(klass, template_args);
   EXPECT_TRUE(klass_instantiated);
 
   Cpp::TCppScope_t var = Cpp::GetNamed("ref_value", klass_instantiated);
@@ -598,9 +598,8 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, VariableReflection_StaticConstExprDatamember) {
   std::vector<Cpp::TemplateArgInfo> template_args = {
       {C.IntTy.getAsOpaquePtr(), "5"}};
 
-  Cpp::TCppFunction_t MyTemplatedClass =
-      Cpp::InstantiateTemplate(Cpp::GetNamed("MyTemplatedClass"),
-                               template_args.data(), template_args.size());
+  Cpp::TCppFunction_t MyTemplatedClass = Cpp::InstantiateTemplate(
+      Cpp::GetNamed("MyTemplatedClass"), template_args);
   EXPECT_TRUE(MyTemplatedClass);
 
   datamembers.clear();
@@ -613,9 +612,8 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, VariableReflection_StaticConstExprDatamember) {
   std::vector<Cpp::TemplateArgInfo> ele_template_args = {
       {C.IntTy.getAsOpaquePtr()}, {C.FloatTy.getAsOpaquePtr()}};
 
-  Cpp::TCppFunction_t Elements = Cpp::InstantiateTemplate(
-      Cpp::GetNamed("Elements"), ele_template_args.data(),
-      ele_template_args.size());
+  Cpp::TCppFunction_t Elements =
+      Cpp::InstantiateTemplate(Cpp::GetNamed("Elements"), ele_template_args);
   EXPECT_TRUE(Elements);
 
   EXPECT_EQ(1, Cpp::GetNumBases(Elements));

--- a/utils/TableGen/CppInterOpEmitter.cpp
+++ b/utils/TableGen/CppInterOpEmitter.cpp
@@ -47,6 +47,7 @@ struct APIRecord {
   StringRef DispatchName;
   StringRef ReturnType;
   StringRef Doc;
+  StringRef Deprecated;
   std::vector<ArgInfo> Args;
 };
 
@@ -59,6 +60,7 @@ std::vector<APIRecord> collectAPIs(const RecordKeeper& Records) {
     R.DispatchName = Rec->getValueAsString("DispatchName");
     R.ReturnType = Rec->getValueAsString("ReturnType");
     R.Doc = Rec->getValueAsString("Doc");
+    R.Deprecated = Rec->getValueAsString("Deprecated");
     for (const auto* ArgRec : Rec->getValueAsListOfDefs("Args")) {
       ArgInfo A;
       A.Type = ArgRec->getValueAsString("Type");
@@ -143,8 +145,13 @@ void EmitCppInterOpDecl(const RecordKeeper& Records, raw_ostream& OS) {
       }
     }
 
-    // Emit the declaration.
-    OS << "CPPINTEROP_API " << R.ReturnType << " " << R.CppName << "(";
+    // Emit the declaration. CPPINTEROP_DEPRECATED expands to the
+    // vendor-specific deprecation attribute -- older Clang (Cling)
+    // mis-parses C++11 [[deprecated]] near the return type.
+    OS << "CPPINTEROP_API ";
+    if (!R.Deprecated.empty())
+      OS << "CPPINTEROP_DEPRECATED(\"" << R.Deprecated << "\") ";
+    OS << R.ReturnType << " " << R.CppName << "(";
     for (size_t I = 0; I < R.Args.size(); ++I) {
       if (I)
         OS << ", ";


### PR DESCRIPTION
The pointer+size InstantiateTemplate API forces every caller to spell two arguments and lose ownership semantics, and the trace records only an opaque pointer to the template-argument array -- the reproducer cannot reconstruct the call.

Add an overload that takes the template arguments by const std::vector<TemplateArgInfo>& and forwards directly to the static helper (so the trace records one call, not nested ones); mark the old overload deprecated with a vendor-portable CPPINTEROP_DEPRECATED macro that older Clang versions (Cling) parse correctly. The TableGen schema gains a Deprecated field consumed by the Decl emitter; the dispatch table suppresses the warning at the cast site since it intentionally exposes every overload. All in-tree callers (31 sites across the C API and unit tests) migrate to the vector form.

Depends on #979 