### PR TITLE
Desugar template type alias specialisations in wrapper return types

### DIFF
--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -2975,6 +2975,18 @@ void get_type_as_string(QualType QT, std::string& type_name, ASTContext& C,
                         PrintingPolicy Policy) {
   // TODO: Implement cling desugaring from utils::AST
   //       cling::utils::Transform::GetPartiallyDesugaredType()
+  // Desugar template type alias specializations (e.g. std::enable_if_t,
+  // std::remove_cvref_t). Their printed form can carry expression-level
+  // template arguments (variable-template references, SFINAE predicates)
+  // that PrintingPolicy::FullyQualifiedName does not propagate into, so the
+  // emitted text may reference identifiers like `is_constructible_v` without
+  // the `std::` qualifier and fail to compile in the wrapper. Regular
+  // typedefs (e.g. std::string) keep their sugared name.
+  while (const auto* TST = QT->getAs<TemplateSpecializationType>()) {
+    if (!TST->isTypeAlias())
+      break;
+    QT = TST->desugar();
+  }
   if (!QT->isTypedefNameType() || QT->isBuiltinType())
     QT = QT.getDesugaredType(C);
   Policy.Suppress_Elab = true;

--- a/unittests/CppInterOp/FunctionReflectionTest.cpp
+++ b/unittests/CppInterOp/FunctionReflectionTest.cpp
@@ -2431,6 +2431,56 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_GetFunctionCallWrapper) {
   EXPECT_EQ(f3.getKind(), Cpp::JitCall::Kind::kGenericCall);
 }
 
+TYPED_TEST(CPPINTEROP_TEST_MODE,
+           FunctionReflection_WrapAliasTemplateReturnType) {
+  // Regression test for cppyy issue
+  // https://github.com/compiler-research/cppyy/issues/218 (original reproducer:
+  // `std::make_any<...>`, return type `std::enable_if_t<is_constructible_v<...>,
+  // std::any>`). Building a wrapper for a function template whose return type is
+  // a type-alias-template specialisation used to fail to compile; the snippet
+  // below is a stdlib-free distillation. It needs three ingredients: an alias
+  // (`enable_if_t`) whose sugar carries a non-type argument that prints as an
+  // *expression* (`trait_v<int>`, which FullyQualifiedName does not qualify); a
+  // predicate in a namespace, so unqualified `trait_v` does not resolve in the
+  // global-scope wrapper; and a class (non-builtin) canonical type, so
+  // get_type_as_string keeps the sugar instead of taking its isBuiltinType()
+  // branch. See get_type_as_string for how the fix desugars this.
+  //
+  // Only checks JitCall::getKind(), i.e. that the wrapper *compiles*; it never
+  // Invoke()s it, so no out-of-process skip is needed.
+#ifdef EMSCRIPTEN
+#if CLANG_VERSION_MAJOR > 21
+  // The Emscripten JIT (LLVM 22) cannot compile this by-value wrapper -- a
+  // separate limitation from the type printing under test, shared with the
+  // other placement-new wrapper tests (e.g. FunctionReflection_Construct).
+  GTEST_SKIP() << "Test fails for Emscripten builds using LLVM 22";
+#endif
+#endif
+  std::vector<const char*> interpreter_args = {"-std=c++17", "-include", "new"};
+  TestFixture::CreateInterpreter(interpreter_args);
+  // Single namespace block: a preceding top-level class plus a namespace in one
+  // process() call makes the LLVM 20 REPL wrap the namespace into non-global
+  // scope.
+  Interp->process(R"(
+    namespace N {
+      struct Ret { int x; };
+      template <class T> inline constexpr bool trait_v = sizeof(T) > 0;
+      template <bool, class T> struct ei {};
+      template <class T> struct ei<true, T> { using type = T; };
+      template <bool B, class T> using enable_if_t = typename ei<B, T>::type;
+      template <class T> enable_if_t<trait_v<T>, Ret> f() { return {}; }
+    }
+  )");
+
+  auto spec = Cpp::InstantiateTemplateFunctionFromString("N::f<int>");
+  ASSERT_TRUE(spec) << "Sema failed to substitute N::f<int>";
+
+  // Without the fix the wrapper fails to compile (`use of undeclared identifier
+  // 'trait_v'`) and MakeFunctionCallable returns a kUnknown JitCall.
+  Cpp::JitCall JC = Cpp::MakeFunctionCallable(spec);
+  EXPECT_EQ(JC.getKind(), Cpp::JitCall::kGenericCall);
+}
+
 TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_IsConstMethod) {
   std::vector<Decl*> Decls, SubDecls;
   std::string code = R"(


### PR DESCRIPTION
When generating a JitCall wrapper for a function whose return type is a
template type alias specialisation -- e.g.
`std::enable_if_t<is_constructible_v<...>, std::any>` as on
`std::make_any` -- get_type_as_string left the alias sugared. The
printer's FullyQualifiedName policy applies to types but does not
propagate into expression-level non-type template arguments, so
identifiers like `is_constructible_v` were emitted without their `std::`
qualifier and the wrapper failed to compile with `use of undeclared
identifier`.

Strip TemplateSpecializationType sugar where isTypeAlias() is true
before printing. The desugared form is the alias body with explicit
arguments substituted (e.g. std::any), which compiles cleanly. Regular
typedefs (std::string and friends) are not TemplateSpecializationType
sugar and keep their preferred name.

Reported as cppyy issue
https://github.com/compiler-research/cppyy/issues/218; reproducer is
`cppyy.gbl.std.make_any["MyClass*", "MyClass*"](my_inst)` after
`cppyy.include("any")`.

Adds a regression test built from a stdlib-free distillation rather than
<any>, so it does not depend on libstdc++ internals. The bug needs three
ingredients, all reproduced by hand: (1) a type-alias-template return
type whose sugar carries a non-type argument that prints as an
expression (a variable-template reference), (2) that predicate living in
a namespace so the unqualified print does not resolve in the global-scope
wrapper, and (3) a class (non-builtin) canonical type returned by value,
so get_type_as_string keeps the sugar instead of taking its existing
isBuiltinType() desugaring branch.