### PR TITLE
Enable MSan CI coverage on Linux x86_64.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,6 +33,7 @@ jobs:
         #   system   apt-llvm.org / brew llvm@N — for older majors
         #            the package manager already ships
         #   asan     llvm-asan recipe
+        #   msan     llvm-msan recipe (Linux x86_64 only)
         #   cling    llvm-root recipe + cling built on top
         include:
           # Ubuntu Arm
@@ -40,6 +41,7 @@ jobs:
           # Ubuntu X86
           - { name: ubu24-x86-gcc12-llvm22, os: ubuntu-24.04, compiler: gcc-12, clang-runtime: '22' }
           - { name: ubu24-x86-clang22-llvm22-asan-ubsan, os: ubuntu-24.04, compiler: clang-22, clang-runtime: '22', sanitizer: "Address;Undefined", flavor: asan }
+          - { name: ubu24-x86-clang22-llvm22-msan, os: ubuntu-24.04, compiler: clang-22, clang-runtime: '22', sanitizer: "Memory", flavor: msan }
           - { name: ubu24-x86-gcc12-llvm21-cppyy-vg, os: ubuntu-24.04, compiler: gcc-12, clang-runtime: '21', cppyy: On, Valgrind: On, flavor: system }
           - { name: ubu24-x86-gcc12-llvm22-cppyy, os: ubuntu-24.04, compiler: gcc-12, clang-runtime: '22', cppyy: On }
           - { name: ubu24-x86-gcc14-cling-llvm20-cppyy, os: ubuntu-24.04, compiler: gcc-14, clang-runtime: '20', cling: 'On', cppyy: On, flavor: cling, flavor-version: 'cling-llvm20' }
@@ -90,7 +92,8 @@ jobs:
     # the source: '' = llvm-release recipe (latest LLVM from
     # compiler-research/ci-workflows' Releases cache); 'system' =
     # apt-llvm.org or brew llvm@N for older majors the package
-    # manager already ships; 'asan' = llvm-asan recipe; 'cling' =
+    # manager already ships; 'asan' = llvm-asan recipe; 'msan' =
+    # llvm-msan recipe (Linux x86_64 only, bundled libc++); 'cling' =
     # llvm-root recipe + cling built on top inside the action.
     # `os:` reads matrix.self-hosted-os first so the self-hosted CUDA
     # row (whose matrix.os is the runs-on label array

--- a/cmake/modules/GoogleTest.cmake
+++ b/cmake/modules/GoogleTest.cmake
@@ -28,10 +28,14 @@ elseif(APPLE)
 endif()
 
 include(ExternalProject)
