### PR TITLE
[Tracing] Register JitCall pointer returns in the handle map.

### DIFF
--- a/include/CppInterOp/CppInterOpTypes.h
+++ b/include/CppInterOp/CppInterOpTypes.h
@@ -61,6 +61,8 @@ inline void (*TraceJitCallInvoke)(const CppImpl::JitCall* JC, void* result,
 inline void (*TraceJitCallInvokeDestructor)(const CppImpl::JitCall* JC,
                                             void* object, unsigned long nary,
                                             int withFree) noexcept = nullptr;
+inline void (*TraceJitCallInvokeReturn)(const CppImpl::JitCall* JC,
+                                        void* result) noexcept = nullptr;
 #else
 extern CPPINTEROP_API void (*TraceJitCallInvoke)(const CppImpl::JitCall* JC,
                                                  void* result, void** args,
@@ -69,6 +71,8 @@ extern CPPINTEROP_API void (*TraceJitCallInvoke)(const CppImpl::JitCall* JC,
 extern CPPINTEROP_API void (*TraceJitCallInvokeDestructor)(
     const CppImpl::JitCall* JC, void* object, unsigned long nary,
     int withFree) noexcept;
+extern CPPINTEROP_API void (*TraceJitCallInvokeReturn)(
+    const CppImpl::JitCall* JC, void* result) noexcept;
 #endif
 } // namespace DispatchRaw
 } // namespace CppInternal
@@ -273,12 +277,12 @@ private:
                                                          void* object,
                                                          unsigned long nary,
                                                          int withFree) noexcept;
+  friend void CppInterOpTraceJitCallInvokeReturnImpl(const JitCall*,
+                                                     void* result) noexcept;
 
   /// Checks if the passed arguments are valid for the given function.
   CPPINTEROP_API bool AreArgumentsValid(void* result, ArgList args, void* self,
                                         size_t nary) const;
-
-  void ReportInvokeEnd() const;
 
 public:
   [[nodiscard]] Kind getKind() const { return m_Kind; }
@@ -315,6 +319,8 @@ public:
       if (auto fn = ::CppInternal::DispatchRaw::TraceJitCallInvoke)
         fn(this, result, args.m_Args, args.m_ArgSize, self);
       m_GenericCall(self, args.m_ArgSize, args.m_Args, result);
+      if (auto fn = ::CppInternal::DispatchRaw::TraceJitCallInvokeReturn)
+        fn(this, result);
       break;
 
     case kConstructorCall:
@@ -359,9 +365,11 @@ public:
     assert(m_Kind == kConstructorCall && "Wrong overload!");
     assert(AreArgumentsValid(result, args, /*self=*/nullptr, nary) &&
            "Invalid args!");
-    if (auto fn = CppInternal::DispatchRaw::TraceJitCallInvoke)
+    if (auto fn = ::CppInternal::DispatchRaw::TraceJitCallInvoke)
       fn(this, result, args.m_Args, args.m_ArgSize, nullptr);
     m_ConstructorCall(result, nary, args.m_ArgSize, args.m_Args, is_arena);
+    if (auto fn = ::CppInternal::DispatchRaw::TraceJitCallInvokeReturn)
+      fn(this, result);
   }
 };
 

--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -506,6 +506,27 @@ void CppInterOpTraceJitCallInvokeDestructorImpl(const JitCall* JC, void* object,
                     Name, ObjPart, nary, withFree));
 }
 
+// Post-invoke trace hook reached via DispatchRaw. Constructors and
+// pointer/reference returns deposit a fresh T* at *result; registering
+// it as vN lets later trace lines render the name instead of
+// `nullptr /*unknown*/`. No-op for value or void returns.
+void CppInterOpTraceJitCallInvokeReturnImpl(const JitCall* JC,
+                                            void* result) noexcept {
+  auto* TI = CppInterOp::Tracing::TheTraceInfo;
+  if (!TI || !result)
+    return;
+  const auto* FD = static_cast<const FunctionDecl*>(JC->m_FD);
+  bool RegisterPtr = isa<CXXConstructorDecl>(FD);
+  if (!RegisterPtr) {
+    QualType RT = FD->getReturnType();
+    RegisterPtr = RT->isPointerType() || RT->isReferenceType();
+  }
+  if (!RegisterPtr)
+    return;
+  if (void* p = *static_cast<void* const*>(result))
+    TI->getOrRegisterHandle(p);
+}
+
 #undef DEBUG_TYPE
 
 std::string GetVersion() {

--- a/lib/CppInterOp/Tracing.cpp
+++ b/lib/CppInterOp/Tracing.cpp
@@ -34,6 +34,8 @@ void CppInterOpTraceJitCallInvokeImpl(const JitCall* JC, void* result,
 void CppInterOpTraceJitCallInvokeDestructorImpl(const JitCall* JC, void* object,
                                                 unsigned long nary,
                                                 int withFree) noexcept;
+void CppInterOpTraceJitCallInvokeReturnImpl(const JitCall* JC,
+                                            void* result) noexcept;
 } // namespace CppImpl
 
 // Linked-mode slot definitions; Dispatch.h consumers use per-DSO inline.
@@ -43,6 +45,8 @@ void (*TraceJitCallInvoke)(const CppImpl::JitCall*, void*, void**, std::size_t,
                            void*) noexcept = nullptr;
 void (*TraceJitCallInvokeDestructor)(const CppImpl::JitCall*, void*,
                                      unsigned long, int) noexcept = nullptr;
+void (*TraceJitCallInvokeReturn)(const CppImpl::JitCall*,
+                                 void*) noexcept = nullptr;
 } // namespace DispatchRaw
 } // namespace CppInternal
 
