### PR TITLE
[cmake] Emit TableGen generated files into subdir build tree

### DIFF
--- a/.github/workflows/root.yml
+++ b/.github/workflows/root.yml
@@ -172,17 +172,14 @@ jobs:
         # so ROOT's `core/clingutils/CMakeLists.txt` resolves
         # `${CLANG_INSTALL_PREFIX}/lib/clang` to the recipe-installed
         # clang (rather than globbing `/usr/lib/clang/*`).
-        # CppInterOp's `.td`-driven dispatch (introduced in #906) emits
-        # `CppInterOpDecl.inc` and `CppInterOpAPI.inc` via cppinterop-tblgen.
-        # CppInterOp's CMakeLists writes them to `${CMAKE_BINARY_DIR}/include/
-        # CppInterOp/` -- which under ROOT's `add_subdirectory` resolves to
-        # `<root-build>/include/CppInterOp/`, NOT to the bundled subtree's
-        # build dir. ROOT's `core/metacling/CMakeLists.txt` only adds the
-        # CppInterOp source `include/` to MetaCling's compile rules, so
+        # CppInterOp's `.td`-driven dispatch emits `CppInterOpDecl.inc` etc.
+        # via cppinterop-tblgen into `${CMAKE_CURRENT_BINARY_DIR}/include/
+        # CppInterOp/` (CppInterOp's own subtree). ROOT master doesn't yet
+        # know to put that on MetaCling's compile rules, so
         # `TClingCallFunc.h`'s `#include "CppInterOp/CppInterOpDecl.inc"`
-        # fails. Inject the top-level build/include globally via
-        # `CMAKE_CXX_FLAGS`.
-        CPPINTEROP_GEN_INC="$PWD/include"
+        # fails without help. Inject the path globally via `CMAKE_CXX_FLAGS`
+        # until ROOT lands the companion etc/cppinterop staging change.
+        CPPINTEROP_GEN_INC="$PWD/interpreter/CppInterOp/include"
         cmake -G Ninja \
               -DCMAKE_BUILD_TYPE=Release \
               -DCMAKE_C_COMPILER_LAUNCHER=ccache \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -323,8 +323,12 @@ endif()
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
-# Generated .inc files from cppinterop-tblgen live under the build tree.
-include_directories(${CMAKE_BINARY_DIR}/include)
+# Generated .inc files from cppinterop-tblgen live under our own build
+# subtree. Use CMAKE_CURRENT_BINARY_DIR so consumers embedding CppInterOP
+# via add_subdirectory() (e.g. ROOT) don't write CppInterOp artifacts into
+# top-level build/include
+set(CPPINTEROP_GEN_DIR ${CMAKE_CURRENT_BINARY_DIR}/include/CppInterOp)
+include_directories(${CMAKE_CURRENT_BINARY_DIR}/include)
 
 # In rare cases we might want to have clang installed in a different place
 # than llvm and the header files should be found first (even though the

--- a/lib/CppInterOp/CMakeLists.txt
+++ b/lib/CppInterOp/CMakeLists.txt
@@ -113,7 +113,6 @@ endif(LLVM_LINK_LLVM_DYLIB)
 # build directory first.
 set(CPPINTEROP_TD_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 set(CPPINTEROP_TD_FILE ${CPPINTEROP_TD_DIR}/CppInterOp.td)
-set(CPPINTEROP_GEN_DIR ${CMAKE_BINARY_DIR}/include/CppInterOp)
 set(CPPINTEROP_TD_DEPS ${CPPINTEROP_TD_FILE}
                         ${CPPINTEROP_TD_DIR}/CppInterOpAPI.td)
 

--- a/unittests/CppInterOp/CMakeLists.txt
+++ b/unittests/CppInterOp/CMakeLists.txt
@@ -101,7 +101,7 @@ add_cppinterop_unittest(TracingTests
 )
 target_compile_definitions(TracingTests PRIVATE
   "CPPINTEROP_DIR=\"${CMAKE_CURRENT_SOURCE_DIR}/../../\""
-  "CPPINTEROP_BINARY_DIR=\"${CMAKE_BINARY_DIR}\""
+  "CPPINTEROP_BINARY_DIR=\"${CMAKE_CURRENT_BINARY_DIR}/../../\""
 )
 # GCC 12 and (less often) 13/14 emit a -Wmaybe-uninitialized false positive
 # inside libstdc++'s <regex> headers when the std::function subobject of


### PR DESCRIPTION
cppinterop-tblgen output (CPPINTEROP_GEN_DIR), the include path that consumes it, and the CPPINTEROP_BINARY_DIR compile-time define used by TracingTests all used ${CMAKE_BINARY_DIR}. This work sin standalone builds but in embedded builds (via add_subdirectory) it resolves to the parent project's top-level build/include namespace, mixing CppInterOp's generated artifacts in alongside the parent's own headers and causing TracingTests's runtime AddIncludePath() to point at the wrong location.

Switch to ${CMAKE_CURRENT_BINARY_DIR}, and move CPPINTEROP_GEN_DIR's definition up to the top-level CMakeLists.txt so it resolves to CppInterOp's own subtree in both modes. This change makes no difference in a standalone-build layout

# Description

Please include a summary of changes, motivation and context for this PR.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [ ] I have read the contribution guide recently