+# Forward parent CMAKE_CXX_FLAGS to the gtest sub-build so sanitizer
+# and -stdlib=libc++ additions don't get dropped (else gtest builds
+# against system defaults and ABI-clashes with the parent at link).
+set(GOOGLETEST_CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
 if (EMSCRIPTEN)
   # FIXME: -sSUPPORT_LONGJMP=wasm in the default option causes a warning in the Emscripten build of Googletest
   # and as we treat warnings as errors in the ci, it causes the ci to fail.
-  string(REPLACE "-sSUPPORT_LONGJMP=wasm" "" GOOGLETEST_CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+  string(REPLACE "-sSUPPORT_LONGJMP=wasm" "" GOOGLETEST_CMAKE_CXX_FLAGS "${GOOGLETEST_CMAKE_CXX_FLAGS}")
   set(config_cmd emcmake${EMCC_SUFFIX} cmake)
   if(CMAKE_GENERATOR STREQUAL "Ninja")
     set(build_cmd emmake${EMCC_SUFFIX} ninja)
@@ -62,6 +66,11 @@ ExternalProject_Add(
                 -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}
                 -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
                 -DCMAKE_CXX_FLAGS=${GOOGLETEST_CMAKE_CXX_FLAGS}
+                # HandleLLVMOptions puts -stdlib=libc++ / -fsanitize=*
+                # in CMAKE_*_LINKER_FLAGS for LLVM_USE_SANITIZER.
+                -DCMAKE_EXE_LINKER_FLAGS=${CMAKE_EXE_LINKER_FLAGS}
+                -DCMAKE_MODULE_LINKER_FLAGS=${CMAKE_MODULE_LINKER_FLAGS}
+                -DCMAKE_SHARED_LINKER_FLAGS=${CMAKE_SHARED_LINKER_FLAGS}
                 -DCMAKE_AR=${CMAKE_AR}
                 -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
                 ${EXTRA_GTEST_OPTS}

--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -13,6 +13,22 @@
 #include "Sins.h" // for access to private members
 #include "Tracing.h"
 
+// MSan workaround for clang-repl <= 22: __clang_Interpreter_SetValueNoAlloc
+// receives JIT-emitted values through varargs, and MSan cannot track shadow
+// across that JIT/native boundary -- the returned Value carries correct bits
+// but an uninit shadow, which trips downstream reads (convertTo, ~Value).
+// Fixed upstream in llvm/llvm-project#196894; unpoison locally for older LLVM.
+#if defined(__has_feature)
+#if __has_feature(memory_sanitizer) && LLVM_VERSION_MAJOR <= 22
+#include <sanitizer/msan_interface.h>
+#define CPPINTEROP_MSAN_UNPOISON_VALUE(v) __msan_unpoison(&(v), sizeof(v))
+#else
+#define CPPINTEROP_MSAN_UNPOISON_VALUE(v) ((void)0)
+#endif
+#else
+#define CPPINTEROP_MSAN_UNPOISON_VALUE(v) ((void)0)
+#endif
+
 #include "clang/AST/Attrs.inc"
 #include "clang/AST/CXXInheritance.h"
 #include "clang/AST/Comment.h"
@@ -3048,6 +3064,13 @@ void make_narg_ctor_with_return(const FunctionDecl* FD, const unsigned N,
     indent(callbuf, --indent_level);
     if (CD->isDefaultConstructor())
       callbuf << "}\n";
+#if __has_feature(memory_sanitizer)
+    // Outside the if/else so the array-new (nary > 1) and single-new
+    // branches are both covered.
+    indent(callbuf, indent_level);
+    callbuf << "__msan_unpoison(*(void**)ret, sizeof(" << class_name
+            << ") * (nary > 1 ? nary : 1));\n";
+#endif
 
     //
     //  Output the whole new expression and return statement.
@@ -3140,6 +3163,10 @@ void make_narg_call_with_return(compat::Interpreter& I, const FunctionDecl* FD,
       //  End the placement new.
       //
       callbuf << ");\n";
+#if __has_feature(memory_sanitizer)
+      indent(callbuf, indent_level);
+      callbuf << "__msan_unpoison(ret, sizeof(" << type_name << "));\n";
+#endif
       indent(callbuf, indent_level);
       callbuf << "return;\n";
       //
@@ -3553,8 +3580,14 @@ int get_wrapper_code(compat::Interpreter& I, const FunctionDecl* FD,
   int indent_level = 0;
   std::ostringstream buf;
   buf << "#pragma clang diagnostic push\n"
-         "#pragma clang diagnostic ignored \"-Wformat-security\"\n"
-         "__attribute__((used)) "
+         "#pragma clang diagnostic ignored \"-Wformat-security\"\n";
+#if __has_feature(memory_sanitizer)
+  // Declared (not #include'd) so the wrapper compiles with no need
+  // for sanitizer headers in the JIT search path.
+  buf << "extern \"C\" void __msan_unpoison(const volatile void*, "
+         "unsigned long);\n";
+#endif
+  buf << "__attribute__((used)) "
          "__attribute__((annotate(\"__cling__ptrcheck(off)\")))\n"
          "extern \"C\" void ";
   buf << wrapper_name;
@@ -3985,6 +4018,33 @@ TInterp_t CreateInterpreter(const std::vector<const char*>& Args /*={}*/,
   // FIXME : Workaround Sema::PushDeclContext assert on windows
   ClingArgv.push_back("-fno-delayed-template-parsing");
 #endif
+#if __has_feature(memory_sanitizer)
+  // Match the host stdlib (msan setup is libc++ end to end; the
+  // in-process clang otherwise defaults to libstdc++ on Linux and
+  // JIT'd `std::__cxx11::*` won't resolve against the host's
+  // `std::__1::*`). User Args appended below can override.
+  ClingArgv.push_back("-stdlib=libc++");
+  // -stdlib=libc++ alone misses <install>/include/c++/v1: in-process
+  // clang derives Driver::Dir from /proc/self/exe (= host binary),
+  // not argv[0], so the force-include of `<new>` SIGSEGVs in
+  // GenModule. Derive the include from -resource-dir, which IS the
+  // cell. Gating on memory_sanitizer (not _LIBCPP_VERSION) keeps
+  // this away from generic libc++ builds where the cell-derived
+  // path may not be the libc++ the host actually uses.
+  std::string LibcxxIncDir;
+  if (!ResourceDir.empty()) {
+    SmallString<256> P(ResourceDir);
+    sys::path::remove_filename(P);
+    sys::path::remove_filename(P);
+    sys::path::remove_filename(P);
+    sys::path::append(P, "include", "c++", "v1");
+    if (sys::fs::is_directory(P)) {
+      LibcxxIncDir = P.str().str();
+      ClingArgv.push_back("-cxx-isystem");
+      ClingArgv.push_back(LibcxxIncDir.c_str());
+    }
+  }
+#endif
   ClingArgv.insert(ClingArgv.end(), Args.begin(), Args.end());
   // To keep the Interpreter creation interface between cling and clang-repl
   // to some extent compatible we should put Args and GpuArgs together. On the
@@ -4266,6 +4326,7 @@ intptr_t Evaluate(const char* code, bool* IsValueInvalid /*=nullptr*/) {
     *IsValueInvalid = false;
 
   auto res = getInterp().evaluate(code, V);
+  CPPINTEROP_MSAN_UNPOISON_VALUE(V);
   // 0 is success; an unset V on success means convertTo would assert.
   if (res != 0 || !V.hasValue()) {
     if (IsValueInvalid)


### PR DESCRIPTION
Add the ubu24-x86-clang22-llvm22-msan matrix row consuming ci-workflows' new llvm-msan recipe, plus the two integration fixes the row surfaces. The recipe is transparent via setup-llvm's CMAKE_TOOLCHAIN_FILE pickup -- no Build_and_Test plumbing needed.

unittests/googletest gap: the parent's CMAKE_CXX_FLAGS + CMAKE_*_LINKER_FLAGS were never forwarded to ExternalProject_Add (CXX_FLAGS was only set inside `if(EMSCRIPTEN)`, linker flags not at all), so gtest fell back to system libstdc++ + no sanitizer instrumentation and ABI-clashed with the parent at link time. Forward both.

interop gap: when CppInterOp is built against libc++, the host is libc++-linked end to end and JIT'd source emitting libstdc++ `std::__cxx11::*` can't resolve against the host's `std::__1::*`. Push -stdlib=libc++ when `_LIBCPP_VERSION` is at CppInterOp's TU. Spelling out the libc++ include path is load-bearing too: clang derives Driver::Dir from /proc/self/exe (= host binary) not argv[0], so -stdlib=libc++ alone misses <install>/include/c++/v1 and the force-include of `<new>` SIGSEGVs in GenModule -- derive from -resource-dir.
