### PR TITLE
[Tracing] Suppress log emission for nested INTEROP_TRACE calls.

### DIFF
--- a/lib/CppInterOp/Tracing.h
+++ b/lib/CppInterOp/Tracing.h
@@ -85,6 +85,9 @@ public:
     return *T;
   }
 
+  /// True when at least one TraceRegion is currently active.
+  bool insideTracedRegion() const { return !m_TimerStack.empty(); }
+
   void pushTimer(llvm::Timer* T) {
     if (!m_TimerStack.empty())
       m_TimerStack.back()->stopTimer();
@@ -468,6 +471,9 @@ struct TraceData {
   /// container (preamble decl needed), false on later calls reusing
   /// the same slot.
   llvm::SmallVector<bool, 2> OutFirstUse;
+  /// Set when another TraceRegion was already active at construction.
+  /// Nested calls skip log emission but still register handles.
+  bool Nested = false;
 };
 
 class TraceRegion {
@@ -475,10 +481,11 @@ class TraceRegion {
 
   /// Resolve the OUT pointer-container's `_outN` index up-front so
   /// format() can render the call site's alias and the dtor knows
-  /// whether to emit the preamble decl (only for the first use of a
-  /// given source container; later calls reuse the same slot).
+  /// whether to emit the preamble decl (only on first use of a given
+  /// source container). Skipped for nested calls (no emission); the
+  /// handle callback still queues so the outer call can resolve names.
   void captureArg(OutParam&& op) {
-    if (op.IsPointerContainer) {
+    if (!m_Data->Nested && op.IsPointerContainer) {
       auto [idx, firstUse] =
           TraceInfo::TheTraceInfo->outIndexFor(op.SourceAddr);
       m_Data->OutIndices.push_back(idx);
@@ -495,15 +502,19 @@ public:
       return;
     m_Data = std::make_unique<TraceData>();
     m_Data->Name = Name;
+    TraceInfo& TI = *TraceInfo::TheTraceInfo;
+    // Detect nesting before pushing this call's frame.
+    m_Data->Nested = TI.insideTracedRegion();
     // captureArg before format(): it fills OutIndices that format()
     // consumes.
     (captureArg(std::forward<Args>(args)), ...);
-    if constexpr (sizeof...(args) > 0) {
-      ReproBuffer RB;
-      RB.format(m_Data->OutIndices, std::forward<Args>(args)...);
-      m_Data->ArgStr = RB.Buffer;
+    if (!m_Data->Nested) {
+      if constexpr (sizeof...(args) > 0) {
+        ReproBuffer RB;
+        RB.format(m_Data->OutIndices, std::forward<Args>(args)...);
+        m_Data->ArgStr = RB.Buffer;
+      }
     }
-    TraceInfo& TI = *TraceInfo::TheTraceInfo;
     TI.pushTimer(&TI.getTimer(Name));
     m_Data->StartTime = llvm::TimeRecord::getCurrentTime(false).getWallTime();
   }
@@ -524,6 +535,13 @@ public:
     auto Dur = static_cast<long long>((EndTime - m_Data->StartTime) * 1e9);
     TraceInfo& TI = *TraceInfo::TheTraceInfo;
     TI.popTimer();
+
+    // Nested calls don't reach the log -- their args reference
+    // outer-scope locals the reproducer doesn't have.
+    if (m_Data->Nested) {
+      m_Data.reset();
+      return;
+    }
 
     // Allocate a `_retN` slot up-front for vector-of-pointer returns so
     // the call line spells `auto _retN = ...` and the per-element decls

--- a/unittests/CppInterOp/TracingTests.cpp
+++ b/unittests/CppInterOp/TracingTests.cpp
@@ -840,6 +840,56 @@ TEST_F(TracingTest, ChainedReproducerLogic) {
 }
 
 // ---------------------------------------------------------------------------
+// Tests: nested-call suppression
+// ---------------------------------------------------------------------------
+
+void* NestedInnerReturn() {
+  INTEROP_TRACE();
+  return INTEROP_RETURN((void*)0x2000);
+}
+
+void* NestedOuterReturn() {
+  INTEROP_TRACE();
+  return INTEROP_RETURN(NestedInnerReturn());
+}
+
+TEST_F(TracingTest, NestedCallSuppressedButHandleRegistered) {
+  // The inner call doesn't appear in the log, yet its handle is
+  // registered so the outer call's `auto vN = ...` line binds the
+  // pointer the inner produced.
+  void* h = NestedOuterReturn();
+  TraceInfo& TI = *TraceInfo::TheTraceInfo;
+  EXPECT_FALSE(TI.lookupHandle(h).empty());
+  auto output = getFullLog();
+  EXPECT_THAT(output, HasSubstr("auto v1 = Cpp::NestedOuterReturn()"));
+  EXPECT_THAT(output, Not(HasSubstr("Cpp::NestedInnerReturn")));
+}
+
+void NestedInnerNoOp() {
+  INTEROP_TRACE();
+  return INTEROP_VOID_RETURN();
+}
+
+void NestedOuterWithOut(std::vector<void*>& out) {
+  INTEROP_TRACE(INTEROP_OUT(out));
+  NestedInnerNoOp();
+  out.push_back((void*)0x3000);
+  return INTEROP_VOID_RETURN();
+}
+
+TEST_F(TracingTest, NestedSuppressionDoesNotLeakOutCounter) {
+  // captureArg must not bump m_OutCount for nested OUT-params --
+  // otherwise the outer call would emit `_out1` while the inner
+  // claimed `_out0` silently.
+  std::vector<void*> v;
+  NestedOuterWithOut(v);
+  auto output = getFullLog();
+  EXPECT_THAT(output, HasSubstr("std::vector<void*> _out0;"));
+  EXPECT_THAT(output, HasSubstr("Cpp::NestedOuterWithOut(_out0);"));
+  EXPECT_THAT(output, Not(HasSubstr("_out1")));
+}
+
+// ---------------------------------------------------------------------------
 // Tests: out-parameters
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
When a Cpp:: function internally calls another Cpp:: function, both TraceRegions append a call line. The inner line references its caller's parameters and locals, which the reproducer doesn't have in scope -- so the auto-generated reproducer fails to compile every time a public API is layered on another.

Detect nesting at TraceRegion construction by reading the timer stack before pushing the new frame, store the result on TraceData, and gate emission on it: nested calls skip the call line, the `_outN` preamble, the `_retN` decls, and the `_outN` index allocation (so the counter stays dense). Handle-registration callbacks still run for nested frames so the outer call's `auto vN = ...` line can resolve a pointer an inner OUT-param fills.

Depends on #980