### PR TITLE
[Tracing] Emit dual-mode reproducers with embedded build context.

### DIFF
--- a/lib/CppInterOp/Tracing.cpp
+++ b/lib/CppInterOp/Tracing.cpp
@@ -19,6 +19,10 @@
 #include <cassert>
 #include <system_error>
 
+#if defined(__linux__) || defined(__APPLE__)
+#include <dlfcn.h>
+#endif
+
 namespace CppInterOp {
 namespace Tracing {
 
@@ -42,6 +46,97 @@ static void WriteVersionComment(llvm::raw_ostream& OS,
   }
 }
 
+/// dladdr-based path to libclangCppInterOp, used as the dispatch-mode
+/// fallback. Empty for statically-linked images (where dladdr returns
+/// the executable, not a real shared object) so the reproducer falls
+/// through to CPPINTEROP_LIBRARY_PATH.
+static std::string GetCppInterOpLibPath() {
+#if defined(__linux__) || defined(__APPLE__)
+  Dl_info info;
+  if (dladdr(reinterpret_cast<const void*>(&CppImpl::GetVersion), &info) &&
+      info.dli_fname) {
+    llvm::StringRef Name(info.dli_fname);
+    if (Name.contains(".so") || Name.ends_with(".dylib") ||
+        Name.ends_with(".dll"))
+      return info.dli_fname;
+  }
+#endif
+  return {};
+}
+
+/// Stream Cpp::GetBuildInfo() into the prologue as `//` comments.
+static void WriteBuildContext(llvm::raw_ostream& OS) {
+  OS << "// Build context (CppInterOp configure-time snapshot):\n";
+  // Bind to a local: StringRef of the GetBuildInfo() rvalue would
+  // dangle past the next `;`.
+  std::string Snapshot = CppImpl::GetBuildInfo();
+  llvm::StringRef Info(Snapshot);
+  while (!Info.empty()) {
+    auto [Line, Rest] = Info.split('\n');
+    if (!Line.empty())
+      OS << "//" << Line << "\n";
+    Info = Rest;
+  }
+}
+
+/// Emit a prologue compilable in two modes selected by -D:
+///   default                       <CppInterOp/CppInterOp.h>, static-link
+///   -DCPPINTEROP_USE_DISPATCH     <CppInterOp/Dispatch.h>, dlopen-based
+/// The dispatch path reads CPPINTEROP_LIBRARY_PATH and falls back to
+/// the dladdr-captured libclangCppInterOp path (when available).
+static void WriteReproducerPrologue(llvm::raw_ostream& OS,
+                                    llvm::StringRef Title,
+                                    const std::string& Version,
+                                    llvm::StringRef Footnote) {
+  OS << "// CppInterOp " << Title << "\n";
+  WriteVersionComment(OS, Version);
+  if (!Footnote.empty())
+    OS << "// " << Footnote << "\n";
+  OS << "//\n";
+  WriteBuildContext(OS);
+  OS << "//\n";
+  OS << "// Build (default, static link):\n";
+  OS << "//   c++ -std=c++17 -I<CppInterOp-include-dir>"
+        " reproducer.cpp -lclangCppInterOp -o reproducer\n";
+  OS << "// Build (dlopen via Dispatch.h):\n";
+  OS << "//   c++ -std=c++17 -DCPPINTEROP_USE_DISPATCH"
+        " -I<CppInterOp-include-dir>"
+        " reproducer.cpp -ldl -o reproducer\n";
+  std::string LibPath = GetCppInterOpLibPath();
+  OS << "// Run: ./reproducer";
+  if (LibPath.empty())
+    OS << "  (dispatch build: set "
+          "CPPINTEROP_LIBRARY_PATH=<libclangCppInterOp.so>)";
+  else
+    OS << "  (dispatch build: CPPINTEROP_LIBRARY_PATH overrides the captured "
+          "path)";
+  OS << "\n\n";
+
+  OS << "#ifdef CPPINTEROP_USE_DISPATCH\n";
+  OS << "#include <CppInterOp/Dispatch.h>\n\n";
+  // X-macro defines one DispatchRaw slot per public API entry.
+  OS << "using namespace CppImpl;\n";
+  OS << "#define CPPINTEROP_API_FUNC(DN, CN, Ret, DeclArgs, CallArgs, "
+        "RawTypes) \\\n"
+        "  Ret(*CppInternal::DispatchRaw::DN) RawTypes = nullptr;\n"
+        "#include \"CppInterOp/CppInterOpAPI.inc\"\n\n";
+  // Lazy: lets a cling-driven harness call reproducer() before main().
+  OS << "static void initCppInterOpReproducer() {\n";
+  OS << "  static bool inited = false;\n";
+  OS << "  if (inited) return;\n";
+  OS << "  const char* path = std::getenv(\"CPPINTEROP_LIBRARY_PATH\");\n";
+  if (!LibPath.empty())
+    OS << "  if (!path) path = R\"PATH(" << LibPath << ")PATH\";\n";
+  OS << "  Cpp::LoadDispatchAPI(path);\n";
+  OS << "  inited = true;\n";
+  OS << "}\n";
+  OS << "#else\n";
+  OS << "#include <CppInterOp/CppInterOp.h>\n";
+  // Static-link path: no-op so reproducer()'s init call is harmless.
+  OS << "static void initCppInterOpReproducer() {}\n";
+  OS << "#endif\n\n";
+}
+
 std::string TraceInfo::writeToFile(const std::string& Version) {
   llvm::SmallString<128> TmpDir;
   llvm::sys::path::system_temp_directory(/*ErasedOnReboot=*/true, TmpDir);
@@ -55,12 +150,11 @@ std::string TraceInfo::writeToFile(const std::string& Version) {
 
   llvm::raw_fd_ostream OS(FD, /*shouldClose=*/true);
 
-  OS << "// CppInterOp crash reproducer\n";
   std::string Ver = Version.empty() ? CppImpl::GetVersion() : Version;
-  WriteVersionComment(OS, Ver);
-  OS << "// Generated automatically — re-run to reproduce the crash.\n";
-  OS << "#include <CppInterOp/CppInterOp.h>\n\n";
+  WriteReproducerPrologue(OS, "crash reproducer", Ver,
+                          "Generated automatically — re-run to reproduce.");
   OS << "void reproducer() {\n";
+  OS << "  initCppInterOpReproducer();\n";
   for (const auto& Line : m_Log)
     OS << Line << "\n";
   OS << "}\n\n";
@@ -108,12 +202,9 @@ void TraceInfo::StopRegion(const std::string& Version) {
     return;
 
   std::string Ver = Version.empty() ? CppImpl::GetVersion() : Version;
-
-  OS << "// CppInterOp trace region\n";
-  WriteVersionComment(OS, Ver);
-  OS << "// Generated automatically.\n";
-  OS << "#include <CppInterOp/CppInterOp.h>\n\n";
+  WriteReproducerPrologue(OS, "trace region", Ver, "Generated automatically.");
   OS << "void reproducer() {\n";
+  OS << "  initCppInterOpReproducer();\n";
   for (size_t i = m_RegionStart; i < m_Log.size(); ++i)
     OS << m_Log[i] << "\n";
   OS << "}\n\n";

--- a/unittests/CppInterOp/TracingTests.cpp
+++ b/unittests/CppInterOp/TracingTests.cpp
@@ -1003,9 +1003,17 @@ TEST_F(TracingTest, WriteToFileProducesValidReproducer) {
   std::string content((std::istreambuf_iterator<char>(ifs)),
                       std::istreambuf_iterator<char>());
 
+  // Both prologue branches must travel together.
+  EXPECT_THAT(content, HasSubstr("#ifdef CPPINTEROP_USE_DISPATCH"));
+  EXPECT_THAT(content, HasSubstr("#include <CppInterOp/Dispatch.h>"));
   EXPECT_THAT(content, HasSubstr("#include <CppInterOp/CppInterOp.h>"));
+  EXPECT_THAT(content, HasSubstr("CPPINTEROP_API_FUNC"));
+  EXPECT_THAT(content, HasSubstr("Cpp::LoadDispatchAPI"));
   EXPECT_THAT(content, HasSubstr("void reproducer()"));
   EXPECT_THAT(content, HasSubstr("Cpp::"));
+  EXPECT_THAT(content, HasSubstr("Build context"));
+  EXPECT_THAT(content, HasSubstr("build type:"));
+  EXPECT_THAT(content, HasSubstr("cmake-cache:"));
 
   // Clean up.
   llvm::sys::fs::remove(Path);
@@ -1080,7 +1088,7 @@ TEST_F(TracingTest, ReproducerCompilesViaInterpreter) {
   ifs.close();
 
   // Verify the reproducer has proper structure and content.
-  EXPECT_THAT(content, HasSubstr("#include <CppInterOp/CppInterOp.h>"));
+  EXPECT_THAT(content, HasSubstr("#include <CppInterOp/Dispatch.h>"));
   EXPECT_THAT(content, HasSubstr("void reproducer()"));
   EXPECT_THAT(content, HasSubstr("Cpp::"));
 
@@ -1095,7 +1103,8 @@ TEST_F(TracingTest, ReproducerCompilesViaInterpreter) {
       << "Reproducer failed to compile via #include:\n"
       << content;
 
-  // Execute the reproducer in clean interpreter state.
+  // Drives the static-link `#else` branch via the in-process interpreter;
+  // the dispatch path is for standalone builds, not exercised here.
   EXPECT_EQ(Cpp::Process("reproducer();"), 0) << "Reproducer failed to execute";
 
   llvm::sys::fs::remove(Path);
@@ -1203,7 +1212,7 @@ TEST_F(TracingTest, StartStopTracingWritesToFile) {
   ASSERT_FALSE(content.empty());
   EXPECT_THAT(content, HasSubstr("Cpp::VoidFunc()"));
   EXPECT_THAT(content, HasSubstr("Cpp::AnnotatedFunction("));
-  EXPECT_THAT(content, HasSubstr("#include <CppInterOp/CppInterOp.h>"));
+  EXPECT_THAT(content, HasSubstr("#include <CppInterOp/Dispatch.h>"));
 
   llvm::sys::fs::remove(Path);
 }
@@ -1326,7 +1335,7 @@ TEST_F(TracingTest, WriteToFileWhenStdErrDisabled) {
 
   // The file should contain the full reproducer.
   std::string FileContent = ReadFileToString(Path);
-  EXPECT_THAT(FileContent, HasSubstr("#include <CppInterOp/CppInterOp.h>"));
+  EXPECT_THAT(FileContent, HasSubstr("#include <CppInterOp/Dispatch.h>"));
   EXPECT_THAT(FileContent, HasSubstr("Cpp::AnnotatedFunction(77)"));
 
   llvm::sys::fs::remove(Path);


### PR DESCRIPTION
Today the reproducer files emitted by writeToFile/StopRegion include `<CppInterOp/CppInterOp.h>` and nothing else, so reproducing a trace needs the project headers and `-lclangCppInterOp` on the link line -- awkward to bootstrap on a fresh machine. Worse, there is no record of how CppInterOp itself was built, so a reviewer reading the trace cannot tell which compiler, LLVM, sanitizer, or cmake -D flags produced it.

Reshape the prologue so a single source file compiles two ways. The default branch keeps `<CppInterOp/CppInterOp.h>` and a no-op init for plain static linking. The opt-in branch (`-DCPPINTEROP_USE_DISPATCH`) pulls in `<CppInterOp/Dispatch.h>`, declares per-TU DispatchRaw slots via the existing CPPINTEROP_API_FUNC X-macro, and lazily calls LoadDispatchAPI on `CPPINTEROP_LIBRARY_PATH` (falling back to the dladdr-captured library when it points to a real .so/.dylib/.dll, not a static-linked executable). The prologue also streams Cpp::GetBuildInfo() into the comment header, so the captured cmake- line and configuration travel with the trace.

Test: WriteToFileProducesValidReproducer pins the `#ifdef`, both header forms, the X-macro plus LoadDispatchAPI markers, and the GetBuildInfo-derived `build type:` / `cmake-line:` lines. ReproducerCompilesViaInterpreter exercises the static-link branch via cling's in-process interpreter; the dispatch branch is for standalone builds.

# Description

Please include a summary of changes, motivation and context for this PR.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [ ] I have read the contribution guide recently
