### PR TITLE
Add public C-API header CXCppInterOp.h

### DIFF
--- a/include/CppInterOp/CXCppInterOp.h
+++ b/include/CppInterOp/CXCppInterOp.h
@@ -1,0 +1,47 @@
+//===- CXCppInterOp.h - C API for the CppInterOp library --------*- C -*-===//
+//
+// Part of the compiler-research project, under the Apache License v2.0 with
+// LLVM Exceptions.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Public C API for CppInterOp. Wraps the tablegen-generated declarations
+// in CXCppInterOpDecl.inc and adds the hand-written extras that cannot
+// be emitted by the generator (NoCWrapper return types, mixed return +
+// out-param shapes).
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CPPINTEROP_CXCPPINTEROP_H
+#define CPPINTEROP_CXCPPINTEROP_H
+
+#include "CppInterOp/CppInterOpTypes.h"
+
+#ifdef __cplusplus
+// The generated .inc references the public namespace alias `Cpp` to
+// pull C-struct types into scope; mirror that alias here so this
+// header is self-sufficient (CppInterOp.h is C++-only, so we can't
+// rely on the consumer having included it).
+// NOLINTNEXTLINE(misc-unused-alias-decls)
+namespace Cpp = CppImpl;
+
+extern "C" {
+#endif
+
+#include "CppInterOp/CXCppInterOpDecl.inc"
+
+// --- Hand-written wrappers (see lib/CppInterOp/CXCppInterOp.cpp) ---
+
+/// Returns the templated method scopes inside \c parent matching
+/// \c name. The bool-return-with-vector-outparam shape is not
+/// expressible by the tablegen wrapper emitter; callers check
+/// \c arr.size > 0 to detect "no matches".
+CPPINTEROP_API CppInterOpArray
+cppinterop_GetClassTemplatedMethods(const char* name, void* parent);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif // CPPINTEROP_CXCPPINTEROP_H

--- a/lib/CppInterOp/CXCppInterOp.cpp
+++ b/lib/CppInterOp/CXCppInterOp.cpp
@@ -1,7 +1,9 @@
 // Hand-written C API wrappers for functions the TableGen emitter
-// cannot generate mechanically. Generated wrappers live in
-// CXCppInterOpGenerated.cpp.
+// cannot generate mechanically. Public declarations of these
+// symbols live in include/CppInterOp/CXCppInterOp.h; generated
+// wrappers live in CXCppInterOpGenerated.cpp.
 
+#include "CppInterOp/CXCppInterOp.h"
 #include "CppInterOp/CppInterOp.h"
 
 #include <cstdlib>

--- a/unittests/CppInterOp/CAPITest.cpp
+++ b/unittests/CppInterOp/CAPITest.cpp
@@ -3,19 +3,12 @@
 
 #include "Utils.h"
 
+#include "CppInterOp/CXCppInterOp.h"
+
 #include "gtest/gtest.h"
 
 #include <cstdlib>
 #include <cstring>
-
-// Pull in the generated C declarations.
-extern "C" {
-#include "CppInterOp/CXCppInterOpDecl.inc"
-
-// Hand-written wrappers not in the .inc file.
-CPPINTEROP_API Cpp::CppInterOpArray
-cppinterop_GetClassTemplatedMethods(const char* name, void* parent);
-}
 
 using namespace TestUtils;
 


### PR DESCRIPTION
Bindings and tests that want to call the cppinterop_* C wrappers currently have to repeat their declarations themselves, either by `#include`ing the generated CXCppInterOpDecl.inc (an internal build artifact, not a stable header) or by hand-writing extern "C" blocks that drift out of sync with the implementation. The hand-written wrappers in CXCppInterOp.cpp -- today that is just cppinterop_GetClassTemplatedMethods, but more will come as functions opt out of generated C wrappers -- have no public declaration at all, so the test pulls them in via a duplicated forward declaration.

Introduce include/CppInterOp/CXCppInterOp.h as the single C-facing public header: it wraps the generated .inc in an extern "C" block, mirrors the `Cpp = CppImpl` namespace alias for self-sufficiency (CppInterOp.h is C++-only, so consumers of the C API cannot rely on it being in scope), and declares the hand-written extras alongside. CAPITest.cpp and CXCppInterOp.cpp now consume it, which also serves as the declaration-matches-definition check.

# Description

Please include a summary of changes, motivation and context for this PR.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [ ] I have read the contribution guide recently
