### PR TITLE
Look up operator overloads by CXXOperatorName in GetFunctionsUsingName

### DIFF
--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -53,6 +53,7 @@
 #include "clang/AST/Stmt.h"
 #include "clang/AST/Type.h"
 #include "clang/AST/VTableBuilder.h"
+#include "clang/Basic/CharInfo.h"
 #include "clang/Basic/Diagnostic.h"
 #include "clang/Basic/DiagnosticSema.h"
 #include "clang/Basic/LangStandard.h"
@@ -1484,6 +1485,29 @@ void DumpScope(ConstDeclRef DRef) {
   return INTEROP_VOID_RETURN();
 }
 
+// Map an operator spelling (e.g. "operator==") to the CXXOperatorName its
+// overloads are stored under, since identifier lookup never matches them.
+// Returns an empty DeclarationName for non-operators (e.g. "operators_count"),
+// leaving the caller on the identifier path. We can't use LookupOperatorName
+// for this: it ignores class members, which this entry point must also find.
+static DeclarationName getCXXOperatorDeclName(ASTContext& Ctx,
+                                              llvm::StringRef name) {
+  static constexpr llvm::StringRef OperatorPrefix("operator");
+  if (!name.consume_front(OperatorPrefix) || name.empty() ||
+      clang::isAsciiIdentifierContinue(
+          static_cast<unsigned char>(name.front())))
+    return DeclarationName();
+
+  llvm::StringRef Spelling = name.trim();
+#define OVERLOADED_OPERATOR(OpName, OpSpelling, Token, Unary, Binary,          \
+                            MemberOnly)                                        \
+  if (Spelling == (OpSpelling))                                                \
+    return Ctx.DeclarationNames.getCXXOperatorName(clang::OO_##OpName);
+#include "clang/Basic/OperatorKinds.def"
+#undef OVERLOADED_OPERATOR
+  return DeclarationName();
+}
+
 std::vector<FuncRef> GetFunctionsUsingName(ConstDeclRef DRef,
                                            const std::string& name) {
   INTEROP_TRACE(DRef, name);
@@ -1494,9 +1518,13 @@ std::vector<FuncRef> GetFunctionsUsingName(ConstDeclRef DRef,
   const auto* D = unwrap<Decl>(GetUnderlyingScope(DRef));
 
   std::vector<FuncRef> funcs;
-  llvm::StringRef Name(name);
   auto& S = getSema();
-  DeclarationName DName = &getASTContext().Idents.get(name);
+  auto& Ctx = getASTContext();
+
+  DeclarationName DName = getCXXOperatorDeclName(Ctx, name);
+  if (!DName)
+    DName = &Ctx.Idents.get(name);
+
   clang::LookupResult R(S, DName, SourceLocation(), Sema::LookupOrdinaryName,
                         RedeclarationKind::ForVisibleRedeclaration);
 

--- a/unittests/CppInterOp/FunctionReflectionTest.cpp
+++ b/unittests/CppInterOp/FunctionReflectionTest.cpp
@@ -309,6 +309,63 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_GetFunctionsUsingName) {
   EXPECT_EQ(get_number_of_funcs_using_name(derived, "h"), 1);
 }
 
+TYPED_TEST(CPPINTEROP_TEST_MODE,
+           FunctionReflection_GetFunctionsUsingNameOperators) {
+  std::vector<Decl*> Decls;
+  std::string code = R"(
+    namespace ComparableSpace {
+      class NSComparable {};
+      bool operator==(const NSComparable&, const NSComparable&) { return true; }
+      bool operator==(const NSComparable&, int) { return false; }
+      bool operator!=(const NSComparable&, const NSComparable&) { return false; }
+      int operators_count() { return 1; }
+    }
+
+    struct WithOps {
+      bool operator==(const WithOps&) const { return true; }
+      WithOps& operator+=(int) { return *this; }
+      int operator[](int) const { return 0; }
+      int operator()(int, int) const { return 0; }
+    };
+    )";
+
+  GetAllTopLevelDecls(code, Decls);
+
+  auto count = [](Cpp::DeclRef scope, const std::string& name) {
+    return Cpp::GetFunctionsUsingName(scope, name).size();
+  };
+
+  // Namespace-scope operator overloads are now findable by name.
+  EXPECT_EQ(count(Decls[0], "operator=="), 2);
+  EXPECT_EQ(count(Decls[0], "operator!="), 1);
+
+  // Non-existent operator at this scope.
+  EXPECT_EQ(count(Decls[0], "operator+"), 0);
+
+  // "operator" followed by a non-identifier char that is not a valid operator
+  // spelling: this passes the early identifier-path check but matches no
+  // overloaded operator, so it must fall through to the empty DeclarationName
+  // and resolve (to nothing) via the identifier path.
+  EXPECT_EQ(count(Decls[0], "operator@"), 0);
+
+  // Identifiers that merely start with "operator" must still resolve via the
+  // identifier lookup path, not be misread as an operator.
+  EXPECT_EQ(count(Decls[0], "operators_count"), 1);
+
+  // Class-scope operators, including multi-token "()" and "[]".
+  EXPECT_EQ(count(Decls[1], "operator=="), 1);
+  EXPECT_EQ(count(Decls[1], "operator+="), 1);
+  EXPECT_EQ(count(Decls[1], "operator[]"), 1);
+  EXPECT_EQ(count(Decls[1], "operator()"), 1);
+  EXPECT_EQ(count(Decls[1], "operator!="), 0);
+
+  // Sanity-check that the returned decls are the operator overloads.
+  auto eqs = Cpp::GetFunctionsUsingName(Decls[0], "operator==");
+  ASSERT_EQ(eqs.size(), 2U);
+  for (auto f : eqs)
+    EXPECT_EQ(Cpp::GetName(Cpp::DeclRef{f.data}), "operator==");
+}
+
 TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_GetClassDecls) {
   std::vector<Decl*> Decls, SubDecls;
   std::string code = R"(


### PR DESCRIPTION
GetFunctionsUsingName built its lookup key only as an identifier, so queries like "operator==" never matched: operator overloads live in the AST under CXXOperatorName, not under an Identifier. cppyy's namespace getattr fallback (Cppyy::GetMethodsFromName -> Cpp::GetFunctionsUsingName) therefore returned no candidates and getattr(ns, 'operator==') raised AttributeError.

Detect names that start with "operator" followed by a non-identifier character and match the trimmed suffix against OperatorKinds.def. When it matches, build the DeclarationName via getCXXOperatorName(OO_...); otherwise fall back to the identifier lookup. Covers symbolic and multi-token overloads (==, +, (), [], new, delete, new[], delete[], ...). Names that merely start with "operator" (e.g. "operators_count") are left on the identifier path because the next character is an identifier-continue.

Fixes https://github.com/compiler-research/cppyy/issues/219.