### PR TITLE
[Tracing] Suppress dumper self-trace and document reproducer scope.

### DIFF
--- a/lib/CppInterOp/Tracing.cpp
+++ b/lib/CppInterOp/Tracing.cpp
@@ -50,6 +50,17 @@ std::optional<uint64_t> TraceRegion::lookupOutMask(llvm::StringRef Name) {
   return It->second;
 }
 
+/// RAII: hold m_Dumping while the reproducer is being emitted.
+namespace {
+class DumpScope {
+  TraceInfo& TI;
+
+public:
+  explicit DumpScope(TraceInfo& T) : TI(T) { TI.setDumping(true); }
+  ~DumpScope() { TI.setDumping(false); }
+};
+} // namespace
+
 /// Helper: emit version info as comment lines.
 static void WriteVersionComment(llvm::raw_ostream& OS,
                                 const std::string& Version) {
@@ -109,6 +120,12 @@ static void WriteReproducerPrologue(llvm::raw_ostream& OS,
   if (!Footnote.empty())
     OS << "// " << Footnote << "\n";
   OS << "//\n";
+  OS << "// Replay scope: re-runs recorded CppInterOp API calls. JIT\n";
+  OS << "// wrappers (Cpp::JitCall::Invoke) are not replayed -- their\n";
+  OS << "// pointer args reference the original process's memory. The\n";
+  OS << "// trailing `// JitCall::Invoke ...` comment, if present,\n";
+  OS << "// names the call active at the crash site.\n";
+  OS << "//\n";
   WriteBuildContext(OS);
   OS << "//\n";
   OS << "// Build (default, static link):\n";
@@ -165,6 +182,7 @@ std::string TraceInfo::writeToFile(const std::string& Version) {
     return "";
 
   llvm::raw_fd_ostream OS(FD, /*shouldClose=*/true);
+  DumpScope Guard(*this);
 
   std::string Ver = Version.empty() ? CppImpl::GetVersion() : Version;
   WriteReproducerPrologue(OS, "crash reproducer", Ver,
@@ -217,6 +235,7 @@ void TraceInfo::StopRegion(const std::string& Version) {
   if (EC)
     return;
 
+  DumpScope Guard(*this);
   std::string Ver = Version.empty() ? CppImpl::GetVersion() : Version;
   WriteReproducerPrologue(OS, "trace region", Ver, "Generated automatically.");
   OS << "void reproducer() {\n";

--- a/lib/CppInterOp/Tracing.h
+++ b/lib/CppInterOp/Tracing.h
@@ -69,6 +69,10 @@ class TraceInfo {
   std::vector<std::string> m_Log;
   size_t m_RegionStart = 0; ///< Log index where current region began.
   bool m_InRegion = false;  ///< True between StartTracing/StopTracing.
+  /// Set while the reproducer is being emitted. Gates appendToLog and
+  /// setLogEntry so the dumper's own INTEROP_TRACE-wrapped calls
+  /// (GetVersion, GetBuildInfo) don't recurse into m_Log.
+  bool m_Dumping = false;
 
 public:
   TraceInfo() : m_TG("CppInterOp", "CppInterOp Timing Report") {}
@@ -150,13 +154,20 @@ public:
   /// Append a line; the returned index pairs with setLogEntry to
   /// rewrite the same slot later (TraceRegion's placeholder pattern).
   size_t appendToLog(const std::string& line) {
+    if (m_Dumping)
+      return 0;
     size_t idx = m_Log.size();
     m_Log.push_back(line);
     if (m_InRegion && m_WriteOnStdErr)
       llvm::errs() << line << "\n";
     return idx;
   }
-  void setLogEntry(size_t idx, const std::string& line) { m_Log[idx] = line; }
+  void setLogEntry(size_t idx, const std::string& line) {
+    if (m_Dumping)
+      return;
+    m_Log[idx] = line;
+  }
+  void setDumping(bool v) { m_Dumping = v; }
   const std::vector<std::string>& getLog() const { return m_Log; }
   std::string getLastLogEntry() const {
     return m_Log.empty() ? "" : m_Log.back();

--- a/unittests/CppInterOp/TracingTests.cpp
+++ b/unittests/CppInterOp/TracingTests.cpp
@@ -1113,6 +1113,28 @@ TEST_F(TracingTest, WriteToFileContainsOutParamCalls) {
   llvm::sys::fs::remove(Path);
 }
 
+TEST_F(TracingTest, WriteToFileSuppressesSelfTrace) {
+  // Without the m_Dumping guard, GetVersion/GetBuildInfo (both
+  // INTEROP_TRACE'd) would leak into the reproducer body.
+  AnnotatedFunction(7);
+  AnnotatedFunction(8);
+
+  TraceInfo& TI = *TraceInfo::TheTraceInfo;
+  size_t before = TI.getLog().size();
+  std::string Path = TI.writeToFile();
+  ASSERT_FALSE(Path.empty());
+  EXPECT_EQ(TI.getLog().size(), before);
+
+  std::ifstream ifs(Path);
+  std::string content((std::istreambuf_iterator<char>(ifs)),
+                      std::istreambuf_iterator<char>());
+  EXPECT_THAT(content, Not(HasSubstr("Cpp::GetVersion()")));
+  EXPECT_THAT(content, Not(HasSubstr("Cpp::GetBuildInfo()")));
+  EXPECT_THAT(content, HasSubstr("// Replay scope:"));
+
+  llvm::sys::fs::remove(Path);
+}
+
 // ---------------------------------------------------------------------------
 // Tests: reproducer compiles via interpreter
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
writeToFile and StopRegion call GetVersion and GetBuildInfo, both of which carry INTEROP_TRACE. Without a guard those calls re-enter the log being written: appendToLog grows m_Log mid-iteration over the very vector the dumper is streaming, and TraceRegion's dtor calls setLogEntry on a slot whose index came from the gated appendToLog. The captured reproducer ends up with stray Cpp::GetVersion() / Cpp::GetBuildInfo() lines inside its body.

Add a `bool m_Dumping` on TraceInfo that gates appendToLog and setLogEntry, toggled via an RAII DumpScope around the dump bodies. The off-trace path pays one predictable branch. While in the prologue, document the replay scope: JIT wrappers
(Cpp::JitCall::Invoke) are not replayed -- their pointer args reference the original process's memory -- and the trailing `// JitCall::Invoke ...` comment, when present, names the call active at the crash site.

Test: WriteToFileSuppressesSelfTrace seeds the log with two traced calls, snapshots getLog().size(), invokes writeToFile, and asserts the size is unchanged, the on-disk reproducer body has no Cpp::GetVersion() / Cpp::GetBuildInfo() lines, and the prologue carries the new "Replay scope:" comment.

# Description

Please include a summary of changes, motivation and context for this PR.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [ ] I have read the contribution guide recently
