### PR TITLE
[tracing] Export DispatchRaw JitCall trace-hook storage from shared library.

### DIFF
--- a/include/CppInterOp/CppInterOpTypes.h
+++ b/include/CppInterOp/CppInterOpTypes.h
@@ -52,12 +52,12 @@ namespace DispatchRaw {
 // Trace-hook slot forward decls; the X-macro expansion of
 // CppInterOpAPI.inc re-declares these with identical types. They're
 // here so JitCall::Invoke's inline body below can reference them.
-extern void (*CppInterOpTraceJitCallInvokeImpl)(const CppImpl::JitCall* JC,
-                                                void* result, void** args,
-                                                std::size_t nargs, void* self);
-extern void (*CppInterOpTraceJitCallInvokeDestructorImpl)(
+extern CPPINTEROP_API void (*CppInterOpTraceJitCallInvokeImpl)(
+    const CppImpl::JitCall* JC, void* result, void** args, std::size_t nargs,
+    void* self);
+extern CPPINTEROP_API void (*CppInterOpTraceJitCallInvokeDestructorImpl)(
     const CppImpl::JitCall* JC, void* object, unsigned long nary, int withFree);
-extern void (*CppInterOpTraceJitCallInvokeReturnImpl)(
+extern CPPINTEROP_API void (*CppInterOpTraceJitCallInvokeReturnImpl)(
     const CppImpl::JitCall* JC, void* result);
 } // namespace DispatchRaw
 } // namespace CppInternal

--- a/lib/CppInterOp/Tracing.cpp
+++ b/lib/CppInterOp/Tracing.cpp
@@ -29,13 +29,12 @@
 // consumers carry their per-DSO copies, populated by LoadDispatchAPI.
 namespace CppInternal {
 namespace DispatchRaw {
-void (*CppInterOpTraceJitCallInvokeImpl)(const CppImpl::JitCall*, void*, void**,
-                                         std::size_t, void*) = nullptr;
-void (*CppInterOpTraceJitCallInvokeDestructorImpl)(const CppImpl::JitCall*,
-                                                   void*, unsigned long,
-                                                   int) = nullptr;
-void (*CppInterOpTraceJitCallInvokeReturnImpl)(const CppImpl::JitCall*,
-                                               void*) = nullptr;
+CPPINTEROP_API void (*CppInterOpTraceJitCallInvokeImpl)(
+    const CppImpl::JitCall*, void*, void**, std::size_t, void*) = nullptr;
+CPPINTEROP_API void (*CppInterOpTraceJitCallInvokeDestructorImpl)(
+    const CppImpl::JitCall*, void*, unsigned long, int) = nullptr;
+CPPINTEROP_API void (*CppInterOpTraceJitCallInvokeReturnImpl)(
+    const CppImpl::JitCall*, void*) = nullptr;
 } // namespace DispatchRaw
 } // namespace CppInternal
 


### PR DESCRIPTION
The three function-pointer slots (CppInterOpTraceJitCallInvokeImpl, CppInterOpTraceJitCallInvokeDestructorImpl, CppInterOpTraceJitCallInvokeReturnImpl) in Tracing.cpp lacked CPPINTEROP_API, so -fvisibility=hidden gave them local linkage. The inline JitCall::Invoke methods in CppInterOpTypes.h reference them, causing link failures when the test binary links the shared library.

# Description

Please include a summary of changes, motivation and context for this PR.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [ ] I have read the contribution guide recently
