### PR TITLE
 [Tracing] Emit a ctor-side placeholder so aborted calls survive in the trace.

### DIFF
--- a/lib/CppInterOp/Tracing.h
+++ b/lib/CppInterOp/Tracing.h
@@ -145,11 +145,16 @@ public:
     return {idx, true};
   }
 
-  void appendToLog(const std::string& line) {
+  /// Append a line; the returned index pairs with setLogEntry to
+  /// rewrite the same slot later (TraceRegion's placeholder pattern).
+  size_t appendToLog(const std::string& line) {
+    size_t idx = m_Log.size();
     m_Log.push_back(line);
     if (m_InRegion && m_WriteOnStdErr)
       llvm::errs() << line << "\n";
+    return idx;
   }
+  void setLogEntry(size_t idx, const std::string& line) { m_Log[idx] = line; }
   const std::vector<std::string>& getLog() const { return m_Log; }
   std::string getLastLogEntry() const {
     return m_Log.empty() ? "" : m_Log.back();
@@ -474,6 +479,8 @@ struct TraceData {
   /// Set when another TraceRegion was already active at construction.
   /// Nested calls skip log emission but still register handles.
   bool Nested = false;
+  /// Slot for the ctor-emitted placeholder; the dtor rewrites it.
+  size_t LogIndex = 0;
 };
 
 class TraceRegion {
@@ -514,6 +521,19 @@ public:
         RB.format(m_Data->OutIndices, std::forward<Args>(args)...);
         m_Data->ArgStr = RB.Buffer;
       }
+      // `_outN` preamble + placeholder so an abort before the dtor
+      // still leaves a record of the failing call. Emit the preamble
+      // only on first use of each source container; reused ones alias
+      // the existing slot.
+      for (size_t i = 0; i < m_Data->OutIndices.size(); ++i)
+        if (m_Data->OutFirstUse[i])
+          TI.appendToLog(llvm::formatv("  std::vector<void*> _out{0};",
+                                       m_Data->OutIndices[i])
+                             .str());
+      m_Data->LogIndex = TI.appendToLog(
+          llvm::formatv("  Cpp::{0}({1}); // [aborted before return]",
+                        m_Data->Name, m_Data->ArgStr)
+              .str());
     }
     TI.pushTimer(&TI.getTimer(Name));
     m_Data->StartTime = llvm::TimeRecord::getCurrentTime(false).getWallTime();
@@ -574,21 +594,10 @@ public:
       VarPart = llvm::formatv("auto _ret{0} = ", RetIdx).str();
     }
 
-    // Preamble: declare a fresh buffer for first-use OUT containers.
-    // Reused containers (same source address) skip the decl and just
-    // alias the existing `_outN`. void* element type matches the
-    // public API's erasure of TCpp*Scope_t et al.
-    for (size_t i = 0; i < m_Data->OutIndices.size(); ++i)
-      if (m_Data->OutFirstUse[i])
-        TI.appendToLog(llvm::formatv("  std::vector<void*> _out{0};",
-                                     m_Data->OutIndices[i])
-                           .str());
-
+    // Rewrite the placeholder with the completed call line.
     std::string Call = llvm::formatv("  {0}Cpp::{1}({2}); // [{3} ns]", VarPart,
                                      m_Data->Name, m_Data->ArgStr, Dur);
-
-    // Store in log for the reproducer file.
-    TI.appendToLog(Call);
+    TI.setLogEntry(m_Data->LogIndex, Call);
 
     // After the call: register OUT-element handles and emit one
     // `void* vN = _outN[i] : nullptr;` decl per newly-seen element so a

--- a/unittests/CppInterOp/TracingTests.cpp
+++ b/unittests/CppInterOp/TracingTests.cpp
@@ -890,6 +890,32 @@ TEST_F(TracingTest, NestedSuppressionDoesNotLeakOutCounter) {
 }
 
 // ---------------------------------------------------------------------------
+// Tests: ctor-side placeholder for aborted calls
+// ---------------------------------------------------------------------------
+
+void PlaceholderProbe() {
+  INTEROP_TRACE();
+  // Mid-call: the ctor-emitted placeholder is already in the log.
+  auto& log = TraceInfo::TheTraceInfo->getLog();
+  ASSERT_FALSE(log.empty());
+  EXPECT_THAT(log.back(), HasSubstr("Cpp::PlaceholderProbe"));
+  EXPECT_THAT(log.back(), HasSubstr("[aborted before return]"));
+  return INTEROP_VOID_RETURN();
+}
+
+TEST_F(TracingTest, PlaceholderInCtorReplacedByDtor) {
+  // Mid-call assertions live inside PlaceholderProbe; here we only
+  // verify the replacement: after the call returns, the slot reads
+  // the completed `// [N ns]` line, not the placeholder.
+  PlaceholderProbe();
+  auto& log = TraceInfo::TheTraceInfo->getLog();
+  ASSERT_FALSE(log.empty());
+  EXPECT_THAT(log.back(), Not(HasSubstr("aborted before return")));
+  EXPECT_THAT(log.back(),
+              ::testing::MatchesRegex(R"(.*Cpp::PlaceholderProbe.*ns\].*)"));
+}
+
+// ---------------------------------------------------------------------------
 // Tests: out-parameters
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
A `Cpp::` call that aborts before returning -- assert fired, signal raised, exception escaped -- never reaches `~TraceRegion`, so its log line is never emitted. The reproducer is silent on exactly the call that failed.

Append a placeholder line at TraceRegion construction (`Cpp::Foo(args); // [aborted before return]`), record its log index, and have the dtor rewrite that slot with the completed `// [N ns]` line on a normal return. The `_outN` preamble moves to ctor-time so it precedes the placeholder. If the dtor never runs the placeholder remains. `appendToLog` now returns the new index and `setLogEntry` does the in-place rewrite.

Depends on #982.