### PR TITLE
add: GetClassTemplateArgs

### DIFF
--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -4602,6 +4602,17 @@ InstantiateTemplate(TCppScope_t tmpl,
                           template_args.size(), instantiate_body));
 }
 
+void GetClassTemplateArgs(TCppScope_t templ_instance,
+                          std::vector<TemplateArgInfo>& args) {
+  INTEROP_TRACE(templ_instance, INTEROP_OUT(args));
+  auto* CTSD = static_cast<ClassTemplateSpecializationDecl*>(templ_instance);
+  for (const auto& TA : CTSD->getTemplateArgs().asArray()) {
+    // FIXME: Support cases with m_IntegralValue.
+    args.push_back({TA.getAsType().getAsOpaquePtr()});
+  }
+  return INTEROP_VOID_RETURN();
+}
+
 void GetClassTemplateInstantiationArgs(TCppScope_t templ_instance,
                                        std::vector<TemplateArgInfo>& args) {
   INTEROP_TRACE(templ_instance, INTEROP_OUT(args));

--- a/lib/CppInterOp/CppInterOp.td
+++ b/lib/CppInterOp/CppInterOp.td
@@ -1145,6 +1145,17 @@ templated function of that type within the parent scope.}];
   ];
 }
 
+def GetClassTemplateArgs : CppInterOpAPI {
+  let Doc = [{Sets the class template arguments of \c templ_instance.
+\param[in] templ_instance Pointer to the template instance.
+\param[out] args Vector of instantiation arguments.}];
+  let ReturnType = "void";
+  let Args = [
+    Arg<"TCppScope_t", "templ_instance">,
+    OutArg<"std::vector<TemplateArgInfo>&", "args">
+  ];
+}
+
 def GetClassTemplateInstantiationArgs : CppInterOpAPI {
   let Doc = [{Sets the class template instantiation arguments of \c templ_instance.
 \param[in] templ_instance Pointer to the template instance.

--- a/unittests/CppInterOp/ScopeReflectionTest.cpp
+++ b/unittests/CppInterOp/ScopeReflectionTest.cpp
@@ -15,6 +15,7 @@
 
 #include "gtest/gtest.h"
 
+#include <CppInterOp/CppInterOpTypes.h>
 #include <memory>
 #include <string>
 
@@ -1251,6 +1252,38 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, ScopeReflection_InstantiateTemplate) {
   TemplateArgument TA4_1 = CTSD4->getTemplateArgs().get(1);
   EXPECT_TRUE(TA4_0.getAsType()->isIntegerType());
   EXPECT_TRUE(TA4_1.getAsIntegral() == 3);
+}
+
+TYPED_TEST(CPPINTEROP_TEST_MODE, ScopeReflection_GetClassTemplateArgs) {
+  std::vector<Decl*> Decls;
+  std::string code = R"(
+        template<typename _Signature>
+        class function;
+
+        template<typename _Res, typename... _ArgTypes>
+        class function<_Res(_ArgTypes...)> {};
+
+        function<int(int)> f;
+    )";
+
+  GetAllTopLevelDecls(code, Decls);
+
+  Cpp::TCppScope_t f =
+      Cpp::GetScopeFromType(Cpp::GetVariableType(Decls.back()));
+  EXPECT_TRUE(f);
+
+  std::vector<Cpp::TemplateArgInfo> tmpl_args;
+  Cpp::GetClassTemplateArgs(f, tmpl_args);
+  EXPECT_EQ(tmpl_args.size(), 1);
+
+  EXPECT_EQ(Cpp::GetTypeAsString(tmpl_args[0].m_Type), "int (int)");
+
+  tmpl_args.clear();
+  Cpp::GetClassTemplateInstantiationArgs(f, tmpl_args);
+  EXPECT_EQ(tmpl_args.size(), 2);
+
+  EXPECT_EQ(Cpp::GetTypeAsString(tmpl_args[0].m_Type), "int");
+  EXPECT_EQ(Cpp::GetTypeAsString(tmpl_args[1].m_Type), "int");
 }
 
 TYPED_TEST(CPPINTEROP_TEST_MODE,


### PR DESCRIPTION
For the cases where Template Instantiation Arguments are not the same as Template Arguments.

For Example:
```c++
template<typename _Signature>
class function;

template<typename _Res, typename... _ArgTypes>
class function<_Res(_ArgTypes...)> {};

function<int(int)> f;
```

`f`'s Template Arguments: int(int)
`f`'s Template Instantiation Arguments: int, int