### PR TITLE
[ci] Read install root from setup-llvm's $LLVM_DIR env.

### DIFF
--- a/.github/actions/Build_and_Test_CppInterOp/action.yml
+++ b/.github/actions/Build_and_Test_CppInterOp/action.yml
@@ -33,51 +33,38 @@ runs:
       shell: bash
       run: |
         if [[ "${{ runner.environment }}" == "self-hosted" ]]; then
-          LLVM_DIR="/usr/lib/llvm-${{ inputs.clang_runtime }}"
-          LLVM_BUILD_DIR="/usr/lib/llvm-${{ inputs.clang_runtime }}"
-          CPLUS_INCLUDE_PATH="/usr/lib/llvm-${{ inputs.clang_runtime }}/include:$PWD/include"
+          LLVM_PREFIX="/usr/lib/llvm-${{ inputs.clang_runtime }}"
+          LLVM_BUILD_DIR="$LLVM_PREFIX"
         else
-          LLVM_DIR="$(pwd)/llvm-project"
-          # Two layouts coexist on github-hosted runners:
-          #   - rows that build LLVM from source (everything except the
-          #     asan row today) leave a build tree at llvm-project/build/.
-          #   - rows that pull a prebuilt asset via setup-recipe extract
-          #     a cmake --install tree directly under llvm-project/, with
-          #     LLVMConfig.cmake at lib/cmake/llvm/ (no build/ prefix).
-          # Probe for lib/cmake/llvm to pick LLVM_BUILD_DIR; LLVMConfig.cmake
-          # lives there in either layout.
-          if [[ -d "$LLVM_DIR/lib/cmake/llvm" ]]; then
-            LLVM_BUILD_DIR="$LLVM_DIR"
+          # setup-llvm exports $LLVM_DIR pointing at the cmake-config
+          # dir; the install root is three levels up. Fall back to the
+          # legacy clone path for source-build rows that bypass setup-llvm.
+          if [[ -n "${LLVM_DIR:-}" && -f "${LLVM_DIR}/LLVMConfig.cmake" ]]; then
+            LLVM_PREFIX="$(dirname "$(dirname "$(dirname "$LLVM_DIR")")")"
           else
-            LLVM_BUILD_DIR="$LLVM_DIR/build"
+            LLVM_PREFIX="$(pwd)/llvm-project"
+          fi
+          # Source-build rows leave a build tree at llvm-project/build/;
+          # setup-recipe rows extract a cmake --install tree with
+          # LLVMConfig.cmake directly under $LLVM_PREFIX/lib/cmake/llvm.
+          if [[ -d "$LLVM_PREFIX/lib/cmake/llvm" ]]; then
+            LLVM_BUILD_DIR="$LLVM_PREFIX"
+          else
+            LLVM_BUILD_DIR="$LLVM_PREFIX/build"
           fi
           cling_on=$(echo "${{ inputs.cling }}" | tr '[:lower:]' '[:upper:]')
-          # FIXME: CPLUS_INCLUDE_PATH itself is a workaround for missing
-          # target-based include propagation in CppInterOp's cmake;
-          # find_package(LLVM)/Clang already export INTERFACE_INCLUDE_DIRECTORIES.
-          # Drop this whole CPLUS_INCLUDE_PATH plumbing once the cmake side
-          # depends on imported targets correctly.
-          #
-          # CPLUS_INCLUDE_PATH unions both layouts' include roots:
-          # ${LLVM_DIR}/include is the install-tree flat header directory;
-          # ${LLVM_DIR}/{llvm,clang}/include and ${LLVM_BUILD_DIR}/{include,tools/clang/include}
-          # are the build-tree split. Non-existent paths in the union are harmless.
           if [[ "${cling_on}" == "ON" ]]; then
