### PR TITLE
[Tracing] Route JitCall trace hooks through CppInterOp.td.

### DIFF
--- a/include/CppInterOp/CppInterOpTypes.h
+++ b/include/CppInterOp/CppInterOpTypes.h
@@ -49,31 +49,16 @@ class JitCall;
 }
 namespace CppInternal {
 namespace DispatchRaw {
-/// JitCall::Invoke trace-hook slots. Dispatch.h consumers get a per-DSO
-/// inline (vague-linkage) variable -- no UND symbol crosses the link --
-/// populated by LoadDispatchAPI. Linked consumers share a single extern
-/// definition in libclangCppInterOp, populated by InitTracing. Nullptr
-/// means tracing is off.
-#ifdef CPPINTEROP_DISPATCH_H
-inline void (*TraceJitCallInvoke)(const CppImpl::JitCall* JC, void* result,
-                                  void** args, std::size_t nargs,
-                                  void* self) noexcept = nullptr;
-inline void (*TraceJitCallInvokeDestructor)(const CppImpl::JitCall* JC,
-                                            void* object, unsigned long nary,
-                                            int withFree) noexcept = nullptr;
-inline void (*TraceJitCallInvokeReturn)(const CppImpl::JitCall* JC,
-                                        void* result) noexcept = nullptr;
-#else
-extern CPPINTEROP_API void (*TraceJitCallInvoke)(const CppImpl::JitCall* JC,
-                                                 void* result, void** args,
-                                                 std::size_t nargs,
-                                                 void* self) noexcept;
-extern CPPINTEROP_API void (*TraceJitCallInvokeDestructor)(
-    const CppImpl::JitCall* JC, void* object, unsigned long nary,
-    int withFree) noexcept;
-extern CPPINTEROP_API void (*TraceJitCallInvokeReturn)(
-    const CppImpl::JitCall* JC, void* result) noexcept;
-#endif
+// Trace-hook slot forward decls; the X-macro expansion of
+// CppInterOpAPI.inc re-declares these with identical types. They're
+// here so JitCall::Invoke's inline body below can reference them.
+extern void (*CppInterOpTraceJitCallInvokeImpl)(const CppImpl::JitCall* JC,
+                                                void* result, void** args,
+                                                std::size_t nargs, void* self);
+extern void (*CppInterOpTraceJitCallInvokeDestructorImpl)(
+    const CppImpl::JitCall* JC, void* object, unsigned long nary, int withFree);
+extern void (*CppInterOpTraceJitCallInvokeReturnImpl)(
+    const CppImpl::JitCall* JC, void* result);
 } // namespace DispatchRaw
 } // namespace CppInternal
 
@@ -270,15 +255,17 @@ private:
       : m_DestructorCall(C), m_Kind(K), m_FD(Dtor) {}
 
   // Trace-hook impls need private m_FD for the function-name lookup.
