### PR TITLE
Preserve using-declaration access for inherited methods

### DIFF
--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -1021,6 +1021,27 @@ static const clang::Decl* GetUnderlyingScopeImpl(const clang::Decl* D) {
   return D->getCanonicalDecl();
 }
 
+// If D is a UsingShadowDecl whose target is a function-like decl,
+// return that target; otherwise return D unchanged. The using-shadow
+// is the only carrier of the "effective access" introduced into the
+// derived class, so callers that need access info should consult D
+// before unwrapping.
+static clang::Decl* UnwrapUsingShadowToFunction(clang::Decl* D) {
+  if (auto* USD = dyn_cast_or_null<UsingShadowDecl>(D))
+    if (auto* Target = USD->getTargetDecl())
+      if (isa<FunctionDecl>(Target) || isa<FunctionTemplateDecl>(Target))
+        return Target;
+  return D;
+}
+
+static const clang::Decl* UnwrapUsingShadowToFunction(const clang::Decl* D) {
+  if (const auto* USD = dyn_cast_or_null<UsingShadowDecl>(D))
+    if (const auto* Target = USD->getTargetDecl())
+      if (isa<FunctionDecl>(Target) || isa<FunctionTemplateDecl>(Target))
+        return Target;
+  return D;
+}
+
 DeclRef GetUnderlyingScope(ConstDeclRef DRef) {
   INTEROP_TRACE(DRef);
   if (!DRef)
@@ -1408,7 +1429,10 @@ static void GetClassDecls(ConstDeclRef DRef, std::vector<HandleType>& methods) {
 
       auto* CUSD = dyn_cast<ConstructorUsingShadowDecl>(DI);
       if (!CUSD) {
-        methods.push_back(MD);
+        // Push the using-shadow rather than the target so that the
+        // effective access (USD->getAccess()) reachable from the
+        // introducing class is preserved for downstream consumers.
+        methods.push_back(USD);
         continue;
       }
 
@@ -1549,7 +1573,7 @@ std::vector<FuncRef> GetFunctionsUsingName(ConstDeclRef DRef,
 
 TypeRef GetFunctionReturnType(ConstFuncRef func) {
   INTEROP_TRACE(func);
-  const auto* D = unwrap<clang::Decl>(func);
+  const auto* D = UnwrapUsingShadowToFunction(unwrap<clang::Decl>(func));
   if (const auto* FD = llvm::dyn_cast_or_null<clang::FunctionDecl>(D)) {
     QualType Type = FD->getReturnType();
     if (Type->isUndeducedAutoType()) {
@@ -1604,7 +1628,7 @@ void GetFnTypeSignature(ConstTypeRef fn_type, std::vector<TypeRef>& sig) {
 // exclude it, which is what callers introspecting the argument list want.
 size_t GetFunctionNumArgs(ConstFuncRef func) {
   INTEROP_TRACE(func);
-  const auto* D = unwrap<clang::Decl>(func);
+  const auto* D = UnwrapUsingShadowToFunction(unwrap<clang::Decl>(func));
   if (const auto* FD = llvm::dyn_cast_or_null<FunctionDecl>(D))
     return INTEROP_RETURN(FD->getNumNonObjectParams());
 
@@ -1616,7 +1640,7 @@ size_t GetFunctionNumArgs(ConstFuncRef func) {
 
 size_t GetFunctionRequiredArgs(ConstFuncRef func) {
   INTEROP_TRACE(func);
-  const auto* D = unwrap<clang::Decl>(func);
+  const auto* D = UnwrapUsingShadowToFunction(unwrap<clang::Decl>(func));
   if (const auto* FD = llvm::dyn_cast_or_null<FunctionDecl>(D))
     return INTEROP_RETURN(FD->getMinRequiredExplicitArguments());
 
@@ -1629,7 +1653,7 @@ size_t GetFunctionRequiredArgs(ConstFuncRef func) {
 
 TypeRef GetFunctionArgType(ConstFuncRef func, size_t iarg) {
   INTEROP_TRACE(func, iarg);
-  const auto* D = unwrap<clang::Decl>(func);
+  const auto* D = UnwrapUsingShadowToFunction(unwrap<clang::Decl>(func));
 
   if (const auto* FTD = llvm::dyn_cast_or_null<clang::FunctionTemplateDecl>(D))
     D = FTD->getTemplatedDecl();
@@ -1655,7 +1679,7 @@ std::string GetFunctionSignature(ConstFuncRef func) {
   if (!func)
     return INTEROP_RETURN("<unknown>");
 
-  const auto* D = unwrap<clang::Decl>(func);
+  const auto* D = UnwrapUsingShadowToFunction(unwrap<clang::Decl>(func));
   const clang::FunctionDecl* FD;
 
   if (llvm::dyn_cast<FunctionDecl>(D))
@@ -1700,13 +1724,14 @@ bool IsTemplateInstantiationOrSpecialization(const Decl* D) {
 
 bool IsFunctionDeleted(ConstFuncRef function) {
   INTEROP_TRACE(function);
-  const auto* FD = cast<FunctionDecl>(unwrap<clang::Decl>(function));
+  const auto* FD = cast<FunctionDecl>(
+      UnwrapUsingShadowToFunction(unwrap<clang::Decl>(function)));
   return INTEROP_RETURN(FD->isDeleted());
 }
 
 bool IsTemplatedFunction(ConstFuncRef func) {
   INTEROP_TRACE(func);
-  const auto* D = unwrap<Decl>(func);
+  const auto* D = UnwrapUsingShadowToFunction(unwrap<Decl>(func));
   return INTEROP_RETURN(IsTemplatedFunction(D) ||
                         IsTemplateInstantiationOrSpecialization(D));
 }
@@ -1912,6 +1937,13 @@ BestOverloadFunctionMatch(const std::vector<FuncRef>& candidates,
 // the provided AccessSpecifier.
 bool CheckMethodAccess(ConstFuncRef method, AccessSpecifier AS) {
   const auto* D = unwrap<Decl>(method);
+  // Must NOT unwrap here: the using-shadow is the only carrier of the effective
+  // access (e.g. `public` in the derived class), while the target only knows
+  // its base access (e.g. `protected`).
+  if (const auto* USD = llvm::dyn_cast_or_null<UsingShadowDecl>(D)) {
+    if (llvm::isa_and_nonnull<CXXMethodDecl>(USD->getTargetDecl()))
+      return USD->getAccess() == AS;
+  }
   if (const auto* CXXMD = llvm::dyn_cast_or_null<CXXMethodDecl>(D)) {
     return CXXMD->getAccess() == AS;
   }
@@ -1921,7 +1953,7 @@ bool CheckMethodAccess(ConstFuncRef method, AccessSpecifier AS) {
 
 bool IsMethod(ConstFuncRef method) {
   INTEROP_TRACE(method);
-  const auto* D = unwrap<clang::Decl>(method);
+  const auto* D = UnwrapUsingShadowToFunction(unwrap<clang::Decl>(method));
   if (const auto* FTD = dyn_cast_or_null<FunctionTemplateDecl>(D))
     D = FTD->getTemplatedDecl();
   return INTEROP_RETURN(dyn_cast_or_null<CXXMethodDecl>(D));
@@ -1945,7 +1977,7 @@ bool IsPrivateMethod(ConstFuncRef method) {
 
 bool IsConstructor(ConstFuncRef method) {
   INTEROP_TRACE(method);
-  const auto* D = unwrap<Decl>(method);
+  const auto* D = UnwrapUsingShadowToFunction(unwrap<Decl>(method));
   if (const auto* FTD = dyn_cast<FunctionTemplateDecl>(D))
     return INTEROP_RETURN(IsConstructor(FTD->getTemplatedDecl()));
   return INTEROP_RETURN(llvm::isa_and_nonnull<CXXConstructorDecl>(D));
@@ -1953,13 +1985,13 @@ bool IsConstructor(ConstFuncRef method) {
 
 bool IsDestructor(ConstFuncRef method) {
   INTEROP_TRACE(method);
-  const auto* D = unwrap<Decl>(method);
+  const auto* D = UnwrapUsingShadowToFunction(unwrap<Decl>(method));
   return INTEROP_RETURN(llvm::isa_and_nonnull<CXXDestructorDecl>(D));
 }
 
 bool IsStaticMethod(ConstFuncRef method) {
   INTEROP_TRACE(method);
-  const auto* D = unwrap<Decl>(method);
+  const auto* D = UnwrapUsingShadowToFunction(unwrap<Decl>(method));
   if (const auto* FTD = llvm::dyn_cast_or_null<FunctionTemplateDecl>(D))
     D = FTD->getTemplatedDecl();
 
@@ -1975,7 +2007,7 @@ bool IsExplicit(ConstFuncRef method) {
   if (!method)
     return INTEROP_RETURN(false);
 
-  const auto* D = unwrap<Decl>(method);
+  const auto* D = UnwrapUsingShadowToFunction(unwrap<Decl>(method));
 
   if (const auto* FTD = llvm::dyn_cast_or_null<FunctionTemplateDecl>(D))
     D = FTD->getTemplatedDecl();
@@ -2032,7 +2064,7 @@ static void* GetFunctionAddress(const FunctionDecl* FD) {
 
 void* GetFunctionAddress(FuncRef method) {
   INTEROP_TRACE(method);
-  auto* D = unwrap<Decl>(method);
+  auto* D = UnwrapUsingShadowToFunction(unwrap<Decl>(method));
   if (auto* FD = llvm::dyn_cast_or_null<FunctionDecl>(D)) {
     if ((IsTemplateInstantiationOrSpecialization(FD) ||
          FD->getTemplatedKind() == FunctionDecl::TK_MemberSpecialization) &&
@@ -2048,7 +2080,7 @@ void* GetFunctionAddress(FuncRef method) {
 
 bool IsVirtualMethod(ConstFuncRef method) {
   INTEROP_TRACE(method);
-  const auto* D = unwrap<Decl>(method);
+  const auto* D = UnwrapUsingShadowToFunction(unwrap<Decl>(method));
   if (const auto* CXXMD = llvm::dyn_cast_or_null<CXXMethodDecl>(D)) {
     return INTEROP_RETURN(CXXMD->isVirtual());
   }
@@ -4037,7 +4069,8 @@ int get_wrapper_code(compat::Interpreter& I, const FunctionDecl* FD,
 }
 
 JitCall::GenericCall make_wrapper(compat::Interpreter& I,
-                                  const FunctionDecl* FD) {
+                                  const FunctionDecl* FD,
+                                  bool relaxAccessControl = false) {
   auto& WrapperStore = getInterpInfo(&I).WrapperStore;
 
   auto R = WrapperStore.find(FD);
@@ -4075,6 +4108,12 @@ JitCall::GenericCall make_wrapper(compat::Interpreter& I,
   // We should be able to call private default constructors.
   if (auto Ctor = dyn_cast<CXXConstructorDecl>(FD))
     withAccessControl = !Ctor->isDefaultConstructor();
+  // Members introduced into a derived class with a public using-declaration
+  // are reachable through the derived class, but the generated wrapper still
+  // calls the target through its original (e.g. protected) qualified name.
+  // Disable access control for this specific case so the wrapper compiles.
+  if (relaxAccessControl)
+    withAccessControl = false;
   void* wrapper =
       compile_wrapper(I, wrapper_name, wrapper_code, withAccessControl);
   if (wrapper) {
@@ -4286,9 +4325,15 @@ static JitCall::DestructorCall make_dtor_wrapper(compat::Interpreter& interp,
 
 CPPINTEROP_API JitCall MakeFunctionCallable(InterpRef I, ConstFuncRef func) {
   INTEROP_TRACE(I, func);
-  const auto* D = unwrap<clang::Decl>(func);
-  if (!D)
+  const auto* InputD = unwrap<clang::Decl>(func);
+  if (!InputD)
     return INTEROP_RETURN(JitCall{});
+
+  // If the caller passed a using-shadow, unwrap to the target function but
+  // remember the fact: the generated wrapper still references the target's
+  // original (e.g. protected) name, so it needs access control relaxed.
+  const bool isUsingShadow = isa<UsingShadowDecl>(InputD);
+  const auto* D = UnwrapUsingShadowToFunction(InputD);
 
   auto* interp = unwrap<compat::Interpreter>(I);
 
@@ -4302,14 +4347,16 @@ CPPINTEROP_API JitCall MakeFunctionCallable(InterpRef I, ConstFuncRef func) {
   }
 
   if (const auto* Ctor = dyn_cast<CXXConstructorDecl>(D)) {
-    if (auto Wrapper = make_wrapper(*interp, cast<FunctionDecl>(D)))
+    if (auto Wrapper =
+            make_wrapper(*interp, cast<FunctionDecl>(D), isUsingShadow))
       return INTEROP_RETURN(JitCall(JitCall::kConstructorCall, Wrapper,
                                     wrap<ConstFuncRef>(Ctor)));
     // FIXME: else error we failed to compile the wrapper.
     return INTEROP_RETURN(JitCall{});
   }
 
-  if (auto Wrapper = make_wrapper(*interp, cast<FunctionDecl>(D))) {
+  if (auto Wrapper =
+          make_wrapper(*interp, cast<FunctionDecl>(D), isUsingShadow)) {
     return INTEROP_RETURN(JitCall(JitCall::kGenericCall, Wrapper,
                                   wrap<ConstFuncRef>(cast<FunctionDecl>(D))));
   }
@@ -5200,7 +5247,7 @@ bool IsTypeDerivedFrom(ConstTypeRef derived, ConstTypeRef base) {
 
 std::string GetFunctionArgDefault(ConstFuncRef func, size_t param_index) {
   INTEROP_TRACE(func, param_index);
-  const auto* D = unwrap<clang::Decl>(func);
+  const auto* D = UnwrapUsingShadowToFunction(unwrap<clang::Decl>(func));
   const clang::ParmVarDecl* PI = nullptr;
 
   if (const auto* FD = llvm::dyn_cast_or_null<clang::FunctionDecl>(D))
@@ -5243,7 +5290,7 @@ bool IsConstMethod(ConstFuncRef method) {
   if (!method)
     return INTEROP_RETURN(false);
 
-  const auto* D = unwrap<clang::Decl>(method);
+  const auto* D = UnwrapUsingShadowToFunction(unwrap<clang::Decl>(method));
   if (const auto* func = dyn_cast<CXXMethodDecl>(D))
     return INTEROP_RETURN(func->getMethodQualifiers().hasConst());
 
@@ -5252,7 +5299,7 @@ bool IsConstMethod(ConstFuncRef method) {
 
 std::string GetFunctionArgName(ConstFuncRef func, size_t param_index) {
   INTEROP_TRACE(func, param_index);
-  const auto* D = unwrap<clang::Decl>(func);
+  const auto* D = UnwrapUsingShadowToFunction(unwrap<clang::Decl>(func));
   const clang::ParmVarDecl* PI = nullptr;
 
   if (const auto* FD = llvm::dyn_cast_or_null<clang::FunctionDecl>(D))
@@ -5282,7 +5329,7 @@ Operator GetOperatorFromSpelling(const std::string& op) {
 
 OperatorArity GetOperatorArity(ConstFuncRef op) {
   INTEROP_TRACE(op);
-  const auto* D = unwrap<Decl>(op);
+  const auto* D = UnwrapUsingShadowToFunction(unwrap<Decl>(op));
   if (const auto* FD = llvm::dyn_cast<FunctionDecl>(D)) {
     if (FD->isOverloadedOperator()) {
       switch (FD->getOverloadedOperator()) {

--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -1059,6 +1059,27 @@ static const clang::Decl* GetUnderlyingScopeImpl(const clang::Decl* D) {
   return D->getCanonicalDecl();
 }
 
+// If D is a UsingShadowDecl whose target is a function-like decl,
+// return that target; otherwise return D unchanged. The using-shadow
+// is the only carrier of the "effective access" introduced into the
+// derived class, so callers that need access info should consult D
+// before unwrapping.
+static clang::Decl* UnwrapUsingShadowToFunction(clang::Decl* D) {
+  if (auto* USD = dyn_cast_or_null<UsingShadowDecl>(D))
+    if (auto* Target = USD->getTargetDecl())
+      if (isa<FunctionDecl>(Target) || isa<FunctionTemplateDecl>(Target))
+        return Target;
+  return D;
+}
+
+static const clang::Decl* UnwrapUsingShadowToFunction(const clang::Decl* D) {
+  if (const auto* USD = dyn_cast_or_null<UsingShadowDecl>(D))
+    if (const auto* Target = USD->getTargetDecl())
+      if (isa<FunctionDecl>(Target) || isa<FunctionTemplateDecl>(Target))
+        return Target;
+  return D;
+}
+
 DeclRef GetUnderlyingScope(ConstDeclRef DRef) {
   INTEROP_TRACE(DRef);
   if (!DRef)
@@ -1446,7 +1467,10 @@ static void GetClassDecls(ConstDeclRef DRef, std::vector<HandleType>& methods) {
 
       auto* CUSD = dyn_cast<ConstructorUsingShadowDecl>(DI);
       if (!CUSD) {
-        methods.push_back(MD);
+        // Push the using-shadow rather than the target so that the
+        // effective access (USD->getAccess()) reachable from the
+        // introducing class is preserved for downstream consumers.
+        methods.push_back(USD);
         continue;
       }
 
@@ -1587,7 +1611,7 @@ std::vector<FuncRef> GetFunctionsUsingName(ConstDeclRef DRef,
 
 TypeRef GetFunctionReturnType(ConstFuncRef func) {
   INTEROP_TRACE(func);
-  const auto* D = unwrap<clang::Decl>(func);
+  const auto* D = UnwrapUsingShadowToFunction(unwrap<clang::Decl>(func));
   if (const auto* FD = llvm::dyn_cast_or_null<clang::FunctionDecl>(D)) {
     QualType Type = FD->getReturnType();
     if (Type->isUndeducedAutoType()) {
@@ -2064,7 +2088,7 @@ void GetFnTypeSignature(ConstTypeRef fn_type, std::vector<TypeRef>& sig) {
 // exclude it, which is what callers introspecting the argument list want.
 size_t GetFunctionNumArgs(ConstFuncRef func) {
   INTEROP_TRACE(func);
-  const auto* D = unwrap<clang::Decl>(func);
+  const auto* D = UnwrapUsingShadowToFunction(unwrap<clang::Decl>(func));
   if (const auto* FD = llvm::dyn_cast_or_null<FunctionDecl>(D))
     return INTEROP_RETURN(FD->getNumNonObjectParams());
 
@@ -2076,7 +2100,7 @@ size_t GetFunctionNumArgs(ConstFuncRef func) {
 
 size_t GetFunctionRequiredArgs(ConstFuncRef func) {
   INTEROP_TRACE(func);
-  const auto* D = unwrap<clang::Decl>(func);
+  const auto* D = UnwrapUsingShadowToFunction(unwrap<clang::Decl>(func));
   if (const auto* FD = llvm::dyn_cast_or_null<FunctionDecl>(D))
     return INTEROP_RETURN(FD->getMinRequiredExplicitArguments());
 
@@ -2089,7 +2113,7 @@ size_t GetFunctionRequiredArgs(ConstFuncRef func) {
 
 TypeRef GetFunctionArgType(ConstFuncRef func, size_t iarg) {
   INTEROP_TRACE(func, iarg);
-  const auto* D = unwrap<clang::Decl>(func);
+  const auto* D = UnwrapUsingShadowToFunction(unwrap<clang::Decl>(func));
 
   if (const auto* FTD = llvm::dyn_cast_or_null<clang::FunctionTemplateDecl>(D))
     D = FTD->getTemplatedDecl();
@@ -2115,7 +2139,7 @@ std::string GetFunctionSignature(ConstFuncRef func) {
   if (!func)
     return INTEROP_RETURN("<unknown>");
 
-  const auto* D = unwrap<clang::Decl>(func);
+  const auto* D = UnwrapUsingShadowToFunction(unwrap<clang::Decl>(func));
   const clang::FunctionDecl* FD;
 
   if (llvm::dyn_cast<FunctionDecl>(D))
@@ -2160,13 +2184,14 @@ bool IsTemplateInstantiationOrSpecialization(const Decl* D) {
 
 bool IsFunctionDeleted(ConstFuncRef function) {
   INTEROP_TRACE(function);
-  const auto* FD = cast<FunctionDecl>(unwrap<clang::Decl>(function));
+  const auto* FD = cast<FunctionDecl>(
+      UnwrapUsingShadowToFunction(unwrap<clang::Decl>(function)));
   return INTEROP_RETURN(FD->isDeleted());
 }
 
 bool IsTemplatedFunction(ConstFuncRef func) {
   INTEROP_TRACE(func);
-  const auto* D = unwrap<Decl>(func);
+  const auto* D = UnwrapUsingShadowToFunction(unwrap<Decl>(func));
   return INTEROP_RETURN(IsTemplatedFunction(D) ||
                         IsTemplateInstantiationOrSpecialization(D));
 }
@@ -2372,6 +2397,13 @@ BestOverloadFunctionMatch(const std::vector<FuncRef>& candidates,
 // the provided AccessSpecifier.
 bool CheckMethodAccess(ConstFuncRef method, AccessSpecifier AS) {
   const auto* D = unwrap<Decl>(method);
+  // Must NOT unwrap here: the using-shadow is the only carrier of the effective
+  // access (e.g. `public` in the derived class), while the target only knows
+  // its base access (e.g. `protected`).
+  if (const auto* USD = llvm::dyn_cast_or_null<UsingShadowDecl>(D)) {
+    if (llvm::isa_and_nonnull<CXXMethodDecl>(USD->getTargetDecl()))
+      return USD->getAccess() == AS;
+  }
   if (const auto* CXXMD = llvm::dyn_cast_or_null<CXXMethodDecl>(D)) {
     return CXXMD->getAccess() == AS;
   }
@@ -2381,7 +2413,7 @@ bool CheckMethodAccess(ConstFuncRef method, AccessSpecifier AS) {
 
 bool IsMethod(ConstFuncRef method) {
   INTEROP_TRACE(method);
-  const auto* D = unwrap<clang::Decl>(method);
+  const auto* D = UnwrapUsingShadowToFunction(unwrap<clang::Decl>(method));
   if (const auto* FTD = dyn_cast_or_null<FunctionTemplateDecl>(D))
     D = FTD->getTemplatedDecl();
   return INTEROP_RETURN(dyn_cast_or_null<CXXMethodDecl>(D));
@@ -2405,7 +2437,7 @@ bool IsPrivateMethod(ConstFuncRef method) {
 
 bool IsConstructor(ConstFuncRef method) {
   INTEROP_TRACE(method);
-  const auto* D = unwrap<Decl>(method);
+  const auto* D = UnwrapUsingShadowToFunction(unwrap<Decl>(method));
   if (const auto* FTD = dyn_cast<FunctionTemplateDecl>(D))
     return INTEROP_RETURN(IsConstructor(FTD->getTemplatedDecl()));
   return INTEROP_RETURN(llvm::isa_and_nonnull<CXXConstructorDecl>(D));
@@ -2413,13 +2445,13 @@ bool IsConstructor(ConstFuncRef method) {
 
 bool IsDestructor(ConstFuncRef method) {
   INTEROP_TRACE(method);
-  const auto* D = unwrap<Decl>(method);
+  const auto* D = UnwrapUsingShadowToFunction(unwrap<Decl>(method));
   return INTEROP_RETURN(llvm::isa_and_nonnull<CXXDestructorDecl>(D));
 }
 
 bool IsStaticMethod(ConstFuncRef method) {
   INTEROP_TRACE(method);
-  const auto* D = unwrap<Decl>(method);
+  const auto* D = UnwrapUsingShadowToFunction(unwrap<Decl>(method));
   if (const auto* FTD = llvm::dyn_cast_or_null<FunctionTemplateDecl>(D))
     D = FTD->getTemplatedDecl();
 
@@ -2435,7 +2467,7 @@ bool IsExplicit(ConstFuncRef method) {
   if (!method)
     return INTEROP_RETURN(false);
 
-  const auto* D = unwrap<Decl>(method);
+  const auto* D = UnwrapUsingShadowToFunction(unwrap<Decl>(method));
 
   if (const auto* FTD = llvm::dyn_cast_or_null<FunctionTemplateDecl>(D))
     D = FTD->getTemplatedDecl();
@@ -2492,7 +2524,7 @@ static void* GetFunctionAddress(const FunctionDecl* FD) {
 
 void* GetFunctionAddress(FuncRef method) {
   INTEROP_TRACE(method);
-  auto* D = unwrap<Decl>(method);
+  auto* D = UnwrapUsingShadowToFunction(unwrap<Decl>(method));
   if (auto* FD = llvm::dyn_cast_or_null<FunctionDecl>(D)) {
     if ((IsTemplateInstantiationOrSpecialization(FD) ||
          FD->getTemplatedKind() == FunctionDecl::TK_MemberSpecialization) &&
@@ -2508,7 +2540,7 @@ void* GetFunctionAddress(FuncRef method) {
 
 bool IsVirtualMethod(ConstFuncRef method) {
   INTEROP_TRACE(method);
-  const auto* D = unwrap<Decl>(method);
+  const auto* D = UnwrapUsingShadowToFunction(unwrap<Decl>(method));
   if (const auto* CXXMD = llvm::dyn_cast_or_null<CXXMethodDecl>(D)) {
     return INTEROP_RETURN(CXXMD->isVirtual());
   }
@@ -4553,7 +4585,8 @@ int get_wrapper_code(compat::Interpreter& I, const FunctionDecl* FD,
 }
 
 JitCall::GenericCall make_wrapper(compat::Interpreter& I,
-                                  const FunctionDecl* FD) {
+                                  const FunctionDecl* FD,
+                                  bool relaxAccessControl = false) {
   auto& WrapperStore = getInterpInfo(&I).WrapperStore;
 
   auto R = WrapperStore.find(FD);
@@ -4591,6 +4624,12 @@ JitCall::GenericCall make_wrapper(compat::Interpreter& I,
   // We should be able to call private default constructors.
   if (auto Ctor = dyn_cast<CXXConstructorDecl>(FD))
     withAccessControl = !Ctor->isDefaultConstructor();
+  // Members introduced into a derived class with a public using-declaration
+  // are reachable through the derived class, but the generated wrapper still
+  // calls the target through its original (e.g. protected) qualified name.
+  // Disable access control for this specific case so the wrapper compiles.
+  if (relaxAccessControl)
+    withAccessControl = false;
   void* wrapper =
       compile_wrapper(I, wrapper_name, wrapper_code, withAccessControl);
   if (wrapper) {
@@ -4802,9 +4841,15 @@ static JitCall::DestructorCall make_dtor_wrapper(compat::Interpreter& interp,
 
 CPPINTEROP_API JitCall MakeFunctionCallable(InterpRef I, ConstFuncRef func) {
   INTEROP_TRACE(I, func);
-  const auto* D = unwrap<clang::Decl>(func);
-  if (!D)
+  const auto* InputD = unwrap<clang::Decl>(func);
+  if (!InputD)
     return INTEROP_RETURN(JitCall{});
+
+  // If the caller passed a using-shadow, unwrap to the target function but
+  // remember the fact: the generated wrapper still references the target's
+  // original (e.g. protected) name, so it needs access control relaxed.
+  const bool isUsingShadow = isa<UsingShadowDecl>(InputD);
+  const auto* D = UnwrapUsingShadowToFunction(InputD);
 
   auto* interp = unwrap<compat::Interpreter>(I);
 
@@ -4818,14 +4863,16 @@ CPPINTEROP_API JitCall MakeFunctionCallable(InterpRef I, ConstFuncRef func) {
   }
 
   if (const auto* Ctor = dyn_cast<CXXConstructorDecl>(D)) {
-    if (auto Wrapper = make_wrapper(*interp, cast<FunctionDecl>(D)))
+    if (auto Wrapper =
+            make_wrapper(*interp, cast<FunctionDecl>(D), isUsingShadow))
       return INTEROP_RETURN(JitCall(JitCall::kConstructorCall, Wrapper,
                                     wrap<ConstFuncRef>(Ctor)));
     // FIXME: else error we failed to compile the wrapper.
     return INTEROP_RETURN(JitCall{});
   }
 
-  if (auto Wrapper = make_wrapper(*interp, cast<FunctionDecl>(D))) {
+  if (auto Wrapper =
+          make_wrapper(*interp, cast<FunctionDecl>(D), isUsingShadow)) {
     return INTEROP_RETURN(JitCall(JitCall::kGenericCall, Wrapper,
                                   wrap<ConstFuncRef>(cast<FunctionDecl>(D))));
   }
@@ -5747,7 +5794,7 @@ bool IsTypeDerivedFrom(ConstTypeRef derived, ConstTypeRef base) {
 
 std::string GetFunctionArgDefault(ConstFuncRef func, size_t param_index) {
   INTEROP_TRACE(func, param_index);
-  const auto* D = unwrap<clang::Decl>(func);
+  const auto* D = UnwrapUsingShadowToFunction(unwrap<clang::Decl>(func));
   const clang::ParmVarDecl* PI = nullptr;
 
   if (const auto* FD = llvm::dyn_cast_or_null<clang::FunctionDecl>(D))
@@ -5790,7 +5837,7 @@ bool IsConstMethod(ConstFuncRef method) {
   if (!method)
     return INTEROP_RETURN(false);
 
-  const auto* D = unwrap<clang::Decl>(method);
+  const auto* D = UnwrapUsingShadowToFunction(unwrap<clang::Decl>(method));
   if (const auto* func = dyn_cast<CXXMethodDecl>(D))
     return INTEROP_RETURN(func->getMethodQualifiers().hasConst());
 
@@ -5799,7 +5846,7 @@ bool IsConstMethod(ConstFuncRef method) {
 
 std::string GetFunctionArgName(ConstFuncRef func, size_t param_index) {
   INTEROP_TRACE(func, param_index);
-  const auto* D = unwrap<clang::Decl>(func);
+  const auto* D = UnwrapUsingShadowToFunction(unwrap<clang::Decl>(func));
   const clang::ParmVarDecl* PI = nullptr;
 
   if (const auto* FD = llvm::dyn_cast_or_null<clang::FunctionDecl>(D))
@@ -5829,7 +5876,7 @@ Operator GetOperatorFromSpelling(const std::string& op) {
 
 OperatorArity GetOperatorArity(ConstFuncRef op) {
   INTEROP_TRACE(op);
-  const auto* D = unwrap<Decl>(op);
+  const auto* D = UnwrapUsingShadowToFunction(unwrap<Decl>(op));
   if (const auto* FD = llvm::dyn_cast<FunctionDecl>(D)) {
     if (FD->isOverloadedOperator()) {
       switch (FD->getOverloadedOperator()) {

--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -1279,6 +1279,11 @@ DeclRef GetParentScope(ConstDeclRef DRef) {
   if (llvm::isa_and_nonnull<TranslationUnitDecl>(D)) {
     return INTEROP_RETURN(nullptr);
   }
+  // For a method handle that is a using-shadow, the parent must be the
+  // target's declaring class, not the class holding the using-declaration:
+  // callers (e.g. CPyCppyy) use it to adjust `this` to the declaring base's
+  // subobject, and the wrapper calls the target through that base type.
+  D = UnwrapUsingShadowToFunction(D);
   auto* ParentDC = D->getDeclContext();
 
   if (!ParentDC)

--- a/unittests/CppInterOp/FunctionReflectionTest.cpp
+++ b/unittests/CppInterOp/FunctionReflectionTest.cpp
@@ -163,6 +163,157 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_GetClassMethods) {
   EXPECT_EQ(get_method_name(templ_methods2[6]), "inline TT::~TT()");
 }
 
+// A method introduced into a derived class with `using Base::name;` in a
+// public section must report public access (taken from the using-declaration),
+// not the access of the underlying target in the base class.
+TYPED_TEST(CPPINTEROP_TEST_MODE,
+           FunctionReflection_GetClassMethods_UsingShadowAccess) {
+  std::vector<Decl*> Decls;
+  std::string code = R"(
+    class MyBase {
+    protected:
+       void foo(int, int) {}
+    };
+    class MyDerived : public MyBase {
+    public:
+       using MyBase::foo;   // promoted to public
+       void foo(int) {}
+    };
+    class HiddenDerived : public MyBase {
+    protected:
+       using MyBase::foo;   // stays protected
+    };
+    )";
+
+  GetAllTopLevelDecls(code, Decls);
+
+  std::vector<Cpp::FuncRef> derived_methods;
+  Cpp::GetClassMethods(Decls[1], derived_methods);
+
+  // Find the using-promoted foo (the two-argument overload).
+  bool found_using_promoted = false;
+  Cpp::FuncRef using_promoted;
+  for (auto m : derived_methods) {
+    if (Cpp::GetName(Cpp::DeclRef{m.data}) != "foo")
+      continue;
+    if (Cpp::GetFunctionNumArgs(m) == 2) {
+      found_using_promoted = true;
+      using_promoted = m;
+      EXPECT_TRUE(Cpp::IsPublicMethod(m));
+      EXPECT_FALSE(Cpp::IsProtectedMethod(m));
+      EXPECT_FALSE(Cpp::IsConstructor(m));
+    }
+  }
+  EXPECT_TRUE(found_using_promoted)
+      << "using-promoted base method missing from GetClassMethods";
+
+  // Resolving the address of the using-promoted overload must transparently
+  // unwrap the using-shadow to its target before emitting code. This is the
+  // only caller exercising the non-const UnwrapUsingShadowToFunction overload
+  // (the reflection-only APIs above all go through the const overload), and the
+  // resolved address must match the one obtained directly from the base method.
+#ifndef _WIN32 // GetFunctionAddress is disabled on Windows; see its own test.
+  if (!TypeParam::isOutOfProcess && found_using_promoted) {
+    std::vector<Cpp::FuncRef> base_methods;
+    Cpp::GetClassMethods(Decls[0], base_methods);
+    Cpp::FuncRef base_foo;
+    for (auto m : base_methods) {
+      if (Cpp::GetName(Cpp::DeclRef{m.data}) == "foo" &&
+          Cpp::GetFunctionNumArgs(m) == 2)
+        base_foo = m;
+    }
+    ASSERT_TRUE(base_foo);
+
+    void* shadow_addr = Cpp::GetFunctionAddress(using_promoted);
+    EXPECT_TRUE(shadow_addr);
+    EXPECT_EQ(shadow_addr, Cpp::GetFunctionAddress(base_foo));
+  }
+#endif
+
+  std::vector<Cpp::FuncRef> hidden_methods;
+  Cpp::GetClassMethods(Decls[2], hidden_methods);
+
+  bool found_hidden = false;
+  for (auto m : hidden_methods) {
+    if (Cpp::GetName(Cpp::DeclRef{m.data}) == "foo" &&
+        Cpp::GetFunctionNumArgs(m) == 2) {
+      found_hidden = true;
+      EXPECT_FALSE(Cpp::IsPublicMethod(m));
+      EXPECT_TRUE(Cpp::IsProtectedMethod(m));
+    }
+  }
+  EXPECT_TRUE(found_hidden);
+}
+
+// Companion to the access test above, covering the *call* path: a method
+// promoted into a derived class with a public `using Base::name;` must be
+// invocable through the derived class even though the target still carries the
+// base class's protected access. The generated wrapper references the target by
+// its original (protected) qualified name, so MakeFunctionCallable threads a
+// relaxAccessControl flag into wrapper compilation for this case. Exercise it
+// end to end: compile the wrapper and actually invoke it.
+TYPED_TEST(CPPINTEROP_TEST_MODE,
+           FunctionReflection_MakeFunctionCallable_UsingShadow) {
+#ifdef EMSCRIPTEN
+  GTEST_SKIP() << "Test fails for Emscripten builds";
+#endif
+#if defined(CPPINTEROP_USE_CLING) && defined(_WIN32)
+  GTEST_SKIP() << "Disabled on Cling/Windows.";
+#endif
+  if (TypeParam::isOutOfProcess)
+    GTEST_SKIP() << "Test fails for OOP JIT builds";
+
+  std::vector<Decl*> Decls;
+  std::string code = R"(
+    class MyBase {
+    protected:
+       int foo(int a, int b) { return a * 100 + b; }
+    };
+    class MyDerived : public MyBase {
+    public:
+       using MyBase::foo;   // promoted to public
+       int foo(int a) { return a; }
+    };
+    )";
+
+  // `-include new` is needed for the constructor wrapper's placement new.
+  GetAllTopLevelDecls(code, Decls, /*filter_implicitGenerated=*/false,
+                      /*interpreter_args=*/{"-include", "new"});
+
+  std::vector<Cpp::FuncRef> derived_methods;
+  Cpp::GetClassMethods(Decls[1], derived_methods);
+
+  // Locate the using-promoted foo (the two-argument overload from the base).
+  Cpp::FuncRef using_promoted;
+  for (auto m : derived_methods) {
+    if (Cpp::GetName(Cpp::DeclRef{m.data}) == "foo" &&
+        Cpp::GetFunctionNumArgs(m) == 2)
+      using_promoted = m;
+  }
+  ASSERT_TRUE(using_promoted);
+
+  // Compiling this wrapper exercises the relaxAccessControl path: the generated
+  // body calls MyBase::foo through its qualified (protected) name, so access
+  // control has to be disabled for the wrapper to compile.
+  Cpp::JitCall Call = Cpp::MakeFunctionCallable(using_promoted);
+  ASSERT_EQ(Call.getKind(), Cpp::JitCall::kGenericCall);
+
+  // Construct a MyDerived and call the promoted overload through it.
+  auto Ctor = Cpp::MakeFunctionCallable(Cpp::GetDefaultConstructor(Decls[1]));
+  void* object = nullptr;
+  Ctor.Invoke((void*)&object, {}, /*self=*/nullptr);
+  ASSERT_TRUE(object);
+
+  int a = 3;
+  int b = 7;
+  int result = 0;
+  std::array<void*, 2> args = {(void*)&a, (void*)&b};
+  Call.Invoke(&result, {args.data(), /*args_size=*/2}, object);
+  EXPECT_EQ(result, (a * 100) + b);
+
+  Cpp::Destruct(object, Decls[1]);
+}
+
 TYPED_TEST(CPPINTEROP_TEST_MODE,
            FunctionReflection_ConstructorInGetClassMethods) {
   std::vector<Decl*> Decls;

--- a/unittests/CppInterOp/FunctionReflectionTest.cpp
+++ b/unittests/CppInterOp/FunctionReflectionTest.cpp
@@ -8,6 +8,7 @@
 #include "clang/Sema/Sema.h"
 
 #include <CppInterOp/CppInterOpTypes.h>
+#include <cstdint>
 #include <llvm/ADT/ArrayRef.h>
 
 #include "gtest/gtest.h"
@@ -312,6 +313,119 @@ TYPED_TEST(CPPINTEROP_TEST_MODE,
   EXPECT_EQ(result, (a * 100) + b);
 
   Cpp::Destruct(object, Decls[1]);
+}
+
+// A using-promoted method still belongs to its declaring base class. When that
+// base sits at a non-zero offset inside the derived object (multiple
+// inheritance), callers adjust `this` with
+// GetBaseClassOffset(derived, GetParentScope(method)) — exactly what CPyCppyy
+// does before invoking the wrapper, which casts `self` to the declaring base
+// type. GetParentScope on the using-shadow handle must therefore return the
+// target's declaring base, not the class holding the using-declaration —
+// otherwise the offset comes out zero and the call writes through an
+// unadjusted pointer into the wrong subobject. Mirrors cppyy's
+// test_regression.py::test50_using_decl_base_this_offset.
+TYPED_TEST(CPPINTEROP_TEST_MODE,
+           FunctionReflection_UsingShadow_BaseThisOffset) {
+#ifdef EMSCRIPTEN
+  GTEST_SKIP() << "Test fails for Emscripten builds";
+#endif
+#if defined(CPPINTEROP_USE_CLING) && defined(_WIN32)
+  GTEST_SKIP() << "Disabled on Cling/Windows.";
+#endif
+
+  std::vector<Decl*> Decls;
+  std::string code = R"(
+    // Fat first base so that SecondBase lands at a non-zero offset in Derived.
+    struct FirstBase {
+      long long a, b, c, d, e, f, g, h;
+      FirstBase() : a(11), b(22), c(33), d(44), e(55), f(66), g(77), h(88) {}
+      long long get_a() const { return a; }
+    };
+    struct SecondBase {
+      int value;
+      SecondBase() : value(-1) {}
+      void set_value(int v) { value = v; }
+      int get_value() const { return value; }
+    };
+    struct Derived : public FirstBase, public SecondBase {
+      int extra;
+      Derived() : extra(0) {}
+      using SecondBase::set_value;                // import the 1-arg overload
+      void set_value(int v, int w) { value = v + w; extra = w; }
+    };
+    )";
+
+  // `-include new` is needed for the constructor wrapper's placement new.
+  GetAllTopLevelDecls(code, Decls, /*filter_implicitGenerated=*/false,
+                      /*interpreter_args=*/{"-include", "new"});
+
+  std::vector<Cpp::FuncRef> derived_methods;
+  Cpp::GetClassMethods(Decls[2], derived_methods);
+
+  // Locate the using-imported set_value (the one-argument overload).
+  Cpp::FuncRef imported;
+  for (auto m : derived_methods) {
+    if (Cpp::GetName(Cpp::DeclRef{m.data}) == "set_value" &&
+        Cpp::GetFunctionNumArgs(m) == 1)
+      imported = m;
+  }
+  ASSERT_TRUE(imported);
+
+  // The declaring scope of the imported method is SecondBase, not Derived.
+  Cpp::DeclRef declaring = Cpp::GetParentScope(Cpp::DeclRef{imported.data});
+  EXPECT_EQ(Cpp::GetQualifiedName(declaring), "SecondBase");
+
+  // ... and SecondBase sits at a non-zero offset inside Derived.
+  int64_t offset = Cpp::GetBaseClassOffset(Decls[2], declaring);
+  EXPECT_GT(offset, 0);
+
+  if (TypeParam::isOutOfProcess)
+    GTEST_SKIP() << "JitCall part fails for OOP JIT builds";
+
+  // End-to-end: construct a Derived, call the imported overload with `this`
+  // adjusted to the SecondBase subobject, and check the value landed there.
+  auto Ctor = Cpp::MakeFunctionCallable(Cpp::GetDefaultConstructor(Decls[2]));
+  void* object = nullptr;
+  Ctor.Invoke((void*)&object, {}, /*self=*/nullptr);
+  ASSERT_TRUE(object);
+  void* second_base = static_cast<char*>(object) + offset;
+
+  Cpp::JitCall SetValue = Cpp::MakeFunctionCallable(imported);
+  ASSERT_EQ(SetValue.getKind(), Cpp::JitCall::kGenericCall);
+  int v = 42;
+  std::array<void*, 1> args = {(void*)&v};
+  SetValue.Invoke(nullptr, {args.data(), /*args_size=*/1}, second_base);
+
+  std::vector<Cpp::FuncRef> second_base_methods;
+  Cpp::GetClassMethods(Decls[1], second_base_methods);
+  Cpp::FuncRef get_value;
+  for (auto m : second_base_methods) {
+    if (Cpp::GetName(Cpp::DeclRef{m.data}) == "get_value")
+      get_value = m;
+  }
+  ASSERT_TRUE(get_value);
+
+  int result = 0;
+  Cpp::MakeFunctionCallable(get_value).Invoke(&result, {}, second_base);
+  EXPECT_EQ(result, 42);
+
+  // The FirstBase subobject must be untouched (no write through an
+  // unadjusted pointer).
+  std::vector<Cpp::FuncRef> first_base_methods;
+  Cpp::GetClassMethods(Decls[0], first_base_methods);
+  Cpp::FuncRef get_a;
+  for (auto m : first_base_methods) {
+    if (Cpp::GetName(Cpp::DeclRef{m.data}) == "get_a")
+      get_a = m;
+  }
+  ASSERT_TRUE(get_a);
+
+  long long a = 0;
+  Cpp::MakeFunctionCallable(get_a).Invoke(&a, {}, object);
+  EXPECT_EQ(a, 11);
+
+  Cpp::Destruct(object, Decls[2]);
 }
 
 TYPED_TEST(CPPINTEROP_TEST_MODE,


### PR DESCRIPTION
When `GetClassDecls<CXXMethodDecl>` walked a class's decls and hit a `UsingShadowDecl` whose target is a method, it pushed the *target* `CXXMethodDecl` from the base class. The target's `getAccess()` returns the access in the base (e.g. `protected`); the elevated access carried by the using-declaration (`public` in the introducing class) was silently lost. Consumers like CPyCppyy filter on `IsPublicMethod`, so a republished overload such as

    class Base   { protected: void foo(int, int); };
    class Derived: public Base {
    public:
        using Base::foo;
        void foo(int);
    };

would never reach the Python proxy - calling `derived.foo(1, 2)` from cppyy raised `TypeError: takes at most 1 arguments (2 given)` (cppyy issue https://github.com/compiler-research/cppyy/issues/220).

Push the `UsingShadowDecl` itself (for the non-constructor case; constructor-using-shadows still go through `findInheritingConstructor`) and teach `CheckMethodAccess` to consult `USD->getAccess()`. A small `UnwrapUsingShadowToFunction` helper unwraps the shadow at the entry of every API that downcasts a `TCppFunction_t` to `FunctionDecl` (return type, arg counts/types/names/defaults, signature, IsConst/Static/Virtual/Constructor/Destructor/Templated/Explicit, function address, operator arity).

`MakeFunctionCallable` keeps the unwrapped target as the wrapped function but threads a `relaxAccessControl` flag into `make_wrapper` when the caller passed a using-shadow: the generated wrapper still references the target by its original qualified name (e.g. `((Base*)obj)->Base::foo(...)`), so access control has to be relaxed during wrapper compilation for it to compile. The runtime call is well-defined because the using-declaration made the member reachable through the derived class.

Adds a `FunctionReflection_GetClassMethods_UsingShadowAccess` regression test covering both the public-promoted case from the issue and a protected-using control case (which must stay hidden).

Fixes: https://github.com/compiler-research/cppyy/issues/220