### PR TITLE
Add Cpp::Box, the typed result carrier for the AOT/JIT boundary

### DIFF
--- a/.github/workflows/root.yml
+++ b/.github/workflows/root.yml
@@ -159,6 +159,19 @@ jobs:
         sed -i '/CPPINTEROP_ENABLE_TESTING.*Enable gtest in CppInterOp/s/ FORCE)/)/' \
           root/interpreter/CMakeLists.txt
 
+        # ROOT's interpreter/CMakeLists.txt hardcodes the list of headers
+        # it stages into ${CMAKE_BINARY_DIR}/etc/cppinterop/CppInterOp/.
+        # That list (search "set(cppinterop_src_files") names only the
+        # original three public headers and three generated .inc files.
+        # CppInterOp.h now also #includes <CppInterOp/Box.h>; without
+        # Box.h next to the staged CppInterOp.h, metacling fails to
+        # compile TCling.cxx with "CppInterOp/Box.h: No such file or
+        # directory". Inject the missing header so the staged set is
+        # complete -- the upstream fix lives in ROOT and is tracked
+        # there; this is a CI-only shim until that lands.
+        sed -i '\|CppInterOp/CppInterOp\.h$|a\  ${CMAKE_CURRENT_SOURCE_DIR}/CppInterOp/include/CppInterOp/Box.h' \
+          root/interpreter/CMakeLists.txt
+
     - name: Configure ROOT
       shell: bash
       run: |