-  friend void CppInterOpTraceJitCallInvokeImpl(const JitCall*, void* result,
-                                               void** args, std::size_t nargs,
-                                               void* self) noexcept;
-  friend void CppInterOpTraceJitCallInvokeDestructorImpl(const JitCall*,
-                                                         void* object,
-                                                         unsigned long nary,
-                                                         int withFree) noexcept;
-  friend void CppInterOpTraceJitCallInvokeReturnImpl(const JitCall*,
-                                                     void* result) noexcept;
+  // CPPINTEROP_API matches the X-macro-generated decl in CppInterOpDecl.inc;
+  // MSVC treats a friend decl without the dllimport/dllexport attribute as
+  // a different-linkage redeclaration.
+  friend CPPINTEROP_API void
+  CppInterOpTraceJitCallInvokeImpl(const JitCall*, void* result, void** args,
+                                   std::size_t nargs, void* self);
+  friend CPPINTEROP_API void
+  CppInterOpTraceJitCallInvokeDestructorImpl(const JitCall*, void* object,
+                                             unsigned long nary, int withFree);
+  friend CPPINTEROP_API void
+  CppInterOpTraceJitCallInvokeReturnImpl(const JitCall*, void* result);
 
   /// Checks if the passed arguments are valid for the given function.
   CPPINTEROP_API bool AreArgumentsValid(void* result, ArgList args, void* self,
@@ -316,10 +303,12 @@ public:
     case kGenericCall:
       // We pass 1UL to nary which is only relevant for structors
       assert(AreArgumentsValid(result, args, self, 1UL) && "Invalid args!");
-      if (auto fn = ::CppInternal::DispatchRaw::TraceJitCallInvoke)
+      if (auto fn =
+              ::CppInternal::DispatchRaw::CppInterOpTraceJitCallInvokeImpl)
         fn(this, result, args.m_Args, args.m_ArgSize, self);
       m_GenericCall(self, args.m_ArgSize, args.m_Args, result);
-      if (auto fn = ::CppInternal::DispatchRaw::TraceJitCallInvokeReturn)
+      if (auto fn = ::CppInternal::DispatchRaw::
+              CppInterOpTraceJitCallInvokeReturnImpl)
         fn(this, result);
       break;
 
@@ -346,7 +335,8 @@ public:
   void InvokeDestructor(void* object, unsigned long nary = 0,
                         int withFree = true) const {
     assert(m_Kind == kDestructorCall && "Wrong overload!");
-    if (auto fn = ::CppInternal::DispatchRaw::TraceJitCallInvokeDestructor)
+    if (auto fn = ::CppInternal::DispatchRaw::
+            CppInterOpTraceJitCallInvokeDestructorImpl)
       fn(this, object, nary, withFree);
     m_DestructorCall(object, nary, withFree);
   }
@@ -365,10 +355,11 @@ public:
     assert(m_Kind == kConstructorCall && "Wrong overload!");
     assert(AreArgumentsValid(result, args, /*self=*/nullptr, nary) &&
            "Invalid args!");
-    if (auto fn = ::CppInternal::DispatchRaw::TraceJitCallInvoke)
+    if (auto fn = ::CppInternal::DispatchRaw::CppInterOpTraceJitCallInvokeImpl)
       fn(this, result, args.m_Args, args.m_ArgSize, nullptr);
     m_ConstructorCall(result, nary, args.m_ArgSize, args.m_Args, is_arena);
-    if (auto fn = ::CppInternal::DispatchRaw::TraceJitCallInvokeReturn)
+    if (auto fn =
+            ::CppInternal::DispatchRaw::CppInterOpTraceJitCallInvokeReturnImpl)
       fn(this, result);
   }
 };

