### PR TITLE
[test] Use cmake compatible GTEST_FLAG to set threadsafe death-test

### DIFF
--- a/unittests/CppInterOp/TracingTests.cpp
+++ b/unittests/CppInterOp/TracingTests.cpp
@@ -34,10 +34,10 @@ class TracingTest : public ::testing::Test {
 protected:
   static void SetUpTestSuite() {
     saved_death_test_style_ = ::testing::GTEST_FLAG(death_test_style);
-    GTEST_FLAG_SET(death_test_style, "threadsafe");
+    ::testing::GTEST_FLAG(death_test_style) = "threadsafe";
   }
   static void TearDownTestSuite() {
-    GTEST_FLAG_SET(death_test_style, saved_death_test_style_);
+    ::testing::GTEST_FLAG(death_test_style) = saved_death_test_style_;
   }
   void SetUp() override {
     if (TheTraceInfo)


### PR DESCRIPTION
The previous approach used GTEST_FLAG_SET(death_test_style, ...), a macro introduced in googletest 1.13.0. Some distros (ubuntu-22, alma9) ship gtest 1.11.0, where the macro is undefined and compilation fails. Switch to `::testing::GTEST_FLAG(death_test_style) = value`, available for gtest>1.8, same form used by compiler-rt