### PR TITLE
[Tracing] Inline-guard JitCall::Invoke trace hooks for Release.

### DIFF
--- a/include/CppInterOp/CppInterOpTypes.h
+++ b/include/CppInterOp/CppInterOpTypes.h
@@ -45,6 +45,35 @@
 #endif
 
 namespace CppImpl {
+class JitCall;
+}
+namespace CppInternal {
+namespace DispatchRaw {
+/// JitCall::Invoke trace-hook slots. Dispatch.h consumers get a per-DSO
+/// inline (vague-linkage) variable -- no UND symbol crosses the link --
+/// populated by LoadDispatchAPI. Linked consumers share a single extern
+/// definition in libclangCppInterOp, populated by InitTracing. Nullptr
+/// means tracing is off.
+#ifdef CPPINTEROP_DISPATCH_H
+inline void (*TraceJitCallInvoke)(const CppImpl::JitCall* JC, void* result,
+                                  void** args, std::size_t nargs,
+                                  void* self) noexcept = nullptr;
+inline void (*TraceJitCallInvokeDestructor)(const CppImpl::JitCall* JC,
+                                            void* object, unsigned long nary,
+                                            int withFree) noexcept = nullptr;
+#else
+extern CPPINTEROP_API void (*TraceJitCallInvoke)(const CppImpl::JitCall* JC,
+                                                 void* result, void** args,
+                                                 std::size_t nargs,
+                                                 void* self) noexcept;
+extern CPPINTEROP_API void (*TraceJitCallInvokeDestructor)(
+    const CppImpl::JitCall* JC, void* object, unsigned long nary,
+    int withFree) noexcept;
+#endif
+} // namespace DispatchRaw
+} // namespace CppInternal
+
+namespace CppImpl {
 using TCppIndex_t = size_t;
 using TCppScope_t = void*;
 using TCppConstScope_t = const void*;
@@ -236,16 +265,19 @@ private:
   JitCall(Kind K, DestructorCall C, TCppConstFunction_t Dtor)
       : m_DestructorCall(C), m_Kind(K), m_FD(Dtor) {}
 
+  // Trace-hook impls need private m_FD for the function-name lookup.
+  friend void CppInterOpTraceJitCallInvokeImpl(const JitCall*, void* result,
+                                               void** args, std::size_t nargs,
+                                               void* self) noexcept;
+  friend void CppInterOpTraceJitCallInvokeDestructorImpl(const JitCall*,
+                                                         void* object,
+                                                         unsigned long nary,
+                                                         int withFree) noexcept;
+
   /// Checks if the passed arguments are valid for the given function.
   CPPINTEROP_API bool AreArgumentsValid(void* result, ArgList args, void* self,
                                         size_t nary) const;
 
-  /// This function is used for debugging, it reports when the function was
-  /// called.
-  CPPINTEROP_API void ReportInvokeStart(void* result, ArgList args,
-                                        void* self) const;
-  CPPINTEROP_API void ReportInvokeStart(void* object, unsigned long nary,
-                                        int withFree) const;
   void ReportInvokeEnd() const;
 
 public:
@@ -278,11 +310,10 @@ public:
       break;
 
     case kGenericCall:
-#ifndef NDEBUG
       // We pass 1UL to nary which is only relevant for structors
       assert(AreArgumentsValid(result, args, self, 1UL) && "Invalid args!");
-      ReportInvokeStart(result, args, self);
-#endif // NDEBUG
+      if (auto fn = ::CppInternal::DispatchRaw::TraceJitCallInvoke)
+        fn(this, result, args.m_Args, args.m_ArgSize, self);
       m_GenericCall(self, args.m_ArgSize, args.m_Args, result);
       break;
 
@@ -309,9 +340,8 @@ public:
   void InvokeDestructor(void* object, unsigned long nary = 0,
                         int withFree = true) const {
     assert(m_Kind == kDestructorCall && "Wrong overload!");
-#ifndef NDEBUG
-    ReportInvokeStart(object, nary, withFree);
-#endif // NDEBUG
+    if (auto fn = ::CppInternal::DispatchRaw::TraceJitCallInvokeDestructor)
+      fn(this, object, nary, withFree);
     m_DestructorCall(object, nary, withFree);
   }
 
@@ -327,11 +357,10 @@ public:
   void InvokeConstructor(void* result, unsigned long nary = 1,
                          ArgList args = {}, void* is_arena = nullptr) const {
     assert(m_Kind == kConstructorCall && "Wrong overload!");
-#ifndef NDEBUG
     assert(AreArgumentsValid(result, args, /*self=*/nullptr, nary) &&
            "Invalid args!");
-    ReportInvokeStart(result, args, nullptr);
-#endif // NDEBUG
+    if (auto fn = CppInternal::DispatchRaw::TraceJitCallInvoke)
+      fn(this, result, args.m_Args, args.m_ArgSize, nullptr);
     m_ConstructorCall(result, nary, args.m_ArgSize, args.m_Args, is_arena);
   }
 };