--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -467,7 +467,7 @@ bool JitCall::AreArgumentsValid(void* result, ArgList args, void* self,
 // Off-trace the slot is nullptr and these never run.
 void CppInterOpTraceJitCallInvokeImpl(const JitCall* JC, void* result,
                                       void** args, std::size_t nargs,
-                                      void* self) noexcept {
+                                      void* self) {
   auto* TI = CppInterOp::Tracing::TheTraceInfo;
   if (!TI)
     return;
@@ -488,7 +488,7 @@ void CppInterOpTraceJitCallInvokeImpl(const JitCall* JC, void* result,
 
 void CppInterOpTraceJitCallInvokeDestructorImpl(const JitCall* JC, void* object,
                                                 unsigned long nary,
-                                                int withFree) noexcept {
+                                                int withFree) {
   auto* TI = CppInterOp::Tracing::TheTraceInfo;
   if (!TI)
     return;
@@ -510,8 +510,7 @@ void CppInterOpTraceJitCallInvokeDestructorImpl(const JitCall* JC, void* object,
 // pointer/reference returns deposit a fresh T* at *result; registering
 // it as vN lets later trace lines render the name instead of
 // `nullptr /*unknown*/`. No-op for value or void returns.
-void CppInterOpTraceJitCallInvokeReturnImpl(const JitCall* JC,
-                                            void* result) noexcept {
+void CppInterOpTraceJitCallInvokeReturnImpl(const JitCall* JC, void* result) {
   auto* TI = CppInterOp::Tracing::TheTraceInfo;
   if (!TI || !result)
     return;

--- a/lib/CppInterOp/CppInterOp.td
+++ b/lib/CppInterOp/CppInterOp.td
@@ -1484,3 +1484,39 @@ def IsVoidPointerType : CppInterOpAPI {
   let ReturnType = "bool";
   let Args = [Arg<"TCppType_t", "type">];
 }
+
+// Trace-hook impls invoked by JitCall's inline fast path through
+// ::CppInternal::DispatchRaw slots. Routing through the X-macro means
+// Dispatch.h consumers pick up the slots via LoadDispatchAPI without
+// any source change of their own.
+def CppInterOpTraceJitCallInvokeImpl : CppInterOpAPI {
+  let Doc = "Trace hook for the JitCall::Invoke generic call path.";
+  let ReturnType = "void";
+  let Args = [
+    Arg<"const CppImpl::JitCall*", "JC">,
+    Arg<"void*", "result">,
+    Arg<"void**", "args">,
+    Arg<"std::size_t", "nargs">,
+    Arg<"void*", "self">
+  ];
+}
+
+def CppInterOpTraceJitCallInvokeDestructorImpl : CppInterOpAPI {
+  let Doc = "Trace hook for the JitCall::InvokeDestructor path.";
+  let ReturnType = "void";
+  let Args = [
+    Arg<"const CppImpl::JitCall*", "JC">,
+    Arg<"void*", "object">,
+    Arg<"unsigned long", "nary">,
+    Arg<"int", "withFree">
+  ];
+}
+
+def CppInterOpTraceJitCallInvokeReturnImpl : CppInterOpAPI {
+  let Doc = "Trace hook for post-Invoke pointer-return handle registration.";
+  let ReturnType = "void";
+  let Args = [
+    Arg<"const CppImpl::JitCall*", "JC">,
+    Arg<"void*", "result">
+  ];
+}

--- a/lib/CppInterOp/Tracing.cpp
+++ b/lib/CppInterOp/Tracing.cpp
@@ -25,28 +25,17 @@
 #include <dlfcn.h>
 #endif
 
-// Forward-declare impls (defined in CppInterOp.cpp) so InitTracing can
-// take their address.
-namespace CppImpl {
-void CppInterOpTraceJitCallInvokeImpl(const JitCall* JC, void* result,
-                                      void** args, std::size_t nargs,
-                                      void* self) noexcept;
-void CppInterOpTraceJitCallInvokeDestructorImpl(const JitCall* JC, void* object,
-                                                unsigned long nary,
-                                                int withFree) noexcept;
-void CppInterOpTraceJitCallInvokeReturnImpl(const JitCall* JC,
-                                            void* result) noexcept;
-} // namespace CppImpl
-
-// Linked-mode slot definitions; Dispatch.h consumers use per-DSO inline.
+// libclangCppInterOp's own trace-hook slot storage; Dispatch.h
+// consumers carry their per-DSO copies, populated by LoadDispatchAPI.
 namespace CppInternal {
 namespace DispatchRaw {
-void (*TraceJitCallInvoke)(const CppImpl::JitCall*, void*, void**, std::size_t,
-                           void*) noexcept = nullptr;
-void (*TraceJitCallInvokeDestructor)(const CppImpl::JitCall*, void*,
-                                     unsigned long, int) noexcept = nullptr;
-void (*TraceJitCallInvokeReturn)(const CppImpl::JitCall*,
-                                 void*) noexcept = nullptr;
+void (*CppInterOpTraceJitCallInvokeImpl)(const CppImpl::JitCall*, void*, void**,
+                                         std::size_t, void*) = nullptr;
+void (*CppInterOpTraceJitCallInvokeDestructorImpl)(const CppImpl::JitCall*,
+                                                   void*, unsigned long,
+                                                   int) = nullptr;
+void (*CppInterOpTraceJitCallInvokeReturnImpl)(const CppImpl::JitCall*,
+                                               void*) = nullptr;
 } // namespace DispatchRaw
 } // namespace CppInternal
 
@@ -59,13 +48,13 @@ void InitTracing() {
   assert(!TheTraceInfo);
   static llvm::ManagedStatic<TraceInfo> TI;
   TheTraceInfo = &*TI;
-  // Wire libclangCppInterOp's own DispatchRaw slot; Dispatch.h
-  // consumers wire their per-DSO copy at LoadDispatchAPI time.
-  ::CppInternal::DispatchRaw::TraceJitCallInvoke =
+  // Wire libclangCppInterOp's own slots; Dispatch.h consumers do
+  // the equivalent via the X-macro in LoadDispatchAPI.
+  ::CppInternal::DispatchRaw::CppInterOpTraceJitCallInvokeImpl =
       &CppImpl::CppInterOpTraceJitCallInvokeImpl;
-  ::CppInternal::DispatchRaw::TraceJitCallInvokeDestructor =
+  ::CppInternal::DispatchRaw::CppInterOpTraceJitCallInvokeDestructorImpl =
       &CppImpl::CppInterOpTraceJitCallInvokeDestructorImpl;
-  ::CppInternal::DispatchRaw::TraceJitCallInvokeReturn =
+  ::CppInternal::DispatchRaw::CppInterOpTraceJitCallInvokeReturnImpl =
       &CppImpl::CppInterOpTraceJitCallInvokeReturnImpl;
 }
 

--- a/unittests/CppInterOp/CMakeLists.txt
+++ b/unittests/CppInterOp/CMakeLists.txt
@@ -124,7 +124,8 @@ if(NOT EMSCRIPTEN AND BUILD_SHARED_LIBS)
     BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/bin/$<CONFIG>/
     LIBRARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/bin/$<CONFIG>/
   )
-  add_test(NAME cppinterop-DownstreamLoaderTest COMMAND TestDownstreamLoader)
+  add_test(NAME cppinterop-DownstreamLoaderTest
+    COMMAND TestDownstreamLoader $<TARGET_FILE:clangCppInterOp>)
   set_tests_properties(cppinterop-DownstreamLoaderTest PROPERTIES
     TIMEOUT "${TIMEOUT_VALUE}")
 endif()

--- a/unittests/CppInterOp/TestDownstreamLib/TestDownstreamLib.cpp
+++ b/unittests/CppInterOp/TestDownstreamLib/TestDownstreamLib.cpp
@@ -1,14 +1,33 @@
 #include "TestDownstreamLib.h"
 
-// Dispatch.h is the cppyy-backend consumer entry point; including it
-// selects per-DSO inline DispatchRaw slots.
 #include "CppInterOp/Dispatch.h"
 
-// ODR-uses the inline JitCall fast path. JC is an opaque param so the
-// optimizer can't DCE the calls at any -O level. The body never runs;
-// only the .o's UND-symbol surface matters.
+// Per-DSO slot storage, mirroring cppyy-backend's cppinterop_dispatch.cxx.
+namespace CppInternal {
+namespace DispatchRaw {
+#define CPPINTEROP_API_FUNC(DN, CN, Ret, DeclArgs, CallArgs, RawTypes)         \
+  Ret(*DN) RawTypes = nullptr;
+#include "CppInterOp/CppInterOpAPI.inc"
+} // namespace DispatchRaw
+} // namespace CppInternal
+
+// ODR-uses the inline JitCall fast path. JC is opaque so the optimizer
+// can't DCE the calls at any -O level. The body never runs at test
+// time; only the .o's UND-symbol surface matters.
 void downstream_link_probe(CppImpl::JitCall* JC) {
   JC->Invoke();
   JC->InvokeConstructor(nullptr);
   JC->InvokeDestructor(nullptr);
+}
+
+int downstream_verify_trace_slots(const char* libpath) {
+  if (!CppInternal::Dispatch::LoadDispatchAPI(libpath))
+    return 1;
+  if (!CppInternal::DispatchRaw::CppInterOpTraceJitCallInvokeImpl)
+    return 2;
+  if (!CppInternal::DispatchRaw::CppInterOpTraceJitCallInvokeDestructorImpl)
+    return 3;
+  if (!CppInternal::DispatchRaw::CppInterOpTraceJitCallInvokeReturnImpl)
+    return 4;
+  return 0;
 }

--- a/unittests/CppInterOp/TestDownstreamLib/TestDownstreamLib.h
+++ b/unittests/CppInterOp/TestDownstreamLib/TestDownstreamLib.h
@@ -7,11 +7,16 @@ namespace CppImpl {
 class JitCall;
 }
 #ifdef _WIN32
-extern "C" __declspec(dllexport) void downstream_link_probe(
-    CppImpl::JitCall* JC);
+#define TESTDOWNSTREAM_EXPORT extern "C" __declspec(dllexport)
 #else
-extern "C" __attribute__((visibility("default"))) void
-downstream_link_probe(CppImpl::JitCall* JC);
+#define TESTDOWNSTREAM_EXPORT extern "C" __attribute__((visibility("default")))
 #endif
+TESTDOWNSTREAM_EXPORT void downstream_link_probe(CppImpl::JitCall* JC);
+
+/// After LoadDispatchAPI(libpath) succeeds, check every DispatchRaw
+/// trace slot in this DSO is non-null. Returns 0 on success, a
+/// positive non-zero code on the first failure (1=LoadDispatchAPI
+/// failed, 2/3/4=corresponding slot still null).
+TESTDOWNSTREAM_EXPORT int downstream_verify_trace_slots(const char* libpath);
 
 #endif // UNITTESTS_CPPINTEROP_TESTDOWNSTREAMLIB_TESTDOWNSTREAMLIB_H

--- a/unittests/CppInterOp/TestDownstreamLoader.cpp
+++ b/unittests/CppInterOp/TestDownstreamLoader.cpp
@@ -1,38 +1,56 @@
-// dlopens TestDownstreamLib without linking libclangCppInterOp -- the
-// same loader posture cppyy_backend.loader uses. Exit status is what
-// ctest checks; any unsatisfied UND on the probe trips here.
+// dlopens TestDownstreamLib without linking libclangCppInterOp; with
+// argv[1] = libclangCppInterOp path, also drives the probe's
+// LoadDispatchAPI check to pin the X-macro slot-population contract.
 
 #include <cstdio>
 #include <cstdlib>
 
 #ifdef _WIN32
 #include <windows.h>
+using HandleTy = HMODULE;
+static HandleTy openLib(const char* p) { return LoadLibraryA(p); }
+static void* findSym(HandleTy h, const char* n) {
+  return reinterpret_cast<void*>(GetProcAddress(h, n));
+}
+static void closeLib(HandleTy h) { FreeLibrary(h); }
+static const char* lastErr() { return "LoadLibrary failed"; }
 #else
 #include <dlfcn.h>
+using HandleTy = void*;
+static HandleTy openLib(const char* p) {
+  return dlopen(p, RTLD_NOW | RTLD_LOCAL);
+}
+static void* findSym(HandleTy h, const char* n) { return dlsym(h, n); }
+static void closeLib(HandleTy h) { dlclose(h); }
+static const char* lastErr() { return dlerror(); }
 #endif
 
 #ifndef TEST_DOWNSTREAM_LIB_PATH
 #error "TEST_DOWNSTREAM_LIB_PATH must be defined"
 #endif
 
-int main() {
-#ifdef _WIN32
-  HMODULE h = LoadLibraryA(TEST_DOWNSTREAM_LIB_PATH);
+int main(int argc, char** argv) {
+  HandleTy h = openLib(TEST_DOWNSTREAM_LIB_PATH);
   if (!h) {
-    std::fprintf(stderr, "LoadLibrary(%s) failed: %lu\n",
-                 TEST_DOWNSTREAM_LIB_PATH,
-                 static_cast<unsigned long>(GetLastError()));
+    std::fprintf(stderr, "open(%s) failed: %s\n", TEST_DOWNSTREAM_LIB_PATH,
+                 lastErr());
     return 1;
   }
-  FreeLibrary(h);
-#else
-  void* h = dlopen(TEST_DOWNSTREAM_LIB_PATH, RTLD_NOW | RTLD_LOCAL);
-  if (!h) {
-    std::fprintf(stderr, "dlopen(%s) failed: %s\n", TEST_DOWNSTREAM_LIB_PATH,
-                 dlerror());
-    return 1;
+  // argv[1] is the libclangCppInterOp path; verify slot population.
+  int rc = 0;
+  if (argc > 1) {
+    auto* verify = reinterpret_cast<int (*)(const char*)>(
+        findSym(h, "downstream_verify_trace_slots"));
+    if (!verify) {
+      std::fprintf(stderr, "missing downstream_verify_trace_slots: %s\n",
+                   lastErr());
+      rc = 2;
+    } else {
+      rc = verify(argv[1]);
+      if (rc != 0)
+        std::fprintf(stderr, "downstream_verify_trace_slots -> %d\n", rc);
+    }
   }
-  dlclose(h);
-#endif
-  return 0;
+  closeLib(h);
+  return rc;
 }

--- a/unittests/CppInterOp/TracingTests.cpp
+++ b/unittests/CppInterOp/TracingTests.cpp
@@ -1567,6 +1567,12 @@ TEST(TracingCoverageTest, AllPublicAPIsAreTraced) {
   ApiNames.erase("AreArgumentsValid");
   ApiNames.erase("ReportInvokeStart");
   ApiNames.erase("ReportInvokeEnd");
+  // Exclude the JitCall trace-hook impls: they are reached only from
+  // INTEROP_TRACE-instrumented inline code; tracing them recursively
+  // would just nest entries for no benefit.
+  ApiNames.erase("CppInterOpTraceJitCallInvokeImpl");
+  ApiNames.erase("CppInterOpTraceJitCallInvokeDestructorImpl");
+  ApiNames.erase("CppInterOpTraceJitCallInvokeReturnImpl");
 
   ASSERT_GT(ApiNames.size(), 100u)
       << "Suspiciously few API functions found — regex may be broken";


### PR DESCRIPTION
PRs #994 and #1001 installed manual `CppInternal::DispatchRaw` slots for the JitCall::Invoke / InvokeDestructor / InvokeReturn trace hooks and populated them in InitTracing, but downstream Dispatch.h consumers (libcppyy-backend.so) had no way to populate their per-DSO copies. After LoadDispatchAPI succeeded the slots stayed nullptr and Release tracing in cppyy was silently off on every platform; the inline-fast plumbing landed without a consumer.

Move the three impls into CppInterOp.td so they appear in the X-macro expansion of CppInterOpAPI.inc. libclangCppInterOp's dispatch table exposes them via CppGetProcAddress, and any Dispatch.h consumer's X-macro-driven LoadDispatchAPI dlsyms them into its own slot storage -- no source change in cppyy-backend or any other header-only consumer. The manual slot declarations shrink to forward-references, the inline JitCall::Invoke call sites use the tablegen-driven names, and `noexcept` drops from the impls + friend declarations to match the X-macro-generated slot type.

Test: TestDownstreamLoader now takes the libclangCppInterOp path as argv[1] and, after dlopening the probe DSO, invokes a new probe entry `downstream_verify_trace_slots` that runs LoadDispatchAPI and checks each of the three trace slots is non-null. ctest passes the path via $<TARGET_FILE:clangCppInterOp>, so the in-tree dlopen guard now also pins the end-to-end X-macro slot-population contract.

# Description

Please include a summary of changes, motivation and context for this PR.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [ ] I have read the contribution guide recently
