### PR TITLE
[clang-repl] Mangle absolute-symbol names per the target DataLayout.

### DIFF
--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -3851,11 +3851,9 @@ bool DefineAbsoluteSymbol(compat::Interpreter& I, const char* unmangled_name,
 
   // mangleAndIntern applies the target DataLayout's symbol prefix
   // (leading `_` on Mach-O, no-op on ELF) so the registered key
-  // matches what the JIT computes when it lowers an IR-level symbol
+  // matches what the JIT computes when it lowers an IR symbol
   // reference for lookup. Plain ES.intern() bypasses the prefix and
-  // silently breaks lookup on Mach-O — e.g.
-  // `__clang_Interpreter_SetValueNoAlloc` registered, but the JIT
-  // looks up `___clang_Interpreter_SetValueNoAlloc`.
+  // silently breaks lookup on Mach-O.
   llvm::orc::SymbolMap InjectedSymbols{
       {Jit.mangleAndIntern(unmangled_name),
        ExecutorSymbolDef(ExecutorAddr(address), JITSymbolFlags::Exported)}};

--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -3841,17 +3841,23 @@ CPPINTEROP_API JitCall MakeFunctionCallable(TCppConstFunction_t func) {
 
 namespace {
 #if !defined(CPPINTEROP_USE_CLING) && !defined(EMSCRIPTEN)
-bool DefineAbsoluteSymbol(compat::Interpreter& I,
-                          const char* linker_mangled_name, uint64_t address) {
+bool DefineAbsoluteSymbol(compat::Interpreter& I, const char* unmangled_name,
+                          uint64_t address) {
   using namespace llvm;
   using namespace llvm::orc;
 
   llvm::orc::LLJIT& Jit = *compat::getExecutionEngine(I);
-  llvm::orc::ExecutionSession& ES = Jit.getExecutionSession();
   JITDylib& DyLib = *Jit.getProcessSymbolsJITDylib().get();
 
+  // mangleAndIntern applies the target DataLayout's symbol prefix
+  // (leading `_` on Mach-O, no-op on ELF) so the registered key
+  // matches what the JIT computes when it lowers an IR-level symbol
+  // reference for lookup. Plain ES.intern() bypasses the prefix and
+  // silently breaks lookup on Mach-O — e.g.
+  // `__clang_Interpreter_SetValueNoAlloc` registered, but the JIT
+  // looks up `___clang_Interpreter_SetValueNoAlloc`.
   llvm::orc::SymbolMap InjectedSymbols{
-      {ES.intern(linker_mangled_name),
+      {Jit.mangleAndIntern(unmangled_name),
        ExecutorSymbolDef(ExecutorAddr(address), JITSymbolFlags::Exported)}};
 
   if (Error Err = DyLib.define(absoluteSymbols(InjectedSymbols))) {


### PR DESCRIPTION
DefineAbsoluteSymbol registered runtime helpers
(__clang_Interpreter_SetValueNoAlloc, __ci_newtag, ...) via plain ExecutionSession::intern, which bypasses the target's symbol-name prefix. On Mach-O the JIT lowers an IR reference for __clang_Interpreter_SetValueNoAlloc to a lookup for ___clang_Interpreter_SetValueNoAlloc (extra leading underscore from the DataLayout mangle); the registered key stays unprefixed, lookup misses, and any clang::Interpreter path that returns a non-void value silently breaks (cppyy.evaluate, cppyy/test/support.py:69's IS_CLANG_REPL probe). ELF adds no prefix so the bug is invisible on Linux.

Switch to LLJIT::mangleAndIntern, which routes the name through the DataLayout's NamePrefix before interning. Registered key now matches what the JIT computes for an IR-level reference: no-op on ELF, restores correct behaviour on Mach-O.

# Description

Please include a summary of changes, motivation and context for this PR.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [ ] I have read the contribution guide recently