--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -255,9 +255,8 @@ static void DefaultProcessCrashHandler(void*) {
 
   llvm::errs() << "\n**************************************************\n";
   llvm::errs() << "  CppInterOp CRASH DETECTED\n";
-  if (CppInterOp::Tracing::TraceInfo::TheTraceInfo) {
-    std::string Path =
-        CppInterOp::Tracing::TraceInfo::TheTraceInfo->writeToFile();
+  if (CppInterOp::Tracing::TheTraceInfo) {
+    std::string Path = CppInterOp::Tracing::TheTraceInfo->writeToFile();
     if (!Path.empty())
       llvm::errs() << "  Reproducer saved to: " << Path << "\n";
     else
@@ -448,44 +447,47 @@ bool JitCall::AreArgumentsValid(void* result, ArgList args, void* self,
   return Valid;
 }
 
-void JitCall::ReportInvokeStart(void* result, ArgList args, void* self) const {
+// Trace-hook impls reached via DispatchRaw from JitCall's inline body.
+// Off-trace the slot is nullptr and these never run.
+void CppInterOpTraceJitCallInvokeImpl(const JitCall* JC, void* result,
+                                      void** args, std::size_t nargs,
+                                      void* self) noexcept {
+  auto* TI = CppInterOp::Tracing::TheTraceInfo;
+  if (!TI)
+    return;
   std::string Name;
   llvm::raw_string_ostream OS(Name);
-  auto* FD = (const FunctionDecl*)m_FD;
+  const auto* FD = static_cast<const FunctionDecl*>(JC->m_FD);
   FD->getNameForDiagnostic(OS, FD->getASTContext().getPrintingPolicy(),
                            /*Qualified=*/true);
   LLVM_DEBUG(dbgs() << "Run '" << Name << "', compiled at: "
-                    << (void*)m_GenericCall << " with result at: " << result
-                    << " , args at: " << args.m_Args << " , arg count: "
-                    << args.m_ArgSize << " , self at: " << self << "\n";);
-
-  if (auto* TI = CppInterOp::Tracing::TraceInfo::TheTraceInfo) {
-    std::string SelfPart = self ? TI->lookupHandle(self) : "";
-    std::string Entry =
-        llvm::formatv("  // JitCall::Invoke {0}(nargs={1}, self={2})", Name,
-                      args.m_ArgSize, SelfPart.empty() ? "nullptr" : SelfPart);
-    TI->appendToLog(Entry);
-  }
+                    << (void*)JC->m_GenericCall << " with result at: " << result
+                    << " , args at: " << args << " , arg count: " << nargs
+                    << " , self at: " << self << "\n";);
+  std::string SelfPart = self ? TI->lookupHandle(self) : "";
+  TI->appendToLog(llvm::formatv("  // JitCall::Invoke {0}(nargs={1}, self={2})",
+                                Name, nargs,
+                                SelfPart.empty() ? "nullptr" : SelfPart));
 }
 
-void JitCall::ReportInvokeStart(void* object, unsigned long nary,
-                                int withFree) const {
+void CppInterOpTraceJitCallInvokeDestructorImpl(const JitCall* JC, void* object,
+                                                unsigned long nary,
+                                                int withFree) noexcept {
+  auto* TI = CppInterOp::Tracing::TheTraceInfo;
+  if (!TI)
+    return;
   std::string Name;
   llvm::raw_string_ostream OS(Name);
-  auto* FD = (const FunctionDecl*)m_FD;
+  const auto* FD = static_cast<const FunctionDecl*>(JC->m_FD);
   FD->getNameForDiagnostic(OS, FD->getASTContext().getPrintingPolicy(),
                            /*Qualified=*/true);
   LLVM_DEBUG(dbgs() << "Finish '" << Name
-                    << "', compiled at: " << (void*)m_DestructorCall);
-
-  if (auto* TI = CppInterOp::Tracing::TraceInfo::TheTraceInfo) {
-    std::string ObjPart = object ? TI->lookupHandle(object) : "nullptr";
-    std::string Entry = llvm::formatv(
-        "  // JitCall::InvokeDestructor {0}(object={1}, nary={2}, "
-        "withFree={3})",
-        Name, ObjPart, nary, withFree);
-    TI->appendToLog(Entry);
-  }
+                    << "', compiled at: " << (void*)JC->m_DestructorCall);
+  std::string ObjPart = object ? TI->lookupHandle(object) : "nullptr";
+  TI->appendToLog(
+      llvm::formatv("  // JitCall::InvokeDestructor {0}(object={1}, nary={2}, "
+                    "withFree={3})",
+                    Name, ObjPart, nary, withFree));
 }
 
 #undef DEBUG_TYPE
@@ -3606,7 +3608,7 @@ JitCall::GenericCall make_wrapper(compat::Interpreter& I,
     return 0;
 
   // Log the wrapper source for the crash reproducer.
-  if (auto* TI = CppInterOp::Tracing::TraceInfo::TheTraceInfo) {
+  if (auto* TI = CppInterOp::Tracing::TheTraceInfo) {
     std::string FuncName;
     llvm::raw_string_ostream FNS(FuncName);
     FD->getNameForDiagnostic(FNS, FD->getASTContext().getPrintingPolicy(),

--- a/lib/CppInterOp/Tracing.cpp
+++ b/lib/CppInterOp/Tracing.cpp
@@ -25,15 +25,42 @@
 #include <dlfcn.h>
 #endif
 
+// Forward-declare impls (defined in CppInterOp.cpp) so InitTracing can
+// take their address.
+namespace CppImpl {
+void CppInterOpTraceJitCallInvokeImpl(const JitCall* JC, void* result,
+                                      void** args, std::size_t nargs,
+                                      void* self) noexcept;
+void CppInterOpTraceJitCallInvokeDestructorImpl(const JitCall* JC, void* object,
+                                                unsigned long nary,
+                                                int withFree) noexcept;
+} // namespace CppImpl
+
+// Linked-mode slot definitions; Dispatch.h consumers use per-DSO inline.
+namespace CppInternal {
+namespace DispatchRaw {
+void (*TraceJitCallInvoke)(const CppImpl::JitCall*, void*, void**, std::size_t,
+                           void*) noexcept = nullptr;
+void (*TraceJitCallInvokeDestructor)(const CppImpl::JitCall*, void*,
+                                     unsigned long, int) noexcept = nullptr;
+} // namespace DispatchRaw
+} // namespace CppInternal
+
 namespace CppInterOp {
 namespace Tracing {
 
-TraceInfo* TraceInfo::TheTraceInfo = nullptr;
+CPPINTEROP_TRACE_API TraceInfo* TheTraceInfo = nullptr;
 
 void InitTracing() {
-  assert(!TraceInfo::TheTraceInfo);
+  assert(!TheTraceInfo);
   static llvm::ManagedStatic<TraceInfo> TI;
-  TraceInfo::TheTraceInfo = &*TI;
+  TheTraceInfo = &*TI;
+  // Wire libclangCppInterOp's own DispatchRaw slot; Dispatch.h
+  // consumers wire their per-DSO copy at LoadDispatchAPI time.
+  ::CppInternal::DispatchRaw::TraceJitCallInvoke =
+      &CppImpl::CppInterOpTraceJitCallInvokeImpl;
+  ::CppInternal::DispatchRaw::TraceJitCallInvokeDestructor =
+      &CppImpl::CppInterOpTraceJitCallInvokeDestructorImpl;
 }
 
 std::optional<uint64_t> TraceRegion::lookupOutMask(llvm::StringRef Name) {

--- a/lib/CppInterOp/Tracing.h
+++ b/lib/CppInterOp/Tracing.h
@@ -46,6 +46,14 @@
 namespace CppInterOp {
 namespace Tracing {
 
+class TraceInfo;
+
+/// Process-global tracer pointer. Exported because TracingTests and
+/// the crash handler (linked-mode consumers) read it directly; cppyy
+/// and Dispatch.h consumers go through the DispatchRaw trace slots
+/// declared in CppInterOpTypes.h instead.
+extern CPPINTEROP_TRACE_API TraceInfo* TheTraceInfo;
+
 class TraceInfo {
   llvm::TimerGroup m_TG;
   llvm::StringMap<std::unique_ptr<llvm::Timer>> m_Timers;
@@ -206,8 +214,6 @@ public:
     m_OutCount = 0;
     m_OutAliases.clear();
   }
-
-  CPPINTEROP_TRACE_API static TraceInfo* TheTraceInfo;
 };
 
 /// Activate tracing. Called once during process initialization.
@@ -218,16 +224,16 @@ CPPINTEROP_TRACE_API void InitTracing();
 /// it. Returns the path where StopTracing() will write the reproducer.
 /// \param WriteOnStdErr if true, also emit the reproducer to stderr on stop.
 inline std::string StartTracing(bool WriteOnStdErr = true) {
-  if (!TraceInfo::TheTraceInfo)
+  if (!TheTraceInfo)
     InitTracing();
-  return TraceInfo::TheTraceInfo->StartRegion(WriteOnStdErr);
+  return TheTraceInfo->StartRegion(WriteOnStdErr);
 }
 
 /// End the traced region and write the reproducer file containing only the
 /// calls made between StartTracing() and this call.
 inline void StopTracing(const std::string& Version = "") {
-  if (TraceInfo::TheTraceInfo)
-    TraceInfo::TheTraceInfo->StopRegion(Version);
+  if (TheTraceInfo)
+    TheTraceInfo->StopRegion(Version);
 }
 
 /// Marks a function parameter as an output container (e.g. std::vector<T>&
@@ -313,7 +319,7 @@ struct ReproBuffer {
       OS << "nullptr";
       return;
     }
-    auto h = TraceInfo::TheTraceInfo->lookupHandle(p);
+    auto h = TheTraceInfo->lookupHandle(p);
     if (h.empty())
       OS << "nullptr /*unknown*/";
     else
@@ -522,8 +528,7 @@ class TraceRegion {
   /// handle callback still queues so the outer call can resolve names.
   void captureArg(OutParam&& op) {
     if (!m_Data->Nested && op.IsPointerContainer) {
-      auto [idx, firstUse] =
-          TraceInfo::TheTraceInfo->outIndexFor(op.SourceAddr);
+      auto [idx, firstUse] = TheTraceInfo->outIndexFor(op.SourceAddr);
       m_Data->OutIndices.push_back(idx);
       m_Data->OutFirstUse.push_back(firstUse);
     }
@@ -534,11 +539,11 @@ class TraceRegion {
 
 public:
   template <typename... Args> TraceRegion(const char* Name, Args&&... args) {
-    if (!TraceInfo::TheTraceInfo)
+    if (!TheTraceInfo)
       return;
     m_Data = std::make_unique<TraceData>();
     m_Data->Name = Name;
-    TraceInfo& TI = *TraceInfo::TheTraceInfo;
+    TraceInfo& TI = *TheTraceInfo;
     // Detect nesting before pushing this call's frame.
     m_Data->Nested = TI.insideTracedRegion();
     // captureArg before format(): it fills OutIndices that format()
@@ -582,7 +587,7 @@ public:
 
     auto EndTime = llvm::TimeRecord::getCurrentTime(false).getWallTime();
     auto Dur = static_cast<long long>((EndTime - m_Data->StartTime) * 1e9);
-    TraceInfo& TI = *TraceInfo::TheTraceInfo;
+    TraceInfo& TI = *TheTraceInfo;
     TI.popTimer();
 
     // Nested calls don't reach the log -- their args reference
@@ -768,7 +773,7 @@ public:
       // so the per-call cost off-trace is one load + branch. The diagnostic
       // is unconditional; assert() is a no-op in NDEBUG, so Release reports
       // the drift via stderr without aborting.
-      if (TraceInfo::TheTraceInfo) {
+      if (TheTraceInfo) {
         if (auto Expected = lookupOutMask(Name)) {
           uint64_t actual_out = computeOutMask<Args...>();
           if (*Expected != actual_out) {

--- a/unittests/CppInterOp/CMakeLists.txt
+++ b/unittests/CppInterOp/CMakeLists.txt
@@ -102,6 +102,33 @@ endif()
 add_subdirectory(TestSharedLib)
 add_dependencies(DynamicLibraryManagerTests TestSharedLib)
 
+# Downstream-DSO dlopen check that mirrors libcppyy-backend's contract:
+# a SHARED lib using <CppInterOp/Dispatch.h> without linking against
+# clangCppInterOp, dlopen'd by a standalone exec that also doesn't link.
+# Any inline-header UND ref that the host lib can't satisfy at runtime
+# trips here before the cppyy integration job.
+if(NOT EMSCRIPTEN AND BUILD_SHARED_LIBS)
+  add_subdirectory(TestDownstreamLib)
+
+  set(_downstream_lib_path
+    "${CMAKE_CURRENT_BINARY_DIR}/bin/$<CONFIG>/${CMAKE_SHARED_LIBRARY_PREFIX}TestDownstreamLib${CMAKE_SHARED_LIBRARY_SUFFIX}")
+
+  add_executable(TestDownstreamLoader EXCLUDE_FROM_ALL TestDownstreamLoader.cpp)
+  add_dependencies(CppInterOpUnitTests TestDownstreamLoader TestDownstreamLib)
+  target_compile_definitions(TestDownstreamLoader PRIVATE
+    TEST_DOWNSTREAM_LIB_PATH="${_downstream_lib_path}")
+  if(UNIX AND NOT APPLE)
+    target_link_libraries(TestDownstreamLoader PRIVATE dl)
+  endif()
+  set_output_directory(TestDownstreamLoader
+    BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/bin/$<CONFIG>/
+    LIBRARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/bin/$<CONFIG>/
+  )
+  add_test(NAME cppinterop-DownstreamLoaderTest COMMAND TestDownstreamLoader)
+  set_tests_properties(cppinterop-DownstreamLoaderTest PROPERTIES
+    TIMEOUT "${TIMEOUT_VALUE}")
+endif()
+
 # Dispatch Tests.
 # Load libclangCppInterOp via dlopen(RTLD_LOCAL) and must NOT link against it
 # directly, to verify true symbol isolation.

--- a/unittests/CppInterOp/TestDownstreamLib/CMakeLists.txt
+++ b/unittests/CppInterOp/TestDownstreamLib/CMakeLists.txt
@@ -1,0 +1,17 @@
+add_llvm_library(TestDownstreamLib
+  SHARED
+  DISABLE_LLVM_LINK_LLVM_DYLIB
+  BUILDTREE_ONLY
+  TestDownstreamLib.cpp)
+add_dependencies(TestDownstreamLib CppInterOpTableGen)
+# NDEBUG mirrors cppyy's Release build so the JitCall::Invoke asserts
+# don't drag in extra UND refs. target_compile_options so the flag
+# appends after add_llvm_library's `-UNDEBUG`.
+target_compile_options(TestDownstreamLib PRIVATE -DNDEBUG)
+
+set_output_directory(TestDownstreamLib
+  BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/../bin/$<CONFIG>/
+  LIBRARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/../bin/$<CONFIG>/
+)
+
+set_target_properties(TestDownstreamLib PROPERTIES FOLDER "Tests")

--- a/unittests/CppInterOp/TestDownstreamLib/TestDownstreamLib.cpp
+++ b/unittests/CppInterOp/TestDownstreamLib/TestDownstreamLib.cpp
@@ -1,0 +1,14 @@
+#include "TestDownstreamLib.h"
+
+// Dispatch.h is the cppyy-backend consumer entry point; including it
+// selects per-DSO inline DispatchRaw slots.
+#include "CppInterOp/Dispatch.h"
+
+// ODR-uses the inline JitCall fast path. JC is an opaque param so the
+// optimizer can't DCE the calls at any -O level. The body never runs;
+// only the .o's UND-symbol surface matters.
+void downstream_link_probe(CppImpl::JitCall* JC) {
+  JC->Invoke();
+  JC->InvokeConstructor(nullptr);
+  JC->InvokeDestructor(nullptr);
+}

--- a/unittests/CppInterOp/TestDownstreamLib/TestDownstreamLib.h
+++ b/unittests/CppInterOp/TestDownstreamLib/TestDownstreamLib.h
@@ -1,0 +1,17 @@
+#ifndef UNITTESTS_CPPINTEROP_TESTDOWNSTREAMLIB_TESTDOWNSTREAMLIB_H
+#define UNITTESTS_CPPINTEROP_TESTDOWNSTREAMLIB_TESTDOWNSTREAMLIB_H
+
+// Probe entry that ODR-uses the inline JitCall fast path. JC is opaque
+// so the optimizer can't DCE the inlined references at any -O level.
+namespace CppImpl {
+class JitCall;
+}
+#ifdef _WIN32
+extern "C" __declspec(dllexport) void downstream_link_probe(
+    CppImpl::JitCall* JC);
+#else
+extern "C" __attribute__((visibility("default"))) void
+downstream_link_probe(CppImpl::JitCall* JC);
+#endif
+
+#endif // UNITTESTS_CPPINTEROP_TESTDOWNSTREAMLIB_TESTDOWNSTREAMLIB_H

--- a/unittests/CppInterOp/TestDownstreamLoader.cpp
+++ b/unittests/CppInterOp/TestDownstreamLoader.cpp
@@ -1,0 +1,38 @@
+// dlopens TestDownstreamLib without linking libclangCppInterOp -- the
+// same loader posture cppyy_backend.loader uses. Exit status is what
+// ctest checks; any unsatisfied UND on the probe trips here.
+
+#include <cstdio>
+#include <cstdlib>
+
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <dlfcn.h>
+#endif
+
+#ifndef TEST_DOWNSTREAM_LIB_PATH
+#error "TEST_DOWNSTREAM_LIB_PATH must be defined"
+#endif
+
+int main() {
+#ifdef _WIN32
+  HMODULE h = LoadLibraryA(TEST_DOWNSTREAM_LIB_PATH);
+  if (!h) {
+    std::fprintf(stderr, "LoadLibrary(%s) failed: %lu\n",
+                 TEST_DOWNSTREAM_LIB_PATH,
+                 static_cast<unsigned long>(GetLastError()));
+    return 1;
+  }
+  FreeLibrary(h);
+#else
+  void* h = dlopen(TEST_DOWNSTREAM_LIB_PATH, RTLD_NOW | RTLD_LOCAL);
+  if (!h) {
+    std::fprintf(stderr, "dlopen(%s) failed: %s\n", TEST_DOWNSTREAM_LIB_PATH,
+                 dlerror());
+    return 1;
+  }
+  dlclose(h);
+#endif
+  return 0;
+}

--- a/unittests/CppInterOp/TracingTests.cpp
+++ b/unittests/CppInterOp/TracingTests.cpp
@@ -21,7 +21,7 @@ using ::testing::Not;
 // Helper: join the full trace log into a single string for matching.
 static std::string getFullLog() {
   std::string result;
-  for (const auto& entry : TraceInfo::TheTraceInfo->getLog())
+  for (const auto& entry : TheTraceInfo->getLog())
     result += entry + "\n";
   return result;
 }
@@ -40,9 +40,9 @@ protected:
     GTEST_FLAG_SET(death_test_style, saved_death_test_style_);
   }
   void SetUp() override {
-    if (TraceInfo::TheTraceInfo)
-      TraceInfo::TheTraceInfo->clear();
-    TraceInfo::TheTraceInfo = nullptr;
+    if (TheTraceInfo)
+      TheTraceInfo->clear();
+    TheTraceInfo = nullptr;
     InitTracing();
   }
 
@@ -54,7 +54,7 @@ std::string TracingTest::saved_death_test_style_;
 
 class NoTracingTest : public ::testing::Test {
 protected:
-  void SetUp() override { TraceInfo::TheTraceInfo = nullptr; }
+  void SetUp() override { TheTraceInfo = nullptr; }
 };
 
 // ---------------------------------------------------------------------------
@@ -191,7 +191,7 @@ intptr_t ScalarOutDummy(const char* code, bool* err) {
 TEST_F(TracingTest, ScalarPointerOutRendersAsNullptr) {
   bool err = true;
   EXPECT_EQ(ScalarOutDummy("x", &err), 42);
-  auto output = TraceInfo::TheTraceInfo->getLastLogEntry();
+  auto output = TheTraceInfo->getLastLogEntry();
   EXPECT_THAT(output, HasSubstr("Cpp::ScalarOutDummy(\"x\", nullptr)"));
 }
 
@@ -217,7 +217,7 @@ TEST_F(TracingTest, ValidAnnotatedBranch) {
 
 TEST_F(TracingTest, VoidFunctionTracing) {
   VoidFunc();
-  auto output = TraceInfo::TheTraceInfo->getLastLogEntry();
+  auto output = TheTraceInfo->getLastLogEntry();
   EXPECT_THAT(output, HasSubstr("Cpp::VoidFunc();"));
 }
 
@@ -238,7 +238,7 @@ void WithOutParamTrace(std::vector<void*>& out) {
 
 TEST_F(TracingTest, TraceWithNoArgs) {
   NoArgTrace();
-  auto output = TraceInfo::TheTraceInfo->getLastLogEntry();
+  auto output = TheTraceInfo->getLastLogEntry();
   EXPECT_THAT(output, HasSubstr("Cpp::NoArgTrace();"));
 }
 
@@ -305,7 +305,7 @@ TEST_F(TracingTest, ArgFormattingUnregisteredHandleAnnotated) {
   // 0xDEADBEEF is unsigned int (>= 2^31) -- cast through uintptr_t
   // to keep MSVC's C4312 silent on 64-bit, where void* is wider.
   FuncTakingHandle(reinterpret_cast<void*>(static_cast<uintptr_t>(0xDEADBEEF)));
-  auto output = TraceInfo::TheTraceInfo->getLastLogEntry();
+  auto output = TheTraceInfo->getLastLogEntry();
   EXPECT_THAT(output, HasSubstr("Cpp::FuncTakingHandle(nullptr /*unknown*/)"));
 }
 
@@ -314,7 +314,7 @@ TEST_F(TracingTest, ArgFormattingNullHandlePlain) {
   // /*unknown*/ annotation, which is reserved for unregistered
   // non-null pointers.
   FuncTakingHandle(nullptr);
-  auto output = TraceInfo::TheTraceInfo->getLastLogEntry();
+  auto output = TheTraceInfo->getLastLogEntry();
   EXPECT_THAT(output, HasSubstr("Cpp::FuncTakingHandle(nullptr)"));
   EXPECT_THAT(output, Not(HasSubstr("/*unknown*/")));
 }
@@ -324,7 +324,7 @@ TEST_F(TracingTest, ArgFormattingString) {
   // raw-literal form is reserved for content that would mis-encode as
   // a plain literal (see ArgFormattingString* tests below).
   FuncTakingString("hello");
-  auto output = TraceInfo::TheTraceInfo->getLastLogEntry();
+  auto output = TheTraceInfo->getLastLogEntry();
   EXPECT_THAT(output, HasSubstr("Cpp::FuncTakingString(\"hello\")"));
 }
 
@@ -332,7 +332,7 @@ TEST_F(TracingTest, ArgFormattingEmptyStringIsPlain) {
   // Empty string takes the no-special-char branch -- emit `""` rather
   // than `R"CPPI()CPPI"`.
   FuncTakingString("");
-  auto output = TraceInfo::TheTraceInfo->getLastLogEntry();
+  auto output = TheTraceInfo->getLastLogEntry();
   EXPECT_THAT(output, HasSubstr("Cpp::FuncTakingString(\"\")"));
   EXPECT_THAT(output, Not(HasSubstr("R\"CPPI(")));
 }
@@ -341,7 +341,7 @@ TEST_F(TracingTest, ArgFormattingStringWithEmbeddedDoubleQuote) {
   // Double quote forces the raw-literal fallback -- a plain `"..."`
   // would terminate the string at the embedded quote.
   FuncTakingString("a\"b");
-  auto output = TraceInfo::TheTraceInfo->getLastLogEntry();
+  auto output = TheTraceInfo->getLastLogEntry();
   EXPECT_THAT(output, HasSubstr("R\"CPPI(a\"b)CPPI\""));
 }
 
@@ -349,7 +349,7 @@ TEST_F(TracingTest, ArgFormattingStringWithEmbeddedBackslash) {
   // Backslash forces raw-literal -- in a plain literal it would start
   // an escape sequence.
   FuncTakingString("a\\b");
-  auto output = TraceInfo::TheTraceInfo->getLastLogEntry();
+  auto output = TheTraceInfo->getLastLogEntry();
   EXPECT_THAT(output, HasSubstr("R\"CPPI(a\\b)CPPI\""));
 }
 
@@ -357,7 +357,7 @@ TEST_F(TracingTest, ArgFormattingStringWithControlChar) {
   // Newline (a control char, < 0x20) forces raw-literal so the line
   // doesn't get split mid-string in the reproducer.
   FuncTakingString("a\nb");
-  auto output = TraceInfo::TheTraceInfo->getLastLogEntry();
+  auto output = TheTraceInfo->getLastLogEntry();
   EXPECT_THAT(output, HasSubstr("R\"CPPI(a\nb)CPPI\""));
 }
 
@@ -366,7 +366,7 @@ TEST_F(TracingTest, ArgFormattingMultiLineStringUsesRawLiteral) {
   // have several embedded newlines; raw-literal preserves the layout
   // verbatim so the reproducer compiles unchanged.
   FuncTakingString("void f() {\n  return 42;\n}\n");
-  auto output = TraceInfo::TheTraceInfo->getLastLogEntry();
+  auto output = TheTraceInfo->getLastLogEntry();
   EXPECT_THAT(output,
               HasSubstr("R\"CPPI(void f() {\n  return 42;\n}\n)CPPI\""));
 }
@@ -376,7 +376,7 @@ TEST_F(TracingTest, ArgFormattingStringWithHighBitStaysPlain) {
   // plain-literal path -- the source bytes pass through unchanged and
   // the reproducer compiles with the same encoding.
   FuncTakingString("r\xc3\xa9sum\xc3\xa9"); // "résumé" in UTF-8
-  auto output = TraceInfo::TheTraceInfo->getLastLogEntry();
+  auto output = TheTraceInfo->getLastLogEntry();
   EXPECT_THAT(output,
               HasSubstr("Cpp::FuncTakingString(\"r\xc3\xa9sum\xc3\xa9\")"));
   EXPECT_THAT(output, Not(HasSubstr("R\"CPPI(")));
@@ -384,7 +384,7 @@ TEST_F(TracingTest, ArgFormattingStringWithHighBitStaysPlain) {
 
 TEST_F(TracingTest, ArgFormattingInt) {
   FuncTakingInt(42);
-  auto output = TraceInfo::TheTraceInfo->getLastLogEntry();
+  auto output = TheTraceInfo->getLastLogEntry();
   EXPECT_THAT(output, HasSubstr("Cpp::FuncTakingInt(42)"));
 }
 
@@ -462,7 +462,7 @@ TEST_F(TracingTest, OutParamElementUsableInLaterCall) {
   auto output = getFullLog();
   // The element's decl reads `_out0[0]` and binds a handle name (vN);
   // the downstream call references the same name.
-  TraceInfo& TI = *TraceInfo::TheTraceInfo;
+  TraceInfo& TI = *TheTraceInfo;
   std::string elem = TI.lookupHandle(out[0]);
   ASSERT_FALSE(elem.empty());
   EXPECT_THAT(output,
@@ -511,7 +511,7 @@ void* ReturnNull() {
 
 TEST_F(TracingTest, NullptrReturnAnnotated) {
   ReturnNull();
-  auto output = TraceInfo::TheTraceInfo->getLastLogEntry();
+  auto output = TheTraceInfo->getLastLogEntry();
   EXPECT_THAT(output, HasSubstr("/*nullptr*/"));
   EXPECT_THAT(output, HasSubstr("Cpp::ReturnNull()"));
 }
@@ -525,7 +525,7 @@ int ReturnInt() {
 
 TEST_F(TracingTest, NonPointerReturnNoAnnotation) {
   ReturnInt();
-  auto output = TraceInfo::TheTraceInfo->getLastLogEntry();
+  auto output = TheTraceInfo->getLastLogEntry();
   EXPECT_THAT(output, Not(HasSubstr("auto")));
   EXPECT_THAT(output, Not(HasSubstr("nullptr")));
   EXPECT_THAT(output, HasSubstr("Cpp::ReturnInt()"));
@@ -554,7 +554,7 @@ TEST_F(TracingTest, ArgFormattingVectorOfStrings) {
   // and the const-char* overload of append (plain-quote form).
   std::vector<const char*> v = {"a", "b"};
   FuncTakingStrVector(v);
-  auto output = TraceInfo::TheTraceInfo->getLastLogEntry();
+  auto output = TheTraceInfo->getLastLogEntry();
   EXPECT_THAT(output, HasSubstr("Cpp::FuncTakingStrVector({\"a\", \"b\"})"));
 }
 
@@ -562,7 +562,7 @@ TEST_F(TracingTest, ArgFormattingVectorOfInts) {
   // Pins the integer-element path through append(int).
   std::vector<int> v = {1, 2, 3};
   FuncTakingIntVector(v);
-  auto output = TraceInfo::TheTraceInfo->getLastLogEntry();
+  auto output = TheTraceInfo->getLastLogEntry();
   EXPECT_THAT(output, HasSubstr("Cpp::FuncTakingIntVector({1, 2, 3})"));
 }
 
@@ -571,7 +571,7 @@ TEST_F(TracingTest, ArgFormattingEmptyVector) {
   // the First-flag branch where it never flips.
   std::vector<int> v;
   FuncTakingIntVector(v);
-  auto output = TraceInfo::TheTraceInfo->getLastLogEntry();
+  auto output = TheTraceInfo->getLastLogEntry();
   EXPECT_THAT(output, HasSubstr("Cpp::FuncTakingIntVector({})"));
 }
 
@@ -580,7 +580,7 @@ TEST_F(TracingTest, ArgFormattingNestedVector) {
   // append(vector<int>) for each element.
   std::vector<std::vector<int>> v = {{1, 2}, {3}};
   FuncTakingNestedVector(v);
-  auto output = TraceInfo::TheTraceInfo->getLastLogEntry();
+  auto output = TheTraceInfo->getLastLogEntry();
   EXPECT_THAT(output, HasSubstr("Cpp::FuncTakingNestedVector({{1, 2}, {3}})"));
 }
 
@@ -617,7 +617,7 @@ TEST_F(TracingTest, ReturnedPointerVectorProducerAndConsumer) {
   // one of those pointers prints it by the same handle name (vN), so
   // the reproducer's producing line and the consumer's argument refer
   // to the same binding.
-  TraceInfo& TI = *TraceInfo::TheTraceInfo;
+  TraceInfo& TI = *TheTraceInfo;
   auto v = ReturnPointerVector();
   std::string h0 = TI.lookupHandle(v[0]);
   std::string h1 = TI.lookupHandle(v[1]);
@@ -638,12 +638,12 @@ TEST_F(TracingTest, ReturnedPointerVectorEmptyEmitsNoDecls) {
   // Empty vector returns the placeholder + zero element decls. The
   // RetDecls loop never appends, so the only log line for this call is
   // the call itself.
-  size_t before = TraceInfo::TheTraceInfo->getLog().size();
+  size_t before = TheTraceInfo->getLog().size();
   ReturnEmptyPointerVector();
-  size_t after = TraceInfo::TheTraceInfo->getLog().size();
+  size_t after = TheTraceInfo->getLog().size();
   EXPECT_EQ(after - before, 1u)
       << "Empty vector return should emit only the call line, no element decls";
-  auto output = TraceInfo::TheTraceInfo->getLastLogEntry();
+  auto output = TheTraceInfo->getLastLogEntry();
   EXPECT_THAT(output,
               HasSubstr("auto _ret0 = Cpp::ReturnEmptyPointerVector()"));
 }
@@ -698,7 +698,7 @@ TEST_F(TracingTest, ArgFormattingEnumStaticCast) {
   // "static_cast<EnumName>(N)" so the reproducer compiles. Used to
   // emit "?" via the catch-all template.
   FuncTakingEnum(tracing_test_enum::Blue);
-  auto output = TraceInfo::TheTraceInfo->getLastLogEntry();
+  auto output = TheTraceInfo->getLastLogEntry();
   EXPECT_THAT(output, HasSubstr("static_cast<"));
   EXPECT_THAT(output, HasSubstr("Flavor"));
   EXPECT_THAT(output, HasSubstr(">(3)"));
@@ -715,7 +715,7 @@ TEST_F(TracingTest, ArgFormattingStringEscapes) {
   // quotes, and backslashes flow through verbatim and the reproducer
   // compiles without a separate escape pass.
   FuncTakingTrickyString("line1\nline2\twith \"quotes\" and a \\backslash");
-  auto output = TraceInfo::TheTraceInfo->getLastLogEntry();
+  auto output = TheTraceInfo->getLastLogEntry();
   EXPECT_THAT(output, HasSubstr("R\"CPPI("));
   EXPECT_THAT(output, HasSubstr(")CPPI\""));
   // Verbatim content survives -- the raw literal preserves the
@@ -748,7 +748,7 @@ TEST_F(TracingTest, ArgFormattingConstVoidHandle) {
 TEST_F(TracingTest, ArgFormattingConstVoidNullptr) {
   // null const void* must emit literal nullptr, not the empty handle name.
   FuncTakingConstHandle(nullptr);
-  auto output = TraceInfo::TheTraceInfo->getLastLogEntry();
+  auto output = TheTraceInfo->getLastLogEntry();
   EXPECT_THAT(output, HasSubstr("Cpp::FuncTakingConstHandle(nullptr)"));
 }
 
@@ -760,12 +760,12 @@ void FuncTakingTemplateArg(Cpp::TemplateArgInfo tai) {
 TEST_F(TracingTest, ArgFormattingTemplateArgInfoTypeAndIntegralValue) {
   // m_Type renders as the registered handle name; m_IntegralValue
   // takes the raw-string path.
-  TraceInfo& TI = *TraceInfo::TheTraceInfo;
+  TraceInfo& TI = *TheTraceInfo;
   void* tp = reinterpret_cast<void*>(static_cast<uintptr_t>(0x12340000));
   std::string h = TI.getOrRegisterHandle(tp);
   Cpp::TemplateArgInfo tai{tp, "5"};
   FuncTakingTemplateArg(tai);
-  auto output = TraceInfo::TheTraceInfo->getLastLogEntry();
+  auto output = TheTraceInfo->getLastLogEntry();
   EXPECT_THAT(output, HasSubstr("Cpp::FuncTakingTemplateArg(Cpp::"
                                 "TemplateArgInfo{" +
                                 h + ", \"5\"})"));
@@ -776,7 +776,7 @@ TEST_F(TracingTest, ArgFormattingTemplateArgInfoNullFields) {
   // constructor's default), not the empty string `""`.
   Cpp::TemplateArgInfo tai{nullptr, nullptr};
   FuncTakingTemplateArg(tai);
-  auto output = TraceInfo::TheTraceInfo->getLastLogEntry();
+  auto output = TheTraceInfo->getLastLogEntry();
   EXPECT_THAT(output, HasSubstr("Cpp::FuncTakingTemplateArg(Cpp::"
                                 "TemplateArgInfo{nullptr, nullptr})"));
 }
@@ -786,7 +786,7 @@ TEST_F(TracingTest, ArgFormattingTemplateArgInfoNullFields) {
 // ---------------------------------------------------------------------------
 
 TEST_F(TracingTest, HandleRegistry) {
-  TraceInfo& TI = *TraceInfo::TheTraceInfo;
+  TraceInfo& TI = *TheTraceInfo;
   void* ptr1 = (void*)0x1234;
   void* ptr2 = (void*)0x5678;
 
@@ -818,7 +818,7 @@ TEST_F(TracingTest, HandleRegistry) {
 // ---------------------------------------------------------------------------
 
 TEST_F(TracingTest, TimerStackPushPop) {
-  TraceInfo& TI = *TraceInfo::TheTraceInfo;
+  TraceInfo& TI = *TheTraceInfo;
 
   llvm::Timer& T1 = TI.getTimer("FuncA");
   llvm::Timer& T2 = TI.getTimer("FuncB");
@@ -846,7 +846,7 @@ TEST_F(TracingTest, TimerStackPushPop) {
 }
 
 TEST_F(TracingTest, ClearWithRunningTimers) {
-  TraceInfo& TI = *TraceInfo::TheTraceInfo;
+  TraceInfo& TI = *TheTraceInfo;
 
   llvm::Timer& T1 = TI.getTimer("RunningTimer");
   TI.pushTimer(&T1);
@@ -863,19 +863,19 @@ TEST_F(TracingTest, ClearWithRunningTimers) {
 
 TEST(StartTracingActivation, ActivatesIfNotActive) {
   // Save and clear TheTraceInfo to simulate tracing not being active.
-  auto* saved = TraceInfo::TheTraceInfo;
-  TraceInfo::TheTraceInfo = nullptr;
+  auto* saved = TheTraceInfo;
+  TheTraceInfo = nullptr;
 
   // StartTracing should call InitTracing (covers line 151).
   std::string Path = CppInterOp::Tracing::StartTracing(/*WriteOnStdErr=*/false);
-  ASSERT_NE(TraceInfo::TheTraceInfo, nullptr);
+  ASSERT_NE(TheTraceInfo, nullptr);
   ASSERT_FALSE(Path.empty());
 
   CppInterOp::Tracing::StopTracing();
   llvm::sys::fs::remove(Path);
 
   // Restore so other tests aren't affected.
-  TraceInfo::TheTraceInfo = saved;
+  TheTraceInfo = saved;
 }
 
 // ---------------------------------------------------------------------------
@@ -933,7 +933,7 @@ TEST_F(TracingTest, NestedCallSuppressedButHandleRegistered) {
   // registered so the outer call's `auto vN = ...` line binds the
   // pointer the inner produced.
   void* h = NestedOuterReturn();
-  TraceInfo& TI = *TraceInfo::TheTraceInfo;
+  TraceInfo& TI = *TheTraceInfo;
   EXPECT_FALSE(TI.lookupHandle(h).empty());
   auto output = getFullLog();
   EXPECT_THAT(output, HasSubstr("auto v1 = Cpp::NestedOuterReturn()"));
@@ -971,7 +971,7 @@ TEST_F(TracingTest, NestedSuppressionDoesNotLeakOutCounter) {
 void PlaceholderProbe() {
   INTEROP_TRACE();
   // Mid-call: the ctor-emitted placeholder is already in the log.
-  auto& log = TraceInfo::TheTraceInfo->getLog();
+  auto& log = TheTraceInfo->getLog();
   ASSERT_FALSE(log.empty());
   EXPECT_THAT(log.back(), HasSubstr("Cpp::PlaceholderProbe"));
   EXPECT_THAT(log.back(), HasSubstr("[aborted before return]"));
@@ -983,7 +983,7 @@ TEST_F(TracingTest, PlaceholderInCtorReplacedByDtor) {
   // verify the replacement: after the call returns, the slot reads
   // the completed `// [N ns]` line, not the placeholder.
   PlaceholderProbe();
-  auto& log = TraceInfo::TheTraceInfo->getLog();
+  auto& log = TheTraceInfo->getLog();
   ASSERT_FALSE(log.empty());
   EXPECT_THAT(log.back(), Not(HasSubstr("aborted before return")));
   EXPECT_THAT(log.back(),
@@ -995,7 +995,7 @@ TEST_F(TracingTest, PlaceholderInCtorReplacedByDtor) {
 // ---------------------------------------------------------------------------
 
 TEST_F(TracingTest, OutParamRegistersHandles) {
-  TraceInfo& TI = *TraceInfo::TheTraceInfo;
+  TraceInfo& TI = *TheTraceInfo;
 
   std::vector<void*> results;
   FillHandles(results);
@@ -1007,7 +1007,7 @@ TEST_F(TracingTest, OutParamRegistersHandles) {
 }
 
 TEST_F(TracingTest, OutParamHandlesUsableInLaterCalls) {
-  TraceInfo& TI = *TraceInfo::TheTraceInfo;
+  TraceInfo& TI = *TheTraceInfo;
 
   std::vector<void*> results;
   FillHandles(results);
@@ -1068,7 +1068,7 @@ TEST_F(TracingTest, WriteToFileProducesValidReproducer) {
     return INTEROP_VOID_RETURN();
   }
 
-  TraceInfo& TI = *TraceInfo::TheTraceInfo;
+  TraceInfo& TI = *TheTraceInfo;
   std::string Path = TI.writeToFile();
   ASSERT_FALSE(Path.empty());
 
@@ -1098,7 +1098,7 @@ TEST_F(TracingTest, WriteToFileContainsOutParamCalls) {
   std::vector<void*> results;
   FillHandles(results);
 
-  TraceInfo& TI = *TraceInfo::TheTraceInfo;
+  TraceInfo& TI = *TheTraceInfo;
   std::string Path = TI.writeToFile();
   ASSERT_FALSE(Path.empty());
 
@@ -1119,7 +1119,7 @@ TEST_F(TracingTest, WriteToFileSuppressesSelfTrace) {
   AnnotatedFunction(7);
   AnnotatedFunction(8);
 
-  TraceInfo& TI = *TraceInfo::TheTraceInfo;
+  TraceInfo& TI = *TheTraceInfo;
   size_t before = TI.getLog().size();
   std::string Path = TI.writeToFile();
   ASSERT_FALSE(Path.empty());
@@ -1145,11 +1145,11 @@ TEST_F(TracingTest, ReproducerCompilesViaInterpreter) {
   Cpp::CreateInterpreter({});
 
   // Verify tracing is active after interpreter creation.
-  ASSERT_NE(TraceInfo::TheTraceInfo, nullptr)
+  ASSERT_NE(TheTraceInfo, nullptr)
       << "TheTraceInfo was cleared during CreateInterpreter";
 
   // Clear any prior trace state so the reproducer only contains our calls.
-  TraceInfo::TheTraceInfo->clear();
+  TheTraceInfo->clear();
 
   // Exercise real API calls that will be recorded.
   auto GlobalScope = Cpp::GetGlobalScope();
@@ -1173,7 +1173,7 @@ TEST_F(TracingTest, ReproducerCompilesViaInterpreter) {
   Cpp::SizeOf(Foo);
 
   // Write the reproducer.
-  TraceInfo& TI = *TraceInfo::TheTraceInfo;
+  TraceInfo& TI = *TheTraceInfo;
   std::string Path = TI.writeToFile();
   ASSERT_FALSE(Path.empty());
 
@@ -1219,7 +1219,7 @@ TEST_F(TracingTest, JitCallWrapperSourceLogged) {
 #endif
 #endif
   Cpp::CreateInterpreter({});
-  ASSERT_NE(TraceInfo::TheTraceInfo, nullptr);
+  ASSERT_NE(TheTraceInfo, nullptr);
 
   // Placement new requires <new>.
   Cpp::Declare("#include <new>");
@@ -1228,7 +1228,7 @@ TEST_F(TracingTest, JitCallWrapperSourceLogged) {
       static_cast<void*>(Cpp::GetNamed("add", Cpp::GetScope("WrapNS")));
   ASSERT_NE(Func, nullptr);
 
-  TraceInfo::TheTraceInfo->clear();
+  TheTraceInfo->clear();
 
   // MakeFunctionCallable triggers make_wrapper which logs the wrapper source.
   auto JC = Cpp::MakeFunctionCallable(Func);
@@ -1244,7 +1244,7 @@ TEST_F(TracingTest, JitCallWrapperSourceLogged) {
 #ifndef NDEBUG
 TEST_F(TracingTest, JitCallInvokeLogged) {
   Cpp::CreateInterpreter({});
-  ASSERT_NE(TraceInfo::TheTraceInfo, nullptr);
+  ASSERT_NE(TheTraceInfo, nullptr);
 
   Cpp::Declare("#include <new>");
   Cpp::Declare("namespace InvNS { int square(int x) { return x * x; } }");
@@ -1256,7 +1256,7 @@ TEST_F(TracingTest, JitCallInvokeLogged) {
   ASSERT_TRUE(JC.isValid());
 
   // Clear so only the Invoke shows up.
-  TraceInfo::TheTraceInfo->clear();
+  TheTraceInfo->clear();
 
   int arg = 7;
   int result = 0;
@@ -1272,12 +1272,79 @@ TEST_F(TracingTest, JitCallInvokeLogged) {
   // And the function should have actually executed.
   EXPECT_EQ(result, 49);
 }
+
+TEST_F(TracingTest, JitCallConstructorInvokeLogged) {
+  // Pins the InvokeConstructor inline-guard: ReportInvokeStart must fire
+  // for kConstructorCall just as it does for kGenericCall.
+  Cpp::CreateInterpreter({});
+  ASSERT_NE(TheTraceInfo, nullptr);
+
+  Cpp::Declare("#include <new>");
+  Cpp::Declare("namespace InvCtorNS { struct Bar { int x = 7; }; }");
+  auto* ClassBar = Cpp::GetScope("Bar", Cpp::GetScope("InvCtorNS"));
+  ASSERT_NE(ClassBar, nullptr);
+  auto* CtorD = Cpp::GetDefaultConstructor(ClassBar);
+  ASSERT_NE(CtorD, nullptr);
+  // Resolve the dtor up-front so the cleanup at the end of the test
+  // can free the heap-allocated Bar (LeakSanitizer otherwise flags
+  // the 4-byte `int x` payload).
+  auto* DtorD = Cpp::GetDestructor(ClassBar);
+  ASSERT_NE(DtorD, nullptr);
+
+  auto CtorJC = Cpp::MakeFunctionCallable(CtorD);
+  auto DtorJC = Cpp::MakeFunctionCallable(DtorD);
+  ASSERT_TRUE(CtorJC.isValid());
+  ASSERT_TRUE(DtorJC.isValid());
+
+  TheTraceInfo->clear();
+  void* obj = nullptr;
+  CtorJC.Invoke(&obj);
+  ASSERT_NE(obj, nullptr);
+
+  auto log = getFullLog();
+  EXPECT_THAT(log, HasSubstr("JitCall::Invoke"));
+  EXPECT_THAT(log, HasSubstr("Bar"));
+
+  DtorJC.Invoke(obj);
+}
+
+TEST_F(TracingTest, JitCallDestructorInvokeLogged) {
+  // Pins the InvokeDestructor inline-guard: ReportInvokeStart must emit
+  // a JitCall::InvokeDestructor line for the dtor path.
+  Cpp::CreateInterpreter({});
+  ASSERT_NE(TheTraceInfo, nullptr);
+
+  Cpp::Declare("#include <new>");
+  Cpp::Declare("namespace InvDtorNS { struct Baz { ~Baz() {} }; }");
+  auto* ClassBaz = Cpp::GetScope("Baz", Cpp::GetScope("InvDtorNS"));
+  ASSERT_NE(ClassBaz, nullptr);
+  auto* CtorD = Cpp::GetDefaultConstructor(ClassBaz);
+  ASSERT_NE(CtorD, nullptr);
+  auto* DtorD = Cpp::GetDestructor(ClassBaz);
+  ASSERT_NE(DtorD, nullptr);
+
+  auto CtorJC = Cpp::MakeFunctionCallable(CtorD);
+  auto DtorJC = Cpp::MakeFunctionCallable(DtorD);
+  ASSERT_TRUE(CtorJC.isValid());
+  ASSERT_TRUE(DtorJC.isValid());
+
+  void* obj = nullptr;
+  CtorJC.Invoke(&obj);
+  ASSERT_NE(obj, nullptr);
+
+  TheTraceInfo->clear();
+  DtorJC.Invoke(obj);
+
+  auto log = getFullLog();
+  EXPECT_THAT(log, HasSubstr("JitCall::InvokeDestructor"));
+  EXPECT_THAT(log, HasSubstr("Baz"));
+}
 #endif
 
 // Verify that log entries include timing annotations.
 TEST_F(TracingTest, LogEntriesIncludeTimingAnnotation) {
   VoidFunc();
-  auto output = TraceInfo::TheTraceInfo->getLastLogEntry();
+  auto output = TheTraceInfo->getLastLogEntry();
   EXPECT_THAT(output, HasSubstr("// ["));
   EXPECT_THAT(output, HasSubstr("ns]"));
 }
@@ -1346,7 +1413,7 @@ TEST_F(TracingTest, OnlyRegionCallsAreRecorded) {
 TEST_F(TracingTest, StartTracingWithEnvVarNarrowsToRegion) {
   // When CPPINTEROP_LOG=1 is set (tracing already active from SetUp),
   // StartTracing/StopTracing should still narrow to just the region.
-  ASSERT_NE(TraceInfo::TheTraceInfo, nullptr);
+  ASSERT_NE(TheTraceInfo, nullptr);
 
   // This call is before the region.
   VoidFunc();
@@ -1512,4 +1579,5 @@ TEST(TracingCoverageTest, AllPublicAPIsAreTraced) {
     FAIL() << Msg;
   }
 }
+
 #endif // !EMSCRIPTEN


### PR DESCRIPTION
JitCall::Invoke fires from the cppyy/Python hot path. The ReportInvokeStart trace hooks were entirely #ifndef-NDEBUG'd out, so JIT-driven calls left no annotation in Release captures. Lifting that gate would otherwise pay an unconditional indirect call per Invoke (plus name lookup and llvm::formatv inside the body before any TraceInfo check) -- a price the hot path does not tolerate.

Move the tracing-active check inline at every Invoke site: `if (CppInterOp::Tracing::TheTraceInfo) ReportInvokeStart(...)`. To let the public CppInterOpTypes.h read TheTraceInfo without including Tracing.h, promote it from a static member of TraceInfo to a namespace-scope extern, with a forward decl in CppInterOpTypes.h. The ReportInvokeStart bodies now assume tracing is active and assert it, so the inner null-check disappears. Off-trace cost reduces to one global load + branch.

All `TraceInfo::TheTraceInfo` references rename to namespace-scope `TheTraceInfo` (or `Tracing::TheTraceInfo` outside the namespace) -- mechanical, NFC. Release captures now include `// JitCall::Invoke ...` lines that the parent commit reproducer prologue already documents.

# Description

Please include a summary of changes, motivation and context for this PR.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [ ] I have read the contribution guide recently