--- a/include/CppInterOp/Box.h
+++ b/include/CppInterOp/Box.h
@@ -1,0 +1,295 @@
+//===--- Box.h - Typed result carrier across the AOT/JIT boundary -*- C++ -*-=//
+//
+// Part of the compiler-research project, under the Apache License v2.0 with
+// LLVM Exceptions.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Cpp::Box is the typed result vocabulary that crosses the binding-AOT /
+// clang-repl-JIT boundary in both directions: catalog thunks Create<T> a
+// Box to hand to the runtime, Evaluate returns one to hand back. Storage
+// is hybrid -- fundamentals (K_Bool ... K_LongDouble) live inline in the
+// union; K_PtrOrObj keeps an owned pointer plus a type-erased
+// {retain, release} pair so the public header sees only `void*` and
+// function pointers, never the concrete payload type. Copy is shallow +
+// refcounted on K_PtrOrObj (matching clang::Value's model); the bridge
+// composes only when both layers share that semantic.
+//
+// The AOT path `Box::Create<T>(x).visit(v)` is designed to fold to a
+// direct `v(x)` -- the always_inline annotations below preserve this
+// against compiler inliner heuristics (validated separately on clang 17
+// and gcc 12 -O3; this commit does not pin the property in-tree).
+//
+// CPP_BOX_BUILTIN_TYPES is the single source of truth: enum positions,
+// storage union slots, KindOf<T> specialisations, and visit's switch are
+// all generated from this one X-macro -- one edit per new fundamental.
+// Mirrors clang's REPL_BUILTIN_TYPES so the Evaluate bridge in
+// CppInterOp.cpp is a Kind-to-Kind switch with no translation table.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CPPINTEROP_BOX_H
+#define CPPINTEROP_BOX_H
+
+// Box.h is meant to be cheap to parse: the JIT pulls it whenever a
+// catalog thunk or evaluated snippet references Cpp::Box, so every
+// pulled-in standard header is paid at interpretation time. We avoid
+// CppInterOpTypes.h (which drags in <vector> / <string> / <set>) and
+// keep <cassert> behind NDEBUG. Under NDEBUG, this file pulls in zero
+// standard or project headers.
+
+#ifndef NDEBUG
+#include <cassert>
+#endif
+
+// Cross-platform always_inline. Duplicated from CppInterOpTypes.h's
+// CPPINTEROP_ALWAYS_INLINE under a guard so consumers don't have to
+// pull that (heavier) header just to use Box.
+#ifndef CPPINTEROP_ALWAYS_INLINE
+#if defined(_MSC_VER)
+#define CPPINTEROP_ALWAYS_INLINE __forceinline
+#elif defined(__GNUC__) || defined(__clang__)
+#define CPPINTEROP_ALWAYS_INLINE __attribute__((always_inline)) inline
+#else
+#define CPPINTEROP_ALWAYS_INLINE inline
+#endif
+#endif
+
+// Cross-platform unreachable hint used in visit's default arms.
+#ifndef CPPINTEROP_UNREACHABLE
+#if defined(_MSC_VER)
+#define CPPINTEROP_UNREACHABLE() __assume(0)
+#elif defined(__GNUC__) || defined(__clang__)
+#define CPPINTEROP_UNREACHABLE() __builtin_unreachable()
+#else
+#define CPPINTEROP_UNREACHABLE() ((void)0)
+#endif
+#endif
+
+namespace CppImpl {
+
+// FIXME: clang's REPL_BUILTIN_TYPES lists `unsigned char` twice (Char_U +
+// UChar) to disambiguate the platform-default signedness of `char` from an
+// explicit `signed char` / `unsigned char`. The proper KindOf<char>()
+// resolution uses std::is_signed_v<char> to pick K_Char_S vs K_Char_U;
+// the duplicate Char_U entry is reached only via the runtime bridge
+// (Evaluate). We keep this table single-valued per C++ type for unambiguous
+// per-T specializations; Evaluate adds the K_Char_U case explicitly.
+#define CPP_BOX_BUILTIN_TYPES                                                  \
+  X(bool, Bool)                                                                \
+  X(char, Char_S)                                                              \
+  X(signed char, SChar)                                                        \
+  X(unsigned char, UChar)                                                      \
+  X(short, Short)                                                              \
+  X(unsigned short, UShort)                                                    \
+  X(int, Int)                                                                  \
+  X(unsigned int, UInt)                                                        \
+  X(long, Long)                                                                \
+  X(unsigned long, ULong)                                                      \
+  X(long long, LongLong)                                                       \
+  X(unsigned long long, ULongLong)                                             \
+  X(float, Float)                                                              \
+  X(double, Double)                                                            \
+  X(long double, LongDouble)
+
+class Box {
+public:
+  enum Kind : unsigned char {
+#define X(type, name) K_##name,
+    CPP_BOX_BUILTIN_TYPES
+#undef X
+        K_Char_U, // alias of UChar storage; reached only by runtime bridge
+    K_Void,
+    K_PtrOrObj,
+    K_Unspecified,
+  };
+
+  /// Operations vtable for a K_PtrOrObj payload. Defined once per concrete
+  /// payload type in the TU that knows the type (see Evaluate's
+  /// kCompatValueOps in CppInterOp.cpp). The Box stores a pointer to this
+  /// const-static struct; the storage slot is 2 pointers (16 bytes).
+  ///
+  /// retain/release implement intrusive ref-counting: AdoptObject installs
+  /// the payload with refcount 1; copy ctor / copy assign call retain;
+  /// destructor calls release; the producer's release fires the payload's
+  /// destructor when the last ref drops.
+  struct ObjectOps {
+    /// Increment the payload's refcount. Must be noexcept; called from the
+    /// (noexcept) copy ctor / copy assign.
+    void (*retain)(void*) noexcept;
+    /// Decrement the payload's refcount; on the last drop, run the payload's
+    /// destructor and free storage. Must be noexcept; called from ~Box.
+    void (*release)(void*) noexcept;
+  };
+
+private:
+  union Storage {
+#define X(type, name) type m_##name;
+    CPP_BOX_BUILTIN_TYPES
+#undef X
+    struct {
+      void* m_Ptr;
+      const ObjectOps* m_Ops;
+    } m_Object;
+  };
+
+  Kind m_kind = K_Unspecified;
+  void* m_Type = nullptr;
+  Storage m_storage = {};
+
+  template <class T> static constexpr Kind KindOf() noexcept;
+  template <class T> static T& slot(Storage& s) noexcept;
+  template <class T> static const T& slot(const Storage& s) noexcept;
+
+public:
+  // -- rule of five: refcount-shared on K_PtrOrObj, bitwise on fundamentals --
+  Box() = default;
+  Box(const Box& o) noexcept
+      : m_kind(o.m_kind), m_Type(o.m_Type), m_storage(o.m_storage) {
+    // Kind check first so fundamentals constant-fold the branch away
+    // (AOT-fold preserved). K_PtrOrObj bumps the payload refcount.
+    if (m_kind == K_PtrOrObj && m_storage.m_Object.m_Ops)
+      m_storage.m_Object.m_Ops->retain(m_storage.m_Object.m_Ptr);
+  }
+  Box& operator=(const Box& o) noexcept {
+    if (this != &o) {
+      this->~Box();
+      m_kind = o.m_kind;
+      m_Type = o.m_Type;
+      m_storage = o.m_storage;
+      if (m_kind == K_PtrOrObj && m_storage.m_Object.m_Ops)
+        m_storage.m_Object.m_Ops->retain(m_storage.m_Object.m_Ptr);
+    }
+    return *this;
+  }
+  Box(Box&& o) noexcept
+      : m_kind(o.m_kind), m_Type(o.m_Type), m_storage(o.m_storage) {
+    // moved-from: dtor sees K_Unspecified → no release of the stolen ref.
+    o.m_kind = K_Unspecified;
+  }
+  Box& operator=(Box&& o) noexcept {
+    if (this != &o) {
+      this->~Box();
+      m_kind = o.m_kind;
+      m_Type = o.m_Type;
+      m_storage = o.m_storage;
+      o.m_kind = K_Unspecified;
+    }
+    return *this;
+  }
+  // always_inline so a static Kind constant-propagates into the dtor
+  // body and the K_PtrOrObj branch dead-strips on the AOT path.
+  CPPINTEROP_ALWAYS_INLINE ~Box() noexcept {
+    if (m_kind == K_PtrOrObj && m_storage.m_Object.m_Ops)
+      m_storage.m_Object.m_Ops->release(m_storage.m_Object.m_Ptr);
+  }
+
+  Kind getKind() const noexcept { return m_kind; }
+  void* getType() const noexcept { return m_Type; }
+
+  /// AOT-typed extraction. \c T must match the runtime \c Kind exactly
+  /// (UB to read an inactive union member otherwise -- e.g. calling
+  /// \c unbox<int>() on a \c K_Long Box). For unknown-kind extraction
+  /// use \c visit() or check \c getKind() against \c KindOf<T>() first.
+  /// The assert is a no-op under \c NDEBUG so the AOT-fold path stays
+  /// zero-overhead.
+  template <class T> T unbox() const noexcept {
+    assert(m_kind == KindOf<T>() &&
+           "Cpp::Box::unbox<T>(): T does not match the runtime Kind");
+    return slot<T>(m_storage);
+  }
+
+  /// AOT-typed construction for fundamentals. Sets Kind = KindOf<T>(),
+  /// stores x. Optional QualType preserves typedef sugar (int8_t vs
+  /// signed char) the Kind enum collapses.
+  // always_inline so `Create<T>(x).visit(toPy)` folds bit-identical to
+  // a direct `toPy(x)` on gcc-12 (default inliner gives up otherwise).
+  template <class T>
+  CPPINTEROP_ALWAYS_INLINE static Box Create(T x,
+                                             void* type = nullptr) noexcept {
+    Box v;
+    v.m_kind = KindOf<T>();
+    v.m_Type = type;
+    slot<T>(v.m_storage) = x;
+    return v;
+  }
+
+  /// Object-payload construction. `obj` enters with refcount 1 (the
+  /// producer's invariant); ~Box calls `ops->release(obj)` which on the
+  /// last drop runs the payload's destructor. The ops table is const-static,
+  /// defined in the TU that knows the concrete payload type.
+  static Box AdoptObject(void* obj, const ObjectOps* ops, void* type) noexcept {
+    Box v;
+    v.m_kind = K_PtrOrObj;
+    v.m_Type = type;
+    v.m_storage.m_Object.m_Ptr = obj;
+    v.m_storage.m_Object.m_Ops = ops;
+    return v;
+  }
+
+  /// Object payload accessor; only valid for K_PtrOrObj. Returns the
+  /// raw pointer set at AdoptObject time. Layout is producer-defined --
+  /// the producer that installed the ObjectOps knows how to extract the
+  /// underlying object.
+  void* getObjectPtr() const noexcept {
+    return m_kind == K_PtrOrObj ? m_storage.m_Object.m_Ptr : nullptr;
+  }
+
+  /// Runtime convert across Kinds: dispatches on the actual Kind and
+  /// returns the value reinterpreted (via \c static_cast) as \c T.
+  /// Mirrors clang::Value::convertTo<T>. Only valid for fundamental
+  /// Kinds (K_Bool ... K_LongDouble); K_PtrOrObj / K_Void /
+  /// K_Unspecified are caller-must-check-Kind cases.
+  template <class T> T convertTo() const noexcept {
+    return visit([](auto x) -> T { return static_cast<T>(x); });
+  }
+
+  /// Runtime-typed dispatch via visitor. Switch over Kind, call visitor
+  /// with the typed T extracted from storage. K_PtrOrObj / K_Void / K_*
+  /// non-fundamental kinds are not dispatched -- caller checks Kind first.
+  // always_inline so the switch reduces to the single case the AOT Kind
+  // resolves to; the other arms then dead-strip.
+  template <class V>
+  CPPINTEROP_ALWAYS_INLINE auto visit(V&& vis) const -> decltype(vis(int{})) {
+    switch (m_kind) {
+#define X(type, name)                                                          \
+  case K_##name:                                                               \
+    return vis(unbox<type>());
+      CPP_BOX_BUILTIN_TYPES
+#undef X
+    case K_Char_U:
+    case K_Void:
+    case K_PtrOrObj:
+    case K_Unspecified:
+      CPPINTEROP_UNREACHABLE();
+    }
+    CPPINTEROP_UNREACHABLE();
+  }
+};
+
+// --- Per-T specializations, generated via the same X-macro -------------------
+
+#define X(type, name)                                                          \
+  template <> constexpr Box::Kind Box::KindOf<type>() noexcept {               \
+    return K_##name;                                                           \
+  }                                                                            \
+  template <> inline type& Box::slot<type>(Storage & s) noexcept {             \
+    return s.m_##name;                                                         \
+  }                                                                            \
+  template <> inline const type& Box::slot<type>(const Storage& s) noexcept {  \
+    return s.m_##name;                                                         \
+  }
+CPP_BOX_BUILTIN_TYPES
+#undef X
+
+} // namespace CppImpl
+
+// The `Cpp` alias is mutually exclusive with Dispatch.h's own alias to
+// CppInternal::Dispatch, so skip it on that path (Dispatch.h sets it).
+#ifndef CPPINTEROP_DISPATCH_H
+// NOLINTNEXTLINE(misc-unused-alias-decls)
+namespace Cpp = CppImpl;
+#endif
+
+#endif // CPPINTEROP_BOX_H

