### PR TITLE
Filter GetBuildInfo's cache dump to user-passed -D flags.

### DIFF
--- a/lib/CppInterOp/BuildInfo.inc.in
+++ b/lib/CppInterOp/BuildInfo.inc.in
@@ -9,5 +9,5 @@ R"BUILDINFO(  build type:    @CMAKE_BUILD_TYPE@
   llvm:          @LLVM_PACKAGE_VERSION@
   sanitizer:     @LLVM_USE_SANITIZER@
   target:        @CMAKE_SYSTEM_NAME@ @CMAKE_SYSTEM_PROCESSOR@
-  cmake-cache:  @CPPINTEROP_CMAKE_CONFIGURE_FLAGS@
+  cmake-line:    @CPPINTEROP_CMAKE_INVOCATION@
 )BUILDINFO"

--- a/lib/CppInterOp/CMakeLists.txt
+++ b/lib/CppInterOp/CMakeLists.txt
@@ -155,20 +155,29 @@ else()
     "cppinterop-tblgen binary when cross-compiling.")
 endif()
 
-# Capture the relevant subset of CMake cache vars that the user passed at
-# configure time, so Cpp::GetBuildInfo() can return a self-contained
-# reproducer-friendly snapshot. We filter to LLVM_*, CPPINTEROP_* plus
-# the CMAKE_* names listed below; the rest is noise for a bug report.
+# Filter cache entries to those CMake marks with HELPSTRING="No help,
+# variable specified on the command line." -- the property is left on
+# -D vars the project never reclaimed via set(... CACHE), so what
+# survives is the user's extra args.
+# See https://gitlab.kitware.com/cmake/cmake/-/work_items/19622
 get_cmake_property(_cppinterop_cache_vars CACHE_VARIABLES)
-set(_cppinterop_keep_cmake_vars
-    CMAKE_BUILD_TYPE CMAKE_CXX_STANDARD CMAKE_PREFIX_PATH)
-set(CPPINTEROP_CMAKE_CONFIGURE_FLAGS "")
+set(CPPINTEROP_CMAKE_INVOCATION "")
 foreach(_v ${_cppinterop_cache_vars})
-  if(_v MATCHES "^(LLVM_|CPPINTEROP_)"
-     OR _v IN_LIST _cppinterop_keep_cmake_vars)
-    string(APPEND CPPINTEROP_CMAKE_CONFIGURE_FLAGS " -D${_v}=${${_v}}")
+  get_property(_help CACHE ${_v} PROPERTY HELPSTRING)
+  if(NOT _help STREQUAL
+     "No help, variable specified on the command line.")
+    continue()
   endif()
+  get_property(_type CACHE ${_v} PROPERTY TYPE)
+  if(_type STREQUAL "UNINITIALIZED")
+    set(_type "")
+  else()
+    set(_type ":${_type}")
+  endif()
+  string(APPEND CPPINTEROP_CMAKE_INVOCATION
+         " -D${_v}${_type}=\"${${_v}}\"")
 endforeach()
+string(STRIP "${CPPINTEROP_CMAKE_INVOCATION}" CPPINTEROP_CMAKE_INVOCATION)
 configure_file(BuildInfo.inc.in
                ${CPPINTEROP_GEN_DIR}/BuildInfo.inc
                @ONLY)

--- a/unittests/CppInterOp/InterpreterTest.cpp
+++ b/unittests/CppInterOp/InterpreterTest.cpp
@@ -35,17 +35,14 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, Interpreter_Version) {
 }
 
 TYPED_TEST(CPPINTEROP_TEST_MODE, Interpreter_BuildInfo) {
+  // Pin the headline labels so a future template edit cannot silently
+  // drop a field.
   std::string Info = Cpp::GetBuildInfo();
-  // Headline labels survived configure_file substitution -- a refactor
-  // that strips a field from the template gets caught here.
   EXPECT_THAT(Info, ::testing::HasSubstr("build type:"));
   EXPECT_THAT(Info, ::testing::HasSubstr("compiler:"));
   EXPECT_THAT(Info, ::testing::HasSubstr("llvm:"));
   EXPECT_THAT(Info, ::testing::HasSubstr("target:"));
-  EXPECT_THAT(Info, ::testing::HasSubstr("cmake-cache:"));
-  // The configure-time foreach captured at least one kept var with its -D
-  // prefix; a regression that turned the loop into a no-op would drop this.
-  EXPECT_THAT(Info, ::testing::HasSubstr("-DCMAKE_BUILD_TYPE="));
+  EXPECT_THAT(Info, ::testing::HasSubstr("cmake-line:"));
 }
 
 #ifndef LLVM_ENABLE_ASSERTIONS


### PR DESCRIPTION
The first cut of Cpp::GetBuildInfo() (#987) emitted a `cmake-cache:` field that ran ~3KB and was dominated by auto-detected and default values (LLVM_LINKER_DETECTED, LLVM_PARALLEL_*, LLVM_THIRD_PARTY_DIR, ...) -- noise that drowned the few -D flags a bug-report reviewer actually wants.

CMake leaves HELPSTRING="No help, variable specified on the command line." on cache entries that came from -D and were never reclaimed by a later set(... CACHE), i.e. the user's extra args. Filter on that property and emit a `cmake-line:` field. Project-defined options (CMAKE_BUILD_TYPE, CPPINTEROP_USE_CLING, ...) get overwritten and drop out, but they remain visible through the headline labels (`build type:`, `cling:`), so the two channels stay complementary. Idiom from https://gitlab.kitware.com/cmake/cmake/-/work_items/19622.

Test: Interpreter_BuildInfo's last assertion now pins `cmake-line:` instead of `cmake-cache:`.

# Description

Please include a summary of changes, motivation and context for this PR.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [ ] I have read the contribution guide recently
