### PR TITLE
add API to work with FunctionProtoType

### DIFF
--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -125,6 +125,7 @@
 #include <dlfcn.h>
 #include <unistd.h>
 #endif // WIN32
+#include <vector>
 
 //  Runtime symbols required if the library using JIT (Cpp::Evaluate) does
 //  not link to llvm
@@ -1553,6 +1554,25 @@ TCppType_t GetFunctionReturnType(TCppFunction_t func) {
         (FD->getTemplatedDecl())->getReturnType().getAsOpaquePtr());
 
   return INTEROP_RETURN(nullptr);
+}
+
+bool IsFunctionProtoType(TCppType_t typ) {
+  INTEROP_TRACE(typ);
+  QualType QT = QualType::getFromOpaquePtr(typ);
+  const auto* T = QT.getTypePtr();
+  return llvm::isa_and_nonnull<clang::FunctionProtoType>(T);
+}
+
+void GetFnTypeSignature(TCppType_t fn_type, std::vector<TCppType_t>& sig) {
+  INTEROP_TRACE(fn_type, INTEROP_OUT(sig));
+  QualType QT = QualType::getFromOpaquePtr(fn_type);
+  const auto* FPT = QT->getAs<clang::FunctionProtoType>();
+  if (!FPT)
+    return INTEROP_VOID_RETURN();
+  sig.push_back(FPT->getReturnType().getAsOpaquePtr());
+  for (size_t i = 0; i < FPT->getNumParams(); i++)
+    sig.push_back(FPT->getParamType(i).getAsOpaquePtr());
+  return INTEROP_VOID_RETURN();
 }
 
 TCppIndex_t GetFunctionNumArgs(TCppFunction_t func) {

--- a/lib/CppInterOp/CppInterOp.td
+++ b/lib/CppInterOp/CppInterOp.td
@@ -744,6 +744,26 @@ supplied as a parameter.
   ];
 }
 
+def IsFunctionProtoType : CppInterOpAPI {
+  let Doc = "Check if given type is FunctionProtoType.";
+
+  let ReturnType = "bool";
+  let Args = [
+    Arg<"TCppType_t", "typ">
+  ];
+}
+
+def GetFnTypeSignature : CppInterOpAPI {
+  let Doc = [{Pushed the signature type of the given function type,
+  where the first item is the return type.}];
+
+  let ReturnType = "void";
+  let Args = [
+    Arg<"TCppType_t", "fn_type">,
+    OutArg<"std::vector<TCppType_t>&", "sig">
+  ];
+}
+
 def GetFunctionNumArgs : CppInterOpAPI {
   let Doc = "Gets the number of Arguments for the provided function.";
 

--- a/unittests/CppInterOp/FunctionReflectionTest.cpp
+++ b/unittests/CppInterOp/FunctionReflectionTest.cpp
@@ -7,6 +7,7 @@
 #include "clang/Frontend/CompilerInstance.h"
 #include "clang/Sema/Sema.h"
 
+#include <CppInterOp/CppInterOpTypes.h>
 #include <llvm/ADT/ArrayRef.h>
 
 #include "clang-c/CXCppInterOp.h"
@@ -586,6 +587,48 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_GetFunctionArgType) {
   EXPECT_EQ(Cpp::GetTypeAsString(Cpp::GetFunctionArgType(Decls[1], 2)), "long *");
   EXPECT_EQ(Cpp::GetTypeAsString(Cpp::GetFunctionArgType(Decls[1], 3)), "char[4]");
   EXPECT_EQ(Cpp::GetTypeAsString(Cpp::GetFunctionArgType(Decls[2], 0)), "NULL TYPE");
+}
+
+TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_FunctionTypes) {
+  std::vector<Decl*> Decls;
+  std::string code = R"(
+      typedef int myint;
+      int (*f1)(int, double) = nullptr;
+      void f2(int (&f)(myint, double)) {}
+    )";
+
+  GetAllTopLevelDecls(code, Decls);
+  EXPECT_EQ(Decls.size(), 3);
+
+  Cpp::TCppType_t typ1 = Cpp::GetVariableType(Decls[1]);
+  EXPECT_TRUE(typ1);
+  EXPECT_FALSE(Cpp::IsFunctionProtoType(typ1));
+  EXPECT_TRUE(Cpp::IsFunctionProtoType(Cpp::GetPointeeType(typ1)));
+
+  typ1 = Cpp::GetPointeeType(typ1);
+  EXPECT_TRUE(typ1);
+
+  std::vector<Cpp::TCppType_t> sig;
+  Cpp::GetFnTypeSignature(typ1, sig);
+  EXPECT_EQ(sig.size(), 3);
+  EXPECT_EQ(Cpp::GetTypeAsString(sig[0]), "int");
+  EXPECT_EQ(Cpp::GetTypeAsString(sig[1]), "int");
+  EXPECT_EQ(Cpp::GetTypeAsString(sig[2]), "double");
+
+  Cpp::TCppType_t typ2 = Cpp::GetFunctionArgType(Decls[2], 0);
+  EXPECT_TRUE(typ1);
+
+  typ2 = Cpp::GetNonReferenceType(typ2);
+  EXPECT_TRUE(typ2);
+
+  sig.clear();
+  Cpp::GetFnTypeSignature(typ2, sig);
+  EXPECT_EQ(sig.size(), 3);
+  EXPECT_EQ(Cpp::GetTypeAsString(sig[0]), "int");
+  EXPECT_EQ(Cpp::GetTypeAsString(sig[1]), "myint");
+  EXPECT_EQ(Cpp::GetTypeAsString(sig[2]), "double");
+
+  EXPECT_TRUE(Cpp::IsSameType(typ1, typ2));
 }
 
 TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_GetFunctionSignature) {


### PR DESCRIPTION
These functions take `QualType`, when a `Decl` is not available.
For example:
```c++
void f2(int (&f)(int, double)) {}
```
The first argument is a `QualType`, and there is no associated `Decl`.