--- a/include/CppInterOp/CXCppInterOp.h
+++ b/include/CppInterOp/CXCppInterOp.h
@@ -33,6 +33,12 @@ extern "C" {
 
 // --- Hand-written wrappers (see lib/CppInterOp/CXCppInterOp.cpp) ---
 
+/// C-ABI overload of Cpp::Evaluate. Returns the execution result as
+/// a raw \c intptr_t bit pattern; on parse error or no-value-after-
+/// success writes \c true to \c *HadError (if non-null) and returns
+/// \c ~0UL. The Box-returning C++ overload is marked NoCWrapper.
+CPPINTEROP_API intptr_t cppinterop_Evaluate(const char* code, bool* HadError);
+
 /// Returns the templated method scopes inside \c parent matching
 /// \c name. The bool-return-with-vector-outparam shape is not
 /// expressible by the tablegen wrapper emitter; callers check

--- a/include/CppInterOp/CppInterOp.h
+++ b/include/CppInterOp/CppInterOp.h
@@ -19,6 +19,9 @@
 #endif
 
 #include "CppInterOp/CppInterOpTypes.h"
+// Cpp::Box must be visible before the tablegen-generated declarations
+// below, since Evaluate (and future Value-returning APIs) reference it.
+#include "CppInterOp/Box.h"
 
 #include <initializer_list>
 #include <memory>
@@ -39,10 +42,13 @@ namespace detail {
 // self-pointer. Exposed only so the inline VTableOverlayExtraSlot helper
 // below can compile the offset; users should not read or write any slots
 // directly.
+// static (not inline) so the reproducer-as-TU compiles under C++14;
+// inline-variable is a C++17 extension and the JIT-compiled reproducer
+// is fed back through the interpreter at its default language standard.
 #ifdef _WIN32
-inline constexpr int kVTableOverlayPrefixSize = 1 + 1;
+static constexpr int kVTableOverlayPrefixSize = 1 + 1;
 #else
-inline constexpr int kVTableOverlayPrefixSize = 2 + 1;
+static constexpr int kVTableOverlayPrefixSize = 2 + 1;
 #endif
 } // namespace detail
 

--- a/include/CppInterOp/Dispatch.h
+++ b/include/CppInterOp/Dispatch.h
@@ -32,6 +32,7 @@
 #include <dlfcn.h>
 #endif
 
+#include "CppInterOp/Box.h"
 #include "CppInterOp/CppInterOpTypes.h"
 
 #include <cstdlib>

--- a/lib/CppInterOp/CXCppInterOp.cpp
+++ b/lib/CppInterOp/CXCppInterOp.cpp
@@ -1,16 +1,64 @@
 // Hand-written C API wrappers for functions the TableGen emitter
-// cannot generate mechanically. Public declarations of these
-// symbols live in include/CppInterOp/CXCppInterOp.h; generated
-// wrappers live in CXCppInterOpGenerated.cpp.
+// cannot generate mechanically, plus C-ABI-shaped overloads of Cpp::
+// APIs whose primary form (in CppInterOp.cpp) cannot cross the C
+// boundary. Public declarations of these symbols live in
+// include/CppInterOp/CXCppInterOp.h; generated wrappers live in
+// CXCppInterOpGenerated.cpp.
 
 #include "CppInterOp/CXCppInterOp.h"
 #include "CppInterOp/CppInterOp.h"
+
+#include "Compatibility.h"
 
 #include <cstdlib>
 #include <cstring>
 #include <vector>
 
+#if defined(__has_feature)
+#if __has_feature(memory_sanitizer)
+#include <sanitizer/msan_interface.h>
+#define CPPINTEROP_MSAN_UNPOISON_VALUE(v) __msan_unpoison(&(v), sizeof(v))
+#else
+#define CPPINTEROP_MSAN_UNPOISON_VALUE(v) ((void)0)
+#endif
+#else
+#define CPPINTEROP_MSAN_UNPOISON_VALUE(v) ((void)0)
+#endif
+
+namespace CppImpl {
+
+// Legacy C-ABI overload of Cpp::Evaluate. The Box-returning overload in
+// CppInterOp.cpp cannot cross the C boundary; bindings that go through
+// the generated cppinterop_Evaluate_intptr wrapper (e.g. cppyy) land
+// here instead.
+intptr_t Evaluate(const char* code, bool* HadError) {
+  auto* I = static_cast<compat::Interpreter*>(GetInterpreter());
+  compat::Value V;
+
+  if (HadError)
+    *HadError = false;
+
+  auto res = I->evaluate(code, V);
+  CPPINTEROP_MSAN_UNPOISON_VALUE(V);
+  if (res != 0 || !V.hasValue()) {
+    if (HadError)
+      *HadError = true;
+    // FIXME: Make this return llvm::Expected.
+    return ~0UL;
+  }
+
+  return compat::convertTo<intptr_t>(V);
+}
+
+} // namespace CppImpl
+
 extern "C" {
+
+// C-ABI bridge for the intptr_t Cpp::Evaluate overload above. The Box-
+// returning overload generated from CppInterOp.td is C++-only.
+CPPINTEROP_API intptr_t cppinterop_Evaluate(const char* code, bool* HadError) {
+  return Cpp::Evaluate(code, HadError);
+}
 
 // GetClassTemplatedMethods returns bool AND fills a vector out-param.
 // The C wrapper drops the bool (caller checks arr.size > 0 instead).

--- a/lib/CppInterOp/Compatibility.h
+++ b/lib/CppInterOp/Compatibility.h
@@ -32,6 +32,9 @@
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/Support/FileSystem.h"
 
+#include "CppInterOp/Box.h"
+
+#include <atomic>
 #include <cstdint>
 #include <cstring>
 #include <memory>
@@ -714,6 +717,42 @@ template <typename T> inline T convertTo(clang::Value V) {
   return V.convertTo<T>();
 }
 #endif // CPPINTEROP_USE_CLING
+
+// Refcount-shared payload wrapping a `compat::Value` for Cpp::Box's
+// K_PtrOrObj slot. Boxing-via-copy (not move): clang::Value's move ctor
+// releases its own storage on construction -- fixed upstream by
+// llvm/llvm-project#200888. The copy ctor correctly retains.
+// FIXME(llvm 23): static_assert below fails the build once the minimum
+// LLVM crosses 23, prompting the move-semantics cleanup.
+static_assert(LLVM_VERSION_MAJOR < 23,
+              "clang::Value::Value(Value&&) was fixed upstream in "
+              "llvm/llvm-project#200888; switch ValueRefCount to move "
+              "semantics and drop this workaround.");
+
+namespace detail {
+struct ValueRefCount {
+  std::atomic<unsigned> rc;
+  Value v;
+  explicit ValueRefCount(const Value& V) noexcept : rc(1), v(V) {}
+
+  static void retain(void* p) noexcept {
+    static_cast<ValueRefCount*>(p)->rc.fetch_add(1, std::memory_order_relaxed);
+  }
+  static void release(void* p) noexcept {
+    auto* rc = static_cast<ValueRefCount*>(p);
+    if (rc->rc.fetch_sub(1, std::memory_order_acq_rel) == 1)
+      delete rc;
+  }
+  static constexpr Cpp::Box::ObjectOps Ops{&retain, &release};
+};
+} // namespace detail
+
+/// Wrap a compat::Value into a refcount-shared K_PtrOrObj Cpp::Box.
+/// `qt` is the opaque QualType (clang::QualType::getAsOpaquePtr()).
+inline Cpp::Box MakeValueBox(const Value& V, void* qt) noexcept {
+  return Cpp::Box::AdoptObject(new detail::ValueRefCount(V),
+                               &detail::ValueRefCount::Ops, qt);
+}
 
 inline void InstantiateClassTemplateSpecialization(
     Interpreter& interp, clang::ClassTemplateSpecializationDecl* CTSD) {

--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -4676,24 +4676,85 @@ int Process(const char* code) {
   return INTEROP_RETURN(getInterp().process(code));
 }
 
-intptr_t Evaluate(const char* code, bool* IsValueInvalid /*=nullptr*/) {
-  INTEROP_TRACE(code, INTEROP_OUT(IsValueInvalid));
+// Classify the QualType of a successfully-evaluated value into a
+// Box::Kind. clang::Value's own ctor asserts on builtins the X-macro
+// doesn't list (`__int128`, `_BitInt`, `_Float16`, ...), so by the time
+// we get here QT is non-null and BT->getKind() is one of the enumerated
+// arms. Records, pointers and references fall through to K_PtrOrObj.
+// See memory/clang_value_wide_types_gap.md for the upstream follow-up
+// that would broaden Value's coverage.
+static Cpp::Box::Kind classifyByQualType(clang::QualType QT) {
+  if (const auto* BT = QT->getAs<clang::BuiltinType>()) {
+    switch (BT->getKind()) {
+    case clang::BuiltinType::Bool:
+      return Cpp::Box::K_Bool;
+    case clang::BuiltinType::Char_S:
+      return Cpp::Box::K_Char_S;
+    case clang::BuiltinType::Char_U:
+      // Platform-`unsigned`-char alias; share UChar storage so the
+      // X-macro doesn't need a duplicate Box::Create<T> specialization.
+      return Cpp::Box::K_UChar;
+    case clang::BuiltinType::SChar:
+      return Cpp::Box::K_SChar;
+    case clang::BuiltinType::UChar:
+      return Cpp::Box::K_UChar;
+    case clang::BuiltinType::Short:
+      return Cpp::Box::K_Short;
+    case clang::BuiltinType::UShort:
+      return Cpp::Box::K_UShort;
+    case clang::BuiltinType::Int:
+      return Cpp::Box::K_Int;
+    case clang::BuiltinType::UInt:
+      return Cpp::Box::K_UInt;
+    case clang::BuiltinType::Long:
+      return Cpp::Box::K_Long;
+    case clang::BuiltinType::ULong:
+      return Cpp::Box::K_ULong;
+    case clang::BuiltinType::LongLong:
+      return Cpp::Box::K_LongLong;
+    case clang::BuiltinType::ULongLong:
+      return Cpp::Box::K_ULongLong;
+    case clang::BuiltinType::Float:
+      return Cpp::Box::K_Float;
+    case clang::BuiltinType::Double:
+      return Cpp::Box::K_Double;
+    case clang::BuiltinType::LongDouble:
+      return Cpp::Box::K_LongDouble;
+    default:
+      llvm_unreachable(
+          "clang::Value asserts on builtins outside the X-macro set");
+    }
+  }
+  return Cpp::Box::K_PtrOrObj;
+}
+
+Box Evaluate(const char* code) {
+  INTEROP_TRACE(code);
   compat::Value V;
-
-  if (IsValueInvalid)
-    *IsValueInvalid = false;
-
   auto res = getInterp().evaluate(code, V);
   CPPINTEROP_MSAN_UNPOISON_VALUE(V);
-  // 0 is success; an unset V on success means convertTo would assert.
-  if (res != 0 || !V.hasValue()) {
-    if (IsValueInvalid)
-      *IsValueInvalid = true;
-    // FIXME: Make this return llvm::Expected
-    return INTEROP_RETURN(~0UL);
-  }
+  if (res != 0 || !V.hasValue())
+    return INTEROP_RETURN(Box{});
 
-  return INTEROP_RETURN(compat::convertTo<intptr_t>(V));
+  clang::QualType QT = V.getType();
+  void* qt = QT.getAsOpaquePtr();
+  switch (classifyByQualType(QT)) {
+#define X(type, name)                                                          \
+  case Cpp::Box::K_##name:                                                     \
+    return INTEROP_RETURN(                                                     \
+        Cpp::Box::Create<type>(compat::convertTo<type>(V), qt));
+    CPP_BOX_BUILTIN_TYPES
+#undef X
+  case Cpp::Box::K_PtrOrObj:
+    return INTEROP_RETURN(compat::MakeValueBox(V, qt));
+  case Cpp::Box::K_Char_U:
+  case Cpp::Box::K_Void:
+  case Cpp::Box::K_Unspecified:
+    // classifyByQualType never produces these (Char_U folds to UChar;
+    // Void/Unspecified can't reach a hasValue=true path).
+    llvm_unreachable("Box::Kind not produced by classifyByQualType");
+  }
+  llvm_unreachable("classifyByQualType returned an unhandled Kind");
 }
 
 std::string LookupLibrary(const char* lib_name) {

--- a/lib/CppInterOp/CppInterOp.td
+++ b/lib/CppInterOp/CppInterOp.td
@@ -69,18 +69,28 @@ def Declare : CppInterOpAPI {
 }
 
 def Evaluate : CppInterOpAPI {
-  let Doc = [{Declares, executes and returns the execution result as a intptr_t.
+  let Doc = [{Declares, executes and returns the execution result as a typed
+\c Cpp::Box carrying the Kind tag and the source QualType (when available).
+\c getKind() returns \c K_Unspecified on parse error or
+no-value-after-success.
 \param[in] code - the snippet to declare and execute.
-\param[out] IsValueInvalid - if non-null, set true when the result is
-            unusable (parse error or no-Value-after-success).
-\returns the expression results as a intptr_t.}];
-
-  let ReturnType = "intptr_t";
+\returns a \c Cpp::Box. Use \c unbox<T>() to extract a fundamental
+         (assert-checked: \c T must match the runtime Kind) or
+         \c getObjectPtr() for object payloads. For unknown-Kind extraction
+         dispatch on \c getKind() / \c KindOf<T>() first, or use \c visit().}];
+  // Box has non-trivial copy/dtor and cannot cross the C ABI; suppress
+  // the auto-generated C wrapper.
+  let NoCWrapper = true;
+  let ReturnType = "Box";
   let Args = [
-    Arg<"const char*", "code">,
-    OutArg<"bool*", "IsValueInvalid", "nullptr">
+    Arg<"const char*", "code">
   ];
 }
+
+// NOTE: The legacy C-ABI overload `intptr_t Evaluate(const char*, bool*)`
+// and its matching C wrapper `cppinterop_Evaluate` live hand-written in
+// CXCppInterOp.cpp / CppInterOp.h (look for "C-ABI"). They are not
+// declared here because tablegen does not need to know about them.
 
 // --- Scope / type queries ---
 

--- a/unittests/CppInterOp/CAPITest.cpp
+++ b/unittests/CppInterOp/CAPITest.cpp
@@ -168,13 +168,32 @@ TYPED_TEST(CppInterOpTest, CAPI_EnumFunctions) {
   // GetLanguage returns an InterpreterLanguage enum as unsigned char.
   // CXX == 5 (Unknown=0, Asm=1, CIR=2, LLVM_IR=3, C=4, CXX=5)
   EXPECT_EQ(cppinterop_GetLanguage(nullptr), 5);
+}
 
-  // Evaluate with bool* HadError.
-  bool HadError = false;
-  EXPECT_EQ(cppinterop_Evaluate("42", &HadError), 42);
-  EXPECT_FALSE(HadError);
-  // Evaluate error path tested in Interpreter_DeclareSilent; not
-  // duplicated here to avoid LLVM 22 crash and Windows MSBuild issues.
+// Exercises the hand-written cppinterop_Evaluate C bridge. The C++ overload
+// returning Cpp::Box has no C wrapper (NoCWrapper); C clients use this form.
+TYPED_TEST(CppInterOpTest, CAPI_Evaluate) {
+  if (TypeParam::isOutOfProcess)
+    GTEST_SKIP() << "Evaluate not supported in OOP JIT";
+  TestFixture::CreateInterpreter();
+
+  bool had_error = true; // ensure success path clears it
+  EXPECT_EQ(cppinterop_Evaluate("42", &had_error), 42);
+  EXPECT_FALSE(had_error);
+
+  // Null HadError pointer is documented as supported.
+  EXPECT_EQ(cppinterop_Evaluate("7 * 6", nullptr), 42);
+
+  // Error path: function writes true to HadError and returns ~0UL.
+  // Use a no-Value-after-success snippet (pure declaration) instead of
+  // `#error`; both hit the `!V.hasValue()` arm in CXCppInterOp.cpp's
+  // legacy Evaluate, but `#error` emits clang diagnostics that MSBuild's
+  // error-regex flags as a compile failure on the Windows CI runner.
+  had_error = false;
+  EXPECT_EQ(static_cast<unsigned long>(
+                cppinterop_Evaluate("class CAPIEvalNoValue {};", &had_error)),
+            ~0UL);
+  EXPECT_TRUE(had_error);
 }
 
 TYPED_TEST(CppInterOpTest, CAPI_CollectionReturn) {

--- a/unittests/CppInterOp/CUDATest.cpp
+++ b/unittests/CppInterOp/CUDATest.cpp
@@ -35,8 +35,9 @@ protected:
       Cpp::DeleteInterpreter(I);
       return;
     }
-    bool evalErr = false;
-    int cudaErr = (int)Cpp::Evaluate("(int)cudaGetLastError()", &evalErr);
+    Cpp::Box v = Cpp::Evaluate("(int)cudaGetLastError()");
+    bool evalErr = v.getKind() == Cpp::Box::K_Unspecified;
+    int cudaErr = evalErr ? -1 : v.unbox<int>();
     if (evalErr || cudaErr != 0)
       GTEST_LOG_(WARNING) << "CUDA Kernel execution failed (cudaError="
                           << cudaErr << "). Runtime tests will be skipped.";
@@ -113,10 +114,9 @@ TEST_F(CUDATest, CUDARuntime) {
     int deviceCount = 0;
     cudaGetDeviceCount(&deviceCount);
   )"));
-  bool err = false;
-  intptr_t count = Cpp::Evaluate("deviceCount", &err);
-  EXPECT_FALSE(err);
-  EXPECT_GT((int)count, 0);
+  Cpp::Box count = Cpp::Evaluate("deviceCount");
+  EXPECT_NE(count.getKind(), Cpp::Box::K_Unspecified);
+  EXPECT_GT(count.unbox<int>(), 0);
 }
 
 TEST_F(CUDATest, Interpreter_GetLanguageCUDA) {
@@ -140,15 +140,15 @@ TEST_F(CUDATest, SimpleKernelExecution) {
     int kernelErr = (int)cudaGetLastError();
   )")) << "Failed to declare/launch kernel";
 
-  bool err = false;
-  int cudaErr = (int)Cpp::Evaluate("kernelErr", &err);
-  EXPECT_FALSE(err);
+  Cpp::Box kernelErrV = Cpp::Evaluate("kernelErr");
+  EXPECT_NE(kernelErrV.getKind(), Cpp::Box::K_Unspecified);
+  int cudaErr = kernelErrV.unbox<int>();
   EXPECT_EQ(cudaErr, 0) << "Simple kernel launch failed";
 
   if (cudaErr == 0) {
-    intptr_t result = Cpp::Evaluate("*d", &err);
-    EXPECT_FALSE(err);
-    EXPECT_EQ((int)result, 42);
+    Cpp::Box result = Cpp::Evaluate("*d");
+    EXPECT_NE(result.getKind(), Cpp::Box::K_Unspecified);
+    EXPECT_EQ(result.unbox<int>(), 42);
   }
 
   Cpp::Declare("cudaFree(d);");
@@ -195,16 +195,13 @@ TEST_F(CUDATest, CUB_BlockReduceWithDeviceFunction) {
     cudaError_t lastErr = cudaGetLastError();
   )")) << "Failed to launch kernel";
 
-  bool err = false;
-  EXPECT_EQ((int)Cpp::Evaluate("(int)syncErr", &err), 0);
-  EXPECT_FALSE(err);
-  EXPECT_EQ((int)Cpp::Evaluate("(int)lastErr", &err), 0);
-  EXPECT_FALSE(err);
+  EXPECT_EQ(Cpp::Evaluate("(int)syncErr").unbox<int>(), 0);
+  EXPECT_EQ(Cpp::Evaluate("(int)lastErr").unbox<int>(), 0);
 
   // read result directly from managed memory
-  intptr_t result = Cpp::Evaluate("*d_out", &err);
-  EXPECT_FALSE(err);
-  EXPECT_EQ((int)result, 5625216);
+  Cpp::Box result = Cpp::Evaluate("*d_out");
+  EXPECT_NE(result.getKind(), Cpp::Box::K_Unspecified);
+  EXPECT_EQ(result.unbox<int>(), 5625216);
 
   Cpp::Declare("cudaFree(d_in); cudaFree(d_out);");
 }

--- a/unittests/CppInterOp/InterpreterTest.cpp
+++ b/unittests/CppInterOp/InterpreterTest.cpp
@@ -84,27 +84,190 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, Interpreter_Evaluate) {
   // Due to a deficiency in the clang-repl implementation to get the value we
   // always must omit the ;
   TestFixture::CreateInterpreter();
-  EXPECT_TRUE(Cpp::Evaluate("__cplusplus", nullptr) == 201402);
+  EXPECT_EQ(Cpp::Evaluate("__cplusplus").unbox<long>(), 201402L);
 
-  bool HadError;
-  EXPECT_TRUE(Cpp::Evaluate("#error", &HadError) == (intptr_t)~0UL);
-  EXPECT_TRUE(HadError);
+  // K_Unspecified is the "no usable value" sentinel (parse error or
+  // no-Value-after-success). Replaces the old IsValueInvalid out-param.
+  EXPECT_EQ(Cpp::Evaluate("#error").getKind(), Cpp::Box::K_Unspecified);
   // for llvm < 19 this tests different overloads of
   // __clang_Interpreter_SetValueNoAlloc
-  EXPECT_EQ(Cpp::Evaluate("int i = 11; ++i", &HadError), 12);
-  EXPECT_FALSE(HadError);
-  EXPECT_EQ(Cpp::Evaluate("double a = 12.; a", &HadError), 12.);
-  EXPECT_FALSE(HadError);
-  EXPECT_EQ(Cpp::Evaluate("float b = 13.; b", &HadError), 13.);
-  EXPECT_FALSE(HadError);
-  EXPECT_EQ(Cpp::Evaluate("long double c = 14.; c", &HadError), 14.);
-  EXPECT_FALSE(HadError);
-  EXPECT_EQ(Cpp::Evaluate("long double d = 15.; d", &HadError), 15.);
-  EXPECT_FALSE(HadError);
-  EXPECT_EQ(Cpp::Evaluate("unsigned long long e = 16; e", &HadError), 16);
-  EXPECT_FALSE(HadError);
-  EXPECT_NE(Cpp::Evaluate("struct S{} s; s", &HadError), (intptr_t)~0UL);
-  EXPECT_FALSE(HadError);
+  EXPECT_EQ(Cpp::Evaluate("int i = 11; ++i").unbox<int>(), 12);
+  EXPECT_EQ(Cpp::Evaluate("double a = 12.; a").unbox<double>(), 12.);
+  EXPECT_EQ(Cpp::Evaluate("float b = 13.; b").unbox<float>(), 13.f);
+  EXPECT_EQ(Cpp::Evaluate("long double c = 14.; c").unbox<long double>(), 14.L);
+  EXPECT_EQ(Cpp::Evaluate("long double d = 15.; d").unbox<long double>(), 15.L);
+  EXPECT_EQ(
+      Cpp::Evaluate("unsigned long long e = 16; e").unbox<unsigned long long>(),
+      16ULL);
+  // Object payload: K_PtrOrObj carries an owned pointer to the JIT-managed
+  // instance; lifetime ends with the Value going out of scope.
+  Cpp::Box sV = Cpp::Evaluate("struct S{} s; s");
+  EXPECT_EQ(sV.getKind(), Cpp::Box::K_PtrOrObj);
+  EXPECT_NE(sV.getObjectPtr(), nullptr);
+}
+
+// Copy semantics mirror clang::Value: fundamentals POD-copy; K_PtrOrObj is
+// refcounted-shallow (retain bumps a ref, dtor releases). The test exercises
+// both: fundamentals copy independently, K_PtrOrObj copy shares the payload
+// pointer and survives the original going out of scope.
+TYPED_TEST(CPPINTEROP_TEST_MODE, Interpreter_Evaluate_Copy) {
+#ifdef EMSCRIPTEN
+  GTEST_SKIP() << "Test fails for Emscipten builds";
+#endif
+#ifdef _WIN32
+  GTEST_SKIP() << "Disabled on Windows. Needs fixing.";
+#endif
+  if (TypeParam::isOutOfProcess)
+    GTEST_SKIP() << "Test fails for OOP JIT builds";
+  TestFixture::CreateInterpreter();
+
+  // Fundamentals: POD copy; original and copy hold equal data, independent.
+  Cpp::Box i = Cpp::Evaluate("int x = 42; x");
+  Cpp::Box ic = i;
+  EXPECT_EQ(ic.getKind(), Cpp::Box::K_Int);
+  EXPECT_EQ(ic.unbox<int>(), 42);
+  EXPECT_EQ(i.unbox<int>(), 42); // original survives copy
+
+  // K_PtrOrObj: shallow + refcounted. Copy shares the payload pointer; the
+  // payload survives the original going out of scope. Refcount reaches 0
+  // only when both Values destruct (no double-free, no use-after-free under
+  // ASan).
+  void* sharedPtr = nullptr;
+  {
+    Cpp::Box sV = Cpp::Evaluate("struct CopyT { int v = 7; }; CopyT{}");
+    ASSERT_EQ(sV.getKind(), Cpp::Box::K_PtrOrObj);
+    Cpp::Box sC = sV;
+    EXPECT_EQ(sC.getKind(), Cpp::Box::K_PtrOrObj);
+    EXPECT_EQ(sC.getObjectPtr(), sV.getObjectPtr())
+        << "copy shares payload (refcount, not deep copy)";
+    sharedPtr = sV.getObjectPtr();
+    // sV goes out of inner scope here -- refcount drops to 1; sC still owns.
+  }
+  EXPECT_NE(sharedPtr, nullptr);
+
+  // Non-trivial destructor: ValueStorage::Release runs the dtor via its
+  // function pointer when the last ref drops. ASan would flag a leak of
+  // the inner `int` if the refcounted copy fired the dtor twice (or not
+  // at all). Types are declared via Cpp::Declare (TU scope) so cling's
+  // destructor-thunk -- emitted in a later input_line -- can still
+  // resolve the name; declaring the struct inline inside Evaluate would
+  // make it a local struct on cling and break cross-TU lookup.
+  Cpp::Declare("struct DtorT { int* p; DtorT() { p = new int(13); } "
+               "~DtorT() { delete p; } };");
+  {
+    Cpp::Box dV = Cpp::Evaluate("DtorT{}");
+    ASSERT_EQ(dV.getKind(), Cpp::Box::K_PtrOrObj);
+    { Cpp::Box dC = dV; } // copy then drop -- refcount 2 -> 1; no dtor
+    // dV still owns; dtor fires when this scope ends.
+  }
+
+  // Class with a static member: the payload's per-instance heap path
+  // must not double-count the static, and the dtor pointer fires only
+  // for the instance. (Statics live in module data, not the payload.)
+  // TU-scope declaration is required: cling wraps Evaluate snippets in
+  // a function, and C++ forbids static data members in local types.
+  Cpp::Declare("int StatT_freed = 0; "
+               "struct StatT { static int counter; int* p; "
+               "StatT() { p = new int(++counter); } "
+               "~StatT() { delete p; ++StatT_freed; } }; "
+               "int StatT::counter = 0;");
+  {
+    Cpp::Box sV = Cpp::Evaluate("StatT{}");
+    ASSERT_EQ(sV.getKind(), Cpp::Box::K_PtrOrObj);
+    { Cpp::Box sC = sV; } // refcounted copy; no dtor on drop
+  }
+  // After the box drops, exactly one dtor fired (no spurious second
+  // delete from the now-released copy).
+  EXPECT_EQ(Cpp::Evaluate("StatT_freed").unbox<int>(), 1);
+
+  // Move semantics: src is reset to K_Unspecified so its dtor does not
+  // release the storage the destination now owns. A regression here
+  // would double-release the K_PtrOrObj payload (ASan-detectable).
+  Cpp::Declare("struct MoveT { int v = 1; };");
+  Cpp::Box src = Cpp::Evaluate("MoveT{}");
+  ASSERT_EQ(src.getKind(), Cpp::Box::K_PtrOrObj);
+  void* origPtr = src.getObjectPtr();
+  Cpp::Box dst = std::move(src);
+  EXPECT_EQ(src.getKind(), Cpp::Box::K_Unspecified);
+  EXPECT_EQ(dst.getObjectPtr(), origPtr);
+}
+
+// visit() dispatches over Kind to the matching typed slot. Test in two
+// shapes: (a) Kind known statically -- the AOT-fold path that catalog
+// thunks ride, where Create<T>().visit(v) constant-folds to v(x);
+// (b) Kind known only at runtime -- the GenericExecutor pattern, where
+// the visitor must accept every fundamental T.
+TYPED_TEST(CPPINTEROP_TEST_MODE, Interpreter_Evaluate_VisitDispatch) {
+#ifdef EMSCRIPTEN
+  GTEST_SKIP() << "Test fails for Emscipten builds";
+#endif
+#ifdef _WIN32
+  GTEST_SKIP() << "Disabled on Windows. Needs fixing.";
+#endif
+  if (TypeParam::isOutOfProcess)
+    GTEST_SKIP() << "Test fails for OOP JIT builds";
+  TestFixture::CreateInterpreter();
+
+  // (a) AOT fold: Kind is K_Int by construction. The visitor receives an
+  // int and routes through the K_Int case only.
+  auto toll = [](auto x) -> long long { return static_cast<long long>(x); };
+  EXPECT_EQ(Cpp::Box::Create<int>(42).visit(toll), 42LL);
+  EXPECT_EQ(Cpp::Box::Create<double>(3.5).visit(toll), 3LL); // trunc to ll
+  EXPECT_EQ(Cpp::Box::Create<bool>(true).visit(toll), 1LL);
+
+  // (b) Runtime: Kind is data, set by Evaluate. visit dispatches on the
+  // runtime tag; the same visitor handles every fundamental.
+  EXPECT_EQ(Cpp::Evaluate("int i = 11; ++i").visit(toll), 12LL);
+  EXPECT_EQ(Cpp::Evaluate("double a = 12.5; a").visit(toll), 12LL);
+  EXPECT_EQ(Cpp::Evaluate("unsigned long long u = 16; u").visit(toll), 16LL);
+
+  // convertTo<T> is the public "I don't know the Kind, give me T" path.
+  // Internally it visit()s and static_casts -- so the same dispatch
+  // covers fundamentals safely without the Kind-mismatch UB of as<T>.
+  // Distinct decl names keep each Evaluate from being a redeclaration
+  // of the previous (which would parse-error to K_Unspecified and trip
+  // visit's __builtin_unreachable).
+  EXPECT_EQ(Cpp::Evaluate("int cv_a = 7; cv_a").convertTo<long>(), 7L);
+  EXPECT_EQ(Cpp::Evaluate("int cv_b = 7; cv_b").convertTo<double>(), 7.0);
+  EXPECT_EQ(Cpp::Evaluate("double cv_c = 4.5; cv_c").convertTo<int>(), 4);
+}
+
+// Covers every BuiltinType::Kind arm of the QualType classifier in
+// Evaluate. Each line exercises a distinct branch of the switch in
+// CppInterOp.cpp's classifyByQualType.
+TYPED_TEST(CPPINTEROP_TEST_MODE, Interpreter_Evaluate_AllFundamentals) {
+#ifdef EMSCRIPTEN
+  GTEST_SKIP() << "Test fails for Emscipten builds";
+#endif
+#ifdef _WIN32
+  GTEST_SKIP() << "Disabled on Windows. Needs fixing.";
+#endif
+  if (TypeParam::isOutOfProcess)
+    GTEST_SKIP() << "Test fails for OOP JIT builds";
+  TestFixture::CreateInterpreter();
+
+  EXPECT_EQ(Cpp::Evaluate("bool b = true; b").unbox<bool>(), true);
+  EXPECT_EQ(Cpp::Evaluate("signed char sc = -3; sc").unbox<signed char>(), -3);
+  EXPECT_EQ(Cpp::Evaluate("unsigned char uc = 7; uc").unbox<unsigned char>(),
+            7);
+  EXPECT_EQ(Cpp::Evaluate("short sh = -9; sh").unbox<short>(), -9);
+  EXPECT_EQ(Cpp::Evaluate("unsigned short us = 11; us").unbox<unsigned short>(),
+            11);
+  EXPECT_EQ(Cpp::Evaluate("unsigned int ui = 13; ui").unbox<unsigned int>(),
+            13U);
+  EXPECT_EQ(Cpp::Evaluate("unsigned long ul = 17; ul").unbox<unsigned long>(),
+            17UL);
+  EXPECT_EQ(Cpp::Evaluate("long long ll = -21; ll").unbox<long long>(), -21LL);
+
+  // Plain `char` resolves to Char_S on platforms where char is signed
+  // by default (x86_64 Linux/macOS, MSVC) and Char_U on platforms where
+  // it is unsigned (Linux/aarch64, PowerPC); the classifier folds the
+  // latter into K_UChar so the Box::Create<T> X-macro stays single-
+  // valued per C++ type.
+  Cpp::Box c = Cpp::Evaluate("char ch = 'a'; ch");
+  EXPECT_TRUE(c.getKind() == Cpp::Box::K_Char_S ||
+              c.getKind() == Cpp::Box::K_UChar);
+  EXPECT_EQ(c.convertTo<int>(), 'a');
 }
 
 // Regression (cppyy test12): no-Value-after-success used to abort in
@@ -121,10 +284,8 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, Interpreter_Evaluate_NonValueStatement) {
     GTEST_SKIP() << "Test fails for OOP JIT builds";
   TestFixture::CreateInterpreter();
 
-  bool HadError = false;
-  EXPECT_EQ(Cpp::Evaluate("class EvalRegression_NoValue {};", &HadError),
-            (intptr_t)~0UL);
-  EXPECT_TRUE(HadError);
+  EXPECT_EQ(Cpp::Evaluate("class EvalRegression_NoValue {};").getKind(),
+            Cpp::Box::K_Unspecified);
 }
 
 TYPED_TEST(CPPINTEROP_TEST_MODE, Interpreter_DeleteInterpreter) {
@@ -227,20 +388,20 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, Interpreter_ActivateInterpreter) {
   auto* Cpp20 = TestFixture::CreateInterpreter({"-std=c++20"});
 
   EXPECT_TRUE(Cpp14 && Cpp17 && Cpp20);
-  EXPECT_TRUE(Cpp::Evaluate("__cplusplus") == 202002L)
+  EXPECT_EQ(Cpp::Evaluate("__cplusplus").unbox<long>(), 202002L)
       << "Failed to activate C++20";
 
   auto* UntrackedI = reinterpret_cast<void*>(static_cast<std::uintptr_t>(~0U));
   EXPECT_FALSE(Cpp::ActivateInterpreter(UntrackedI));
 
   EXPECT_TRUE(Cpp::ActivateInterpreter(Cpp14));
-  EXPECT_TRUE(Cpp::Evaluate("__cplusplus") == 201402L);
+  EXPECT_EQ(Cpp::Evaluate("__cplusplus").unbox<long>(), 201402L);
 
   Cpp::DeleteInterpreter(Cpp14);
   EXPECT_EQ(Cpp::GetInterpreter(), Cpp20);
 
   EXPECT_TRUE(Cpp::ActivateInterpreter(Cpp17));
-  EXPECT_TRUE(Cpp::Evaluate("__cplusplus") == 201703L);
+  EXPECT_EQ(Cpp::Evaluate("__cplusplus").unbox<long>(), 201703L);
 }
 
 TYPED_TEST(CPPINTEROP_TEST_MODE, Interpreter_Process) {


### PR DESCRIPTION
Add a small tagged-union type, Cpp::Box, that bindings and the interpreter use to exchange typed values in both directions. A binding constructs one with Box::Create<T>(x) and hands it to the runtime; the interpreter returns one from Evaluate and the binding extracts it with unbox<T>(), convertTo<T>(), or visit(v). The same shape works for the fundamental scalar types (stored inline) and for object payloads (stored behind a refcounted pointer the producer attaches via a {retain, release} ops table). Without Box every binding has to write its own Kind switch and duplicate the per-type storage logic.

Evaluate now returns a Box (replacing the old intptr_t + bool* out-param). Object payloads round-trip through a small ValueRefCount wrapper in Compatibility.h next to compat::Value; the wrapper uses clang::Value's copy ctor instead of move ctor to work around an upstream bug fixed by https://github.com/llvm/llvm-project/pull/200888, and a static_assert(LLVM_VERSION_MAJOR < 23) makes sure we revisit it.

Box.h itself is kept cheap to parse since the JIT pulls it whenever a catalog thunk or evaluated snippet references Cpp::Box. We avoid CppInterOpTypes.h (it transitively brings in <vector>, <string>, <set>), use unsigned char for the Kind underlying type instead of <cstdint>, gate <cassert> behind NDEBUG, and inline the cross-platform always_inline macro locally. Under NDEBUG the header pulls in zero project or standard headers; with asserts on, only <cassert>. Tests cover the fundamentals and K_PtrOrObj round-trip (POD, non-trivial destructor, class-with-static-member), refcounted copy + move semantics, and visit / convertTo on both AOT and runtime paths.