### PR TITLE
[bench] Bump Google Benchmark to v1.9.5 + drop the c2y-extensions opt-out

### DIFF
--- a/cmake/modules/GoogleBenchmark.cmake
+++ b/cmake/modules/GoogleBenchmark.cmake
@@ -32,7 +32,7 @@ ExternalProject_Add(
   googlebenchmark
   GIT_REPOSITORY https://github.com/google/benchmark.git
   GIT_SHALLOW FALSE
-  GIT_TAG v1.9.1
+  GIT_TAG v1.9.2
   UPDATE_COMMAND ""
   CONFIGURE_COMMAND ${CMAKE_COMMAND} -G ${CMAKE_GENERATOR}
                 -S ${CMAKE_CURRENT_BINARY_DIR}/googlebenchmark-prefix/src/googlebenchmark/

--- a/cmake/modules/GoogleBenchmark.cmake
+++ b/cmake/modules/GoogleBenchmark.cmake
@@ -32,7 +32,7 @@ ExternalProject_Add(
   googlebenchmark
   GIT_REPOSITORY https://github.com/google/benchmark.git
   GIT_SHALLOW FALSE
-  GIT_TAG v1.9.2
+  GIT_TAG v1.9.5
   UPDATE_COMMAND ""
   CONFIGURE_COMMAND ${CMAKE_COMMAND} -G ${CMAKE_GENERATOR}
                 -S ${CMAKE_CURRENT_BINARY_DIR}/googlebenchmark-prefix/src/googlebenchmark/

--- a/unittests/CppInterOp/CMakeLists.txt
+++ b/unittests/CppInterOp/CMakeLists.txt
@@ -132,12 +132,6 @@ if(CPPINTEROP_BUILT_STANDALONE AND NOT EMSCRIPTEN AND BUILD_SHARED_LIBS)
     VTableOverlayCrossTUBench.cpp)
   target_link_libraries(VTableOverlayCrossTUBench PRIVATE benchmark TestSharedLib)
   add_dependencies(VTableOverlayCrossTUBench TestSharedLib)
-  # Google Benchmark's BENCHMARK() macro expands __COUNTER__, which clang's
-  # -Wc2y-extensions flags; CppInterOp builds -Werror, so the third-party
-  # macro would otherwise fail this TU. (Unknown -Wno- is a no-op elsewhere.)
-  if(NOT MSVC)
-    target_compile_options(VTableOverlayCrossTUBench PRIVATE -Wno-c2y-extensions)
-  endif()
 endif()
 
 # Downstream-DSO dlopen check that mirrors libcppyy-backend's contract:


### PR DESCRIPTION
1.9.1's BENCHMARK() macro expansion tripped clang 22's -Wc2y-extensions diagnostic under -pedantic + -Werror, which required a target-scoped -Wno-c2y-extensions in unittests/ CppInterOp/CMakeLists.txt. That flag is unknown to clang < 22, where -Werror via -Wunknown-warning-option then failed the build in any downstream consumer's older toolchain.

v1.9.5 is pedantic-clean against current clang; drop the target-scoped suppression. If a future clang release reintroduces a pedantic warning here, prefer a target-scoped -Wno-pedantic over chasing per-release -Wno-X flags.

# Description

Please include a summary of changes, motivation and context for this PR.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [ ] I have read the contribution guide recently