@@ -61,6 +65,8 @@ void InitTracing() {
       &CppImpl::CppInterOpTraceJitCallInvokeImpl;
   ::CppInternal::DispatchRaw::TraceJitCallInvokeDestructor =
       &CppImpl::CppInterOpTraceJitCallInvokeDestructorImpl;
+  ::CppInternal::DispatchRaw::TraceJitCallInvokeReturn =
+      &CppImpl::CppInterOpTraceJitCallInvokeReturnImpl;
 }
 
 std::optional<uint64_t> TraceRegion::lookupOutMask(llvm::StringRef Name) {

--- a/unittests/CppInterOp/TracingTests.cpp
+++ b/unittests/CppInterOp/TracingTests.cpp
@@ -1339,6 +1339,38 @@ TEST_F(TracingTest, JitCallDestructorInvokeLogged) {
   EXPECT_THAT(log, HasSubstr("JitCall::InvokeDestructor"));
   EXPECT_THAT(log, HasSubstr("Baz"));
 }
+
+TEST_F(TracingTest, JitCallReturnedPointerRegistered) {
+  // Factory returning T*: the wrapper writes the new pointer at
+  // *result; the return-hook registers it as a vN handle so later
+  // trace lines that consume it render the name instead of
+  // `nullptr /*unknown*/`.
+  Cpp::CreateInterpreter({});
+  ASSERT_NE(TheTraceInfo, nullptr);
+
+  Cpp::Declare("#include <new>");
+  Cpp::Declare("namespace InvRetNS { struct Foo {}; "
+               "Foo* makeFoo() { return new Foo(); } }");
+  auto* MakeFD = Cpp::GetNamed("makeFoo", Cpp::GetScope("InvRetNS"));
+  ASSERT_NE(MakeFD, nullptr);
+  auto MakeJC = Cpp::MakeFunctionCallable(MakeFD);
+  ASSERT_TRUE(MakeJC.isValid());
+
+  // Sanity: an unrelated pointer remains unregistered.
+  EXPECT_TRUE(TheTraceInfo->lookupHandle(reinterpret_cast<void*>(0x1)).empty());
+
+  void* foo = nullptr;
+  MakeJC.Invoke(&foo);
+  ASSERT_NE(foo, nullptr);
+
+  // After Invoke the return-hook has registered foo; lookupHandle
+  // yields its assigned name instead of "".
+  EXPECT_FALSE(TheTraceInfo->lookupHandle(foo).empty());
+
+  // makeFoo heap-allocated a trivially-destructible Foo; free it so
+  // LeakSanitizer doesn't flag the allocation.
+  ::operator delete(foo);
+}
 #endif
 
 // Verify that log entries include timing annotations.


### PR DESCRIPTION
cppyy invokes JIT-compiled wrappers via Cpp::JitCall::Invoke for constructors and pointer-returning factories rather than going through Cpp::Construct/Allocate. The returned pointer never passes through INTEROP_RETURN, so the next public API call that consumes it -- e.g. Cpp::ObjToString(type, raw_ptr) -- renders it as `nullptr /*unknown*/` in the captured trace. A reviewer reading the reproducer cannot tell which earlier object the call references, and replay cannot reconstruct the binding.

Add a third trace-hook slot `CppInternal::DispatchRaw::TraceJitCall- InvokeReturn` and call it from JitCall::Invoke (kGenericCall) and InvokeConstructor right after the wrapper runs. Off-trace the slot is nullptr and the body is one extra load + branch -- the same shape as the start-hook slot the parent commit established. The impl `CppInterOpTraceJitCallInvokeReturnImpl` (free function in CppImpl, friended by JitCall to read m_FD) reads `*result` and registers the pointer via TraceInfo::getOrRegisterHandle when the function is a constructor or returns T*/T&; value and void returns are skipped. libclangCppInterOp's InitTracing wires its own slot; Dispatch.h consumers populate their per-DSO inline slot at LoadDispatchAPI time.

Test: JitCallReturnedPointerRegistered builds a JitCall for a factory returning Foo*, invokes it, and asserts lookupHandle on the returned pointer yields a non-empty vN name -- i.e. the return-hook registered it. The existing in-tree DownstreamLoaderTest continues to pass since the new slot is per-DSO inline in Dispatch.h mode, no new UND symbol crosses the link.

# Description

Please include a summary of changes, motivation and context for this PR.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [ ] I have read the contribution guide recently
