### PR TITLE
Honor no-Value-after-success, rename out-param in Evaluate.

### DIFF
--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -4230,17 +4230,18 @@ int Process(const char* code) {
   return INTEROP_RETURN(getInterp().process(code));
 }
 
-intptr_t Evaluate(const char* code, bool* HadError /*=nullptr*/) {
-  INTEROP_TRACE(code, HadError);
+intptr_t Evaluate(const char* code, bool* IsValueInvalid /*=nullptr*/) {
+  INTEROP_TRACE(code, IsValueInvalid);
   compat::Value V;
 
-  if (HadError)
-    *HadError = false;
+  if (IsValueInvalid)
+    *IsValueInvalid = false;
 
   auto res = getInterp().evaluate(code, V);
-  if (res != 0) { // 0 is success
-    if (HadError)
-      *HadError = true;
+  // 0 is success; an unset V on success means convertTo would assert.
+  if (res != 0 || !V.hasValue()) {
+    if (IsValueInvalid)
+      *IsValueInvalid = true;
     // FIXME: Make this return llvm::Expected
     return INTEROP_RETURN(~0UL);
   }

--- a/lib/CppInterOp/CppInterOp.td
+++ b/lib/CppInterOp/CppInterOp.td
@@ -70,12 +70,15 @@ def Declare : CppInterOpAPI {
 
 def Evaluate : CppInterOpAPI {
   let Doc = [{Declares, executes and returns the execution result as a intptr_t.
+\param[in] code - the snippet to declare and execute.
+\param[out] IsValueInvalid - if non-null, set true when the result is
+            unusable (parse error or no-Value-after-success).
 \returns the expression results as a intptr_t.}];
 
   let ReturnType = "intptr_t";
   let Args = [
     Arg<"const char*", "code">,
-    Arg<"bool*", "HadError", "nullptr">
+    Arg<"bool*", "IsValueInvalid", "nullptr">
   ];
 }
 

--- a/unittests/CppInterOp/InterpreterTest.cpp
+++ b/unittests/CppInterOp/InterpreterTest.cpp
@@ -112,6 +112,26 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, Interpreter_Evaluate) {
   EXPECT_FALSE(HadError);
 }
 
+// Regression (cppyy test12): no-Value-after-success used to abort in
+// convertTo. A pure class decl is no-Value across all clang-repl
+// versions; `int x = 5;` is bound on newer ones.
+TYPED_TEST(CPPINTEROP_TEST_MODE, Interpreter_Evaluate_NonValueStatement) {
+#ifdef EMSCRIPTEN
+  GTEST_SKIP() << "Test fails for Emscipten builds";
+#endif
+#ifdef _WIN32
+  GTEST_SKIP() << "Disabled on Windows. Needs fixing.";
+#endif
+  if (TypeParam::isOutOfProcess)
+    GTEST_SKIP() << "Test fails for OOP JIT builds";
+  TestFixture::CreateInterpreter();
+
+  bool HadError = false;
+  EXPECT_EQ(Cpp::Evaluate("class EvalRegression_NoValue {};", &HadError),
+            (intptr_t)~0UL);
+  EXPECT_TRUE(HadError);
+}
+
 TYPED_TEST(CPPINTEROP_TEST_MODE, Interpreter_DeleteInterpreter) {
   if (TypeParam::isOutOfProcess)
     GTEST_SKIP() << "Test fails for OOP JIT builds";


### PR DESCRIPTION
Cpp::Evaluate calls compat::convertTo<intptr_t>(V) on the result of getInterp().evaluate(...). When the source compiles cleanly but yields no Value -- a statement like "int x = 5;", a void expression, or any input the interpreter accepts but doesn't bind to a result -- V stays default-constructed (invalid). convertTo asserts on an invalid Value, which manifests as a process abort in callers (cppyy's test12 hit this).

Gate the final convertTo on V.hasValue() and, when it isn't set, report through the bool* out-param and return ~0UL. Since the bool now also signals "compiled but produced no Value" (not strictly an error), rename it from HadError to IsValueInvalid -- the parameter answers "is the returned intptr_t unusable?". Polarity is preserved and the bool* is positional, so callers need no in-tree migration.

Test: Interpreter_Evaluate_NonValueStatement pins the new path with `int xx = 7;`, asserting ~0UL plus IsValueInvalid=true rather than the prior abort.

# Description

Please include a summary of changes, motivation and context for this PR.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [ ] I have read the contribution guide recently