-            if [[ -f "$LLVM_DIR/lib/cmake/cling/ClingConfig.cmake" ]]; then
-              # Recipe install tree: cling integrated under llvm-project,
+            if [[ -f "$LLVM_PREFIX/lib/cmake/cling/ClingConfig.cmake" ]]; then
+              # Recipe install tree: cling integrated under install/,
               # cmake config at lib/cmake/cling/, headers under include/cling/.
-              CLING_DIR="$LLVM_DIR"
-              CLING_CMAKE_DIR="$LLVM_DIR/lib/cmake/cling"
-              CPLUS_INCLUDE_PATH="${LLVM_DIR}/include:$PWD/include"
+              CLING_DIR="$LLVM_PREFIX"
+              CLING_CMAKE_DIR="$LLVM_PREFIX/lib/cmake/cling"
             else
               # Build tree: cling lives in a sibling checkout.
               CLING_DIR="$(pwd)/cling"
               CLING_BUILD_DIR="$(pwd)/cling/build"
               CLING_CMAKE_DIR="$LLVM_BUILD_DIR/tools/cling"
-              CPLUS_INCLUDE_PATH="${CLING_DIR}/tools/cling/include:${CLING_BUILD_DIR}/include:${LLVM_DIR}/include:${LLVM_DIR}/llvm/include:${LLVM_DIR}/clang/include:${LLVM_BUILD_DIR}/include:${LLVM_BUILD_DIR}/tools/clang/include:$PWD/include"
             fi
-          else
-            CPLUS_INCLUDE_PATH="${LLVM_DIR}/include:${LLVM_DIR}/llvm/include:${LLVM_DIR}/clang/include:${LLVM_BUILD_DIR}/include:${LLVM_BUILD_DIR}/tools/clang/include:$PWD/include"
           fi
         fi
 
@@ -251,7 +238,6 @@ runs:
         echo "CPPINTEROP_BUILD_DIR=$CPPINTEROP_BUILD_DIR" >> $GITHUB_ENV
         echo "CPPINTEROP_DIR=$CPPINTEROP_DIR" >> $GITHUB_ENV
         echo "LLVM_BUILD_DIR=$LLVM_BUILD_DIR" >> $GITHUB_ENV
-        echo "CPLUS_INCLUDE_PATH=$CPLUS_INCLUDE_PATH" >> $GITHUB_ENV
 
     - name: Build and Test/Install CppInterOp on Windows systems (native static library build)
       if: ${{ runner.os == 'Windows' && matrix.wasm != true }}
@@ -259,44 +245,37 @@ runs:
       run: |
         $env:PWD_DIR= $PWD.Path
 
