### PR TITLE
Switch Box::Kind underlying type to int.

### DIFF
--- a/include/CppInterOp/Box.h
+++ b/include/CppInterOp/Box.h
@@ -95,7 +95,8 @@ namespace CppImpl {
 
 class Box {
 public:
-  enum Kind : unsigned char {
+  // `int` (not `unsigned char`) to work around compiler-research/cppyy#223.
+  enum Kind : int {
 #define X(type, name) K_##name,
     CPP_BOX_BUILTIN_TYPES
 #undef X


### PR DESCRIPTION
cppyy reflects functions returning a value of `enum X : unsigned char` as a 1-character Python str (the byte as Latin-1), while the same enum's members accessed through the enum-class proxy reflect as Python int. That asymmetry breaks `box.getKind() == K_Unspecified` guards silently on osx and lets `Box::convertTo<T>` fall into its precondition-violation arm. See compiler-research/cppyy#223 for the underlying executor-table quirk and the reproducer.

Underlying type change has no size impact: Box pads to 32 bytes either way (driven by 16-byte long double in Storage + 16-byte alignment of the class). Revert to `unsigned char` once the marshaling catalog displaces cppyy's per-T executor selection for enum returns.

# Description

Please include a summary of changes, motivation and context for this PR.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [ ] I have read the contribution guide recently
