### PR TITLE
root.yml: defeat ROOT's FORCE override of CPPINTEROP_ENABLE_TESTING

### DIFF
--- a/.github/workflows/root.yml
+++ b/.github/workflows/root.yml
@@ -150,6 +150,14 @@ jobs:
         # Strip the nested `.git` so ROOT's CMake doesn't get confused by
         # a sub-repository inside its own source tree.
         rm -rf root/interpreter/CppInterOp/.git
+        # ROOT's interpreter/CMakeLists.txt FORCE-overrides
+        # CPPINTEROP_ENABLE_TESTING from its own `-Dtesting` flag, defeating
+        # the -DCPPINTEROP_ENABLE_TESTING=ON we pass in Configure ROOT below
+        # and silently skipping the unittests subdir (no `check-cppinterop`
+        # target). Drop FORCE so a user-set cache value wins, while the
+        # ROOT-default initialization is preserved for non-CI builds.
+        sed -i '/CPPINTEROP_ENABLE_TESTING.*Enable gtest in CppInterOp/s/ FORCE)/)/' \
+          root/interpreter/CMakeLists.txt
 
     - name: Configure ROOT
       shell: bash


### PR DESCRIPTION
ROOT's interpreter/CMakeLists.txt FORCE-sets CPPINTEROP_ENABLE_TESTING from its own `-Dtesting` flag, so the -DCPPINTEROP_ENABLE_TESTING=ON we pass under "Configure ROOT" is silently overridden to OFF in the cling-llvm20-root row (ROOT is configured with -Dtesting=OFF). With the option flipped to OFF, add_subdirectory(unittests) is skipped, no check-cppinterop target is registered, and the "Run CppInterOp unittests" step dies with `ninja: error: unknown target 'check-cppinterop'`.

After substituting the PR's CppInterOp into ROOT, sed-drop the FORCE from the two `set(CPPINTEROP_ENABLE_TESTING ... CACHE BOOL ... FORCE)` lines. With FORCE removed, ROOT's set() respects an already-cached value, so the operator's -D wins and ROOT's default initialization is preserved for non-CI builds.

# Description

Please include a summary of changes, motivation and context for this PR.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [ ] I have read the contribution guide recently
