### PR TITLE
Report parse errors via rc, not just diagnostics in Declare.

### DIFF
--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -4189,17 +4189,22 @@ protected:
 } // namespace
 
 int Declare(compat::Interpreter& I, const char* code, bool silent) {
+  // Trap diagnostics on both paths: I.declare's rc is 0 even when
+  // Parse recovered from emitted errors, so callers need the trap to
+  // distinguish "parsed cleanly" from "parsed with errors".
+  clang::DiagnosticsEngine& Diag = I.getSema().getDiagnostics();
+  clang::DiagnosticErrorTrap Trap(Diag);
   if (silent) {
-    clang::DiagnosticsEngine& Diag = I.getSema().getDiagnostics();
     clangSilent diagSuppr(Diag);
-    clang::DiagnosticErrorTrap Trap(Diag);
     auto result = I.declare(code);
     if (Trap.hasErrorOccurred())
       return 1;
     return result;
   }
-
-  return I.declare(code);
+  auto result = I.declare(code);
+  if (Trap.hasErrorOccurred())
+    return 1;
+  return result;
 }
 
 int Declare(const char* code, bool silent) {

--- a/unittests/CppInterOp/InterpreterTest.cpp
+++ b/unittests/CppInterOp/InterpreterTest.cpp
@@ -190,6 +190,31 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, Interpreter_DeclareSilent) {
   EXPECT_EQ(0, Cpp::Declare("int y = 123;", /*silent=*/false));
 }
 
+TYPED_TEST(CPPINTEROP_TEST_MODE, Interpreter_DeclareReportsParseErrors) {
+#ifdef _WIN32
+  // The non-silent parse-error case emits an `error: expected expression`
+  // diagnostic to stderr, which MSBuild's check-cppinterop custom-build
+  // rule scans and treats as a build failure regardless of the gtest
+  // result.
+  GTEST_SKIP()
+      << "non-silent diagnostic trips MSBuild error scanning on Windows";
+#endif
+#if CLANG_VERSION_MAJOR > 21
+  GTEST_SKIP() << "Test crashes gtest for llvm 22 based build";
+#endif
+  TestFixture::CreateInterpreter();
+
+  // Valid input still returns 0.
+  EXPECT_EQ(0, Cpp::Declare("int z = 7;", /*silent=*/false));
+
+  // Parse error -> rc != 0 (Parse-recovered case the trap catches).
+  EXPECT_NE(0, Cpp::Declare("int err = ;", /*silent=*/false));
+
+  // Warning-only diagnostics must not trip the trap.
+  EXPECT_EQ(0, Cpp::Declare("int __attribute__((deprecated)) v = 0;",
+                            /*silent=*/false));
+}
+
 TYPED_TEST(CPPINTEROP_TEST_MODE, Interpreter_EmscriptenExceptionHandling) {
 #ifndef EMSCRIPTEN
   GTEST_SKIP() << "This test is intended to check exception handling for Emscripten builds.";


### PR DESCRIPTION
Cpp::Declare(silent=false) returned compat::Interpreter::declare's rc directly, but clang's IncrementalParser can return a valid PartialTranslationUnit even when individual diagnostics fired and Parse recovered. The wrapper's `process` then returns kSuccess, Cpp::Declare propagates 0, and callers that branch on the rc mistake "parsed with errors, recovered" for "declaration landed". cppyy-backend's AppendTypesSlow trampoline hits this for non-type bool template args (libstdc++'s `_Rb_tree_iterator<_Tp, false, false>`), follows the success branch, and never reaches its per-chunk fallback -- iteration over `std::map<int, int>` collapses to ints (test_stltypes test01 `cannot unpack non-iterable int object`).

Wrap I.declare with clang::DiagnosticErrorTrap on both paths; return 1 when the trap caught an emitted error. The silent path already used Trap; non-silent now matches. Trap watches for Error-class diagnostics only, so warnings keep their original rc. Test Interpreter_DeclareReportsParseErrors pins the three cases: valid, parse error, warning-only. The companion FIXME in cppyy-backend's clingwrapper.cxx ("We cannot use silent because it erases our error code from Declare!") becomes obsolete once this lands.

# Description

Please include a summary of changes, motivation and context for this PR.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [ ] I have read the contribution guide recently