-        $env:LLVM_DIR="$env:PWD_DIR\llvm-project"
-        echo "LLVM_DIR=$env:LLVM_DIR"
-        echo "LLVM_DIR=$env:LLVM_DIR" >> $env:GITHUB_ENV
-
-        # Probe install vs build tree (mirrors the bash branch above):
-        # recipe install trees ship LLVMConfig.cmake at lib/cmake/llvm
-        # directly; source builds leave a build/ subdir.
-        if ( Test-Path "$env:LLVM_DIR\lib\cmake\llvm" ) {
-          $env:LLVM_BUILD_DIR="$env:LLVM_DIR"
+        # Mirrors the bash branch: derive $LLVM_PREFIX from setup-llvm's
+        # $LLVM_DIR (cmake-config dir, three levels deep), fall back to
+        # the legacy clone for source-build rows.
+        if ($env:LLVM_DIR -and (Test-Path "$env:LLVM_DIR\LLVMConfig.cmake")) {
+          $env:LLVM_PREFIX = (Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $env:LLVM_DIR)))
         } else {
-          $env:LLVM_BUILD_DIR="$env:PWD_DIR\llvm-project\build"
+          $env:LLVM_PREFIX = "$env:PWD_DIR\llvm-project"
+        }
+
+        if ( Test-Path "$env:LLVM_PREFIX\lib\cmake\llvm" ) {
+          $env:LLVM_BUILD_DIR="$env:LLVM_PREFIX"
+        } else {
+          $env:LLVM_BUILD_DIR="$env:LLVM_PREFIX\build"
         }
         echo "LLVM_BUILD_DIR=$env:LLVM_BUILD_DIR"
         echo "LLVM_BUILD_DIR=$env:LLVM_BUILD_DIR" >> $env:GITHUB_ENV
 
         if ( "${{ matrix.cling }}" -imatch "On" )
         {
-          if ( Test-Path "$env:LLVM_DIR\lib\cmake\cling\ClingConfig.cmake" ) {
-            # Recipe install tree: cling integrated under llvm-project.
-            $env:CLING_DIR="$env:LLVM_DIR"
-            $env:CLING_CMAKE_DIR="$env:LLVM_DIR\lib\cmake\cling"
-            $env:CPLUS_INCLUDE_PATH="$env:LLVM_DIR\include;$env:PWD_DIR\include;"
+          if ( Test-Path "$env:LLVM_PREFIX\lib\cmake\cling\ClingConfig.cmake" ) {
+            # Recipe install tree: cling integrated under install/.
+            $env:CLING_DIR="$env:LLVM_PREFIX"
+            $env:CLING_CMAKE_DIR="$env:LLVM_PREFIX\lib\cmake\cling"
           } else {
             $env:CLING_DIR="$env:PWD_DIR\cling"
             $env:CLING_BUILD_DIR="$env:PWD_DIR\cling\build"
             $env:CLING_CMAKE_DIR="$env:LLVM_BUILD_DIR\tools\cling"
-            $env:CPLUS_INCLUDE_PATH="$env:CLING_DIR\tools\cling\include;$env:CLING_BUILD_DIR\include;$env:LLVM_DIR\llvm\include;$env:LLVM_DIR\clang\include;$env:LLVM_BUILD_DIR\include;$env:LLVM_BUILD_DIR\tools\clang\include;$env:PWD_DIR\include;"
             echo "CLING_BUILD_DIR=$env:CLING_BUILD_DIR" >> $env:GITHUB_ENV
           }
           echo "CLING_DIR=$env:CLING_DIR" >> $env:GITHUB_ENV
           echo "CLING_CMAKE_DIR=$env:CLING_CMAKE_DIR" >> $env:GITHUB_ENV
-          echo "CPLUS_INCLUDE_PATH=$env:CPLUS_INCLUDE_PATH" >> $env:GITHUB_ENV
-        }
-        else
-        {
-          $env:CPLUS_INCLUDE_PATH="$env:LLVM_DIR\llvm\include;$env:LLVM_DIR\clang\include;$env:LLVM_BUILD_DIR\include;$env:LLVM_BUILD_DIR\tools\clang\include;$env:PWD_DIR\include;"
-          echo "CPLUS_INCLUDE_PATH=$env:CPLUS_INCLUDE_PATH"
-          echo "CPLUS_INCLUDE_PATH=$env:CPLUS_INCLUDE_PATH" >> $env:GITHUB_ENV
         }
 
         $env:CB_PYTHON_DIR="$env:PWD_DIR\cppyy-backend\python"

--- a/.github/workflows/root.yml
+++ b/.github/workflows/root.yml
@@ -86,7 +86,9 @@ jobs:
         #     CPLUS_INCLUDE_PATH; an over-aggressive trim that nukes
         #     `clang/include` would surface here instead of as a
         #     `RStl.cxx.o` compile failure mid-ROOT-build).
-        LLVM="$GITHUB_WORKSPACE/llvm-project"
+        # setup-llvm exports $LLVM_DIR pointing at the cmake-config dir;
+        # the install root is three levels up.
+        LLVM="$(dirname "$(dirname "$(dirname "$LLVM_DIR")")")"
         fail=0
         for f in \
             "$LLVM/lib/cmake/llvm/LLVMConfig.cmake" \
@@ -197,6 +199,7 @@ jobs:
         # fails. Inject the top-level build/include globally via
         # `CMAKE_CXX_FLAGS`.
         CPPINTEROP_GEN_INC="$PWD/include"
+        LLVM_PREFIX="$(dirname "$(dirname "$(dirname "$LLVM_DIR")")")"
         cmake -G Ninja \
               -DCMAKE_BUILD_TYPE=Release \
               -DCMAKE_C_COMPILER_LAUNCHER=ccache \
@@ -209,9 +212,9 @@ jobs:
               -Dfail-on-missing=ON \
               -Dbuiltin_llvm=OFF \
               -Dbuiltin_clang=OFF \
-              -DCMAKE_PREFIX_PATH="$GITHUB_WORKSPACE/llvm-project" \
-              -DClang_DIR="$GITHUB_WORKSPACE/llvm-project/lib/cmake/clang" \
-              -DCLANG_INSTALL_PREFIX="$GITHUB_WORKSPACE/llvm-project" \
+              -DCMAKE_PREFIX_PATH="$LLVM_PREFIX" \
+              -DClang_DIR="$Clang_DIR" \
+              -DCLANG_INSTALL_PREFIX="$LLVM_PREFIX" \
               -DCMAKE_CXX_FLAGS="-I${CPPINTEROP_GEN_INC}" \
               ../root
 
@@ -222,12 +225,10 @@ jobs:
         # public include dirs but doesn't propagate `CLANG_INCLUDE_DIRS`
         # to its compile rules, so `TClingUtils.h`'s
         # `#include "clang/Basic/Module.h"` resolves only via
-        # `CPLUS_INCLUDE_PATH` -- the same way main.yml's cling rows
-        # resolve clang headers in `Build_and_Test_CppInterOp/action.yml`.
-        # Mirror that env here so `RStl.cxx` and friends find their
-        # clang/cling headers from the recipe's install tree.
-        LLVM="$GITHUB_WORKSPACE/llvm-project"
-        export CPLUS_INCLUDE_PATH="$LLVM/include"
+        # `CPLUS_INCLUDE_PATH`. Mirror that env here so `RStl.cxx` and
+        # friends find their clang/cling headers from the recipe install.
+        LLVM_PREFIX="$(dirname "$(dirname "$(dirname "$LLVM_DIR")")")"
+        export CPLUS_INCLUDE_PATH="$LLVM_PREFIX/include"
         cmake --build root-build --parallel ${{ env.ncpus }}
 
     # ROOT's top-level enable_testing() is gated on -Dtesting=ON, so a


### PR DESCRIPTION
Build_and_Test_CppInterOp's github-hosted branch hardcoded LLVM_DIR="$(pwd)/llvm-project" -- a path the ci-workflows install-tree rename moved to $WS/install/. setup-llvm now exports $LLVM_DIR / $Clang_DIR pointing at the cmake-config dirs (compiler-research/ci-workflows#68). Derive the install root three levels up from $LLVM_DIR when it's set; fall back to the legacy clone path for source-build rows that don't go through setup-llvm. Same fix applied to the Windows native step and to root.yml's cell-layout sanity-check + cmake invocation. The bash local that meant "install root" was also named LLVM_DIR -- it shadowed the env var on second-read paths; renamed to LLVM_PREFIX throughout. self-hosted's branch tracks the same rename for consistency.

Drop CPLUS_INCLUDE_PATH from the native bash and Windows steps. The FIXME documented this as a workaround for missing target-based include propagation; CppInterOp's CMakeLists.txt already calls `include_directories(SYSTEM ${LLVM_INCLUDE_DIRS})` and `${CLANG_INCLUDE_DIRS}` (lines 337-338), making the env-var union redundant. Wasm steps keep their CPLUS_INCLUDE_PATH for now (separate emscripten-side story). ROOT keeps it too: ROOT's own cmake doesn't propagate CLANG_INCLUDE_DIRS, and that's an upstream ROOT bug rather than a workaround we should chase here.

# Description

Please include a summary of changes, motivation and context for this PR.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [ ] I have read the contribution guide recently
