### PR TITLE
[error-model] Add Cpp::Result<T>.

### DIFF
--- a/include/CppInterOp/Error.h
+++ b/include/CppInterOp/Error.h
@@ -1,0 +1,244 @@
+//===--- Error.h - Cpp::Result<T> -------------------------------*- C++ -*-===//
+//
+// Part of the compiler-research project, under the Apache License v2.0 with
+// LLVM Exceptions.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Cpp::Result<T> -- the [[nodiscard]] return type fallible APIs use.
+// A Result holds either a value of T or an ErrorRef. The discipline
+// matches llvm::Expected: call .ok() (or coerce to bool), then .value()
+// on success or .error() on failure. value() on an error aborts;
+// value_or(fallback) is the lenient form.
+//
+// In debug builds, dropping an error-bearing Result without inspecting
+// it aborts. .ignore() opts out of that check.
+//
+// This PR is just the type. Later PRs add the boundary translator,
+// per-call diagnostics, and structured failure payloads.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CPPINTEROP_ERROR_H
+#define CPPINTEROP_ERROR_H
+
+#include "CppInterOp/CppInterOpTypes.h"
+
+#ifdef __cplusplus
+
+#include <cstddef>
+#include <cstdint>
+#include <new>
+#include <type_traits>
+#include <utility>
+
+namespace Cpp {
+
+/// Coarse outcome code. Status::Failed is a placeholder -- later PRs
+/// refine the taxonomy (NotFound, ParseError, ...) as APIs migrate.
+enum class Status : uint8_t {
+  Ok = 0,
+  Failed,
+};
+
+/// 8-byte opaque error handle. nullptr state means "no error". A
+/// non-null state is an opaque pointer interpreted by later PRs.
+struct ErrorRef {
+  const void* state = nullptr;
+
+  [[nodiscard]] bool isOk() const { return state == nullptr; }
+};
+
+/// Out-of-line abort for value()-on-error. Keeps Result<T>'s inline
+/// body small.
+[[noreturn]] CPPINTEROP_API void ResultAbort_ValueOnError(const ErrorRef& Err);
+
+#ifndef NDEBUG
+/// Out-of-line abort for the debug must-handle check. Shared between
+/// Result<T> and Result<void> so the message and abort path live in
+/// one place.
+[[noreturn]] CPPINTEROP_API void
+ResultAbort_UncheckedOnDtor(const ErrorRef& Err);
+#endif
+
+// Result<T>: union of T storage and the ErrorRef pointer, plus a
+// HasError discriminator. Sized comparably to llvm::Expected<T>
+// (pinned by static_assert in ResultBench). Debug adds an Unchecked
+// bit; release shrinks to bare union + discriminator.
+
+template <typename T> class [[nodiscard]] Result {
+  static_assert(!std::is_same<T, void>::value,
+                "Result<void> is provided via specialization below");
+
+  static constexpr size_t kStorageSize = sizeof(T) > sizeof(void*)
+                                             ? sizeof(T)
+                                             : sizeof(void*);
+  static constexpr size_t kStorageAlign = alignof(T) > alignof(void*)
+                                              ? alignof(T)
+                                              : alignof(void*);
+
+  union {
+    alignas(kStorageAlign) unsigned char m_ValueBytes[kStorageSize];
+    const void* m_ErrState; // when m_HasError == true
+  };
+  bool m_HasError = false;
+
+#ifndef NDEBUG
+  mutable bool m_Unchecked = true;
+  void markChecked() const { m_Unchecked = false; }
+#else
+  void markChecked() const {}
+#endif
+
+  // reinterpret_cast across the union member -- std::launder is C++17
+  // and the header has to parse in C++14 consumer contexts.
+  T* valuePtr() { return reinterpret_cast<T*>(m_ValueBytes); }
+  const T* valuePtr() const { return reinterpret_cast<const T*>(m_ValueBytes); }
+
+public:
+  Result() { new (m_ValueBytes) T(); }
+
+  Result(T V) { new (m_ValueBytes) T(std::move(V)); }
+
+  Result(ErrorRef E) : m_ErrState(E.state), m_HasError(true) {}
+
+  Result(const Result& Other) : m_HasError(Other.m_HasError) {
+    if (m_HasError)
+      m_ErrState = Other.m_ErrState;
+    else
+      new (m_ValueBytes) T(*Other.valuePtr());
+#ifndef NDEBUG
+    m_Unchecked = Other.m_Unchecked;
+    Other.m_Unchecked = false;
+#endif
+  }
+
+  Result(Result&& Other) noexcept : m_HasError(Other.m_HasError) {
+    if (m_HasError)
+      m_ErrState = Other.m_ErrState;
+    else
+      new (m_ValueBytes) T(std::move(*Other.valuePtr()));
+#ifndef NDEBUG
+    m_Unchecked = Other.m_Unchecked;
+    Other.m_Unchecked = false;
+#endif
+  }
+
+  ~Result() {
+#ifndef NDEBUG
+    // Must-handle enforcement: an error-bearing Result that wasn't
+    // inspected aborts. Use .ignore() to drop on purpose.
+    if (m_Unchecked && m_HasError)
+      ResultAbort_UncheckedOnDtor(ErrorRef{m_ErrState});
+#endif
+    if (!m_HasError)
+      valuePtr()->~T();
+  }
+
+  Result& operator=(const Result&) = delete;
+  Result& operator=(Result&&) = delete;
+
+  /// Mark this Result checked without reading it -- for when you
+  /// genuinely want to drop the outcome.
+  void ignore() const { markChecked(); }
+
+  [[nodiscard]] bool ok() const {
+    markChecked();
+    return !m_HasError;
+  }
+  explicit operator bool() const { return ok(); }
+
+  [[nodiscard]] Status status() const {
+    markChecked();
+    return m_HasError ? Status::Failed : Status::Ok;
+  }
+
+  [[nodiscard]] ErrorRef error() const {
+    markChecked();
+    return m_HasError ? ErrorRef{m_ErrState} : ErrorRef{};
+  }
+
+  /// Value on Ok; aborts on Error. Use value_or for lenient semantics.
+  T value() const {
+    markChecked();
+    if (m_HasError)
+      ResultAbort_ValueOnError(error());
+    return *valuePtr();
+  }
+
+  T value_or(T fallback) const {
+    markChecked();
+    return m_HasError ? std::move(fallback) : *valuePtr();
+  }
+};
+
+// Void specialization: no T storage, ErrorRef stored directly.
+
+template <> class [[nodiscard]] Result<void> {
+  const void* m_ErrState = nullptr;
+#ifndef NDEBUG
+  mutable bool m_Unchecked = true;
+  void markChecked() const { m_Unchecked = false; }
+#else
+  void markChecked() const {}
+#endif
+
+public:
+  Result() = default;
+  Result(ErrorRef E) : m_ErrState(E.state) {}
+
+  Result& operator=(const Result&) = delete;
+  Result& operator=(Result&&) = delete;
+
+  Result(const Result& O) : m_ErrState(O.m_ErrState) {
+#ifndef NDEBUG
+    m_Unchecked = O.m_Unchecked;
+    O.m_Unchecked = false;
+#endif
+  }
+
+  Result(Result&& O) noexcept : m_ErrState(O.m_ErrState) {
+#ifndef NDEBUG
+    // Transfer the must-handle obligation to the destination -- the
+    // default move leaves m_Unchecked=true on the source and the
+    // source's dtor would abort even though the value went to the
+    // caller (the bug seen when threading Results through tracing
+    // record() wrappers).
+    m_Unchecked = O.m_Unchecked;
+    O.m_Unchecked = false;
+#endif
+    O.m_ErrState = nullptr;
+  }
+
+  ~Result() {
+#ifndef NDEBUG
+    if (m_Unchecked && m_ErrState)
+      ResultAbort_UncheckedOnDtor(ErrorRef{m_ErrState});
+#endif
+  }
+
+  void ignore() const { markChecked(); }
+
+  [[nodiscard]] bool ok() const {
+    markChecked();
+    return m_ErrState == nullptr;
+  }
+  explicit operator bool() const { return ok(); }
+
+  [[nodiscard]] Status status() const {
+    markChecked();
+    return m_ErrState ? Status::Failed : Status::Ok;
+  }
+
+  [[nodiscard]] ErrorRef error() const {
+    markChecked();
+    return ErrorRef{m_ErrState};
+  }
+};
+
+} // namespace Cpp
+
+#endif // __cplusplus
+
+#endif // CPPINTEROP_ERROR_H

--- a/lib/CppInterOp/CMakeLists.txt
+++ b/lib/CppInterOp/CMakeLists.txt
@@ -213,6 +213,7 @@ add_llvm_library(clangCppInterOp
   CppInterOpDispatch.cpp
   CXCppInterOp.cpp
   CXCppInterOpGenerated.cpp
+  ErrorInternal.cpp
   Tracing.cpp
   ${DLM}
   LINK_LIBS

--- a/lib/CppInterOp/ErrorInternal.cpp
+++ b/lib/CppInterOp/ErrorInternal.cpp
@@ -1,0 +1,47 @@
+//===--- ErrorInternal.cpp - Cpp::Result<T> abort helper --------*- C++ -*-===//
+//
+// Part of the compiler-research project, under the Apache License v2.0 with
+// LLVM Exceptions.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Out-of-line abort for Cpp::Result<T>::value() called on an
+// error-bearing Result. Keeps the inline Result<T> body small.
+//
+// Later PRs extend this file with the boundary translator
+// (llvm::Error / Expected<T> -> Cpp::Result<T>) and per-call
+// diagnostic capture.
+//
+//===----------------------------------------------------------------------===//
+
+#include "CppInterOp/Error.h"
+
+#include "CppInterOp/CppInterOpTypes.h"
+
+#include <cstdio>
+#include <cstdlib>
+
+namespace Cpp {
+
+[[noreturn]] CPPINTEROP_API void
+ResultAbort_ValueOnError(const ErrorRef& /*Err*/) {
+  std::fputs("Cpp::Result<T>::value() called on an error-bearing "
+             "Result. Use value_or(fallback) for lenient semantics, "
+             "or branch on .ok() / .error() before calling .value().\n",
+             stderr);
+  std::abort();
+}
+
+#ifndef NDEBUG
+[[noreturn]] CPPINTEROP_API void
+ResultAbort_UncheckedOnDtor(const ErrorRef& /*Err*/) {
+  std::fputs("Cpp::Result destroyed without check (likely a dropped "
+             "error). Call .ok() / .error() / .value() to inspect, "
+             "or .ignore() to acknowledge.\n",
+             stderr);
+  std::abort();
+}
+#endif
+
+} // namespace Cpp

--- a/unittests/CppInterOp/CMakeLists.txt
+++ b/unittests/CppInterOp/CMakeLists.txt
@@ -51,6 +51,7 @@ add_cppinterop_unittest(CppInterOpTests
   HandleTypesTest.cpp
   InterpreterTest.cpp
   JitTest.cpp
+  ResultTest.cpp
   ScopeReflectionTest.cpp
   TypeReflectionTest.cpp
   Utils.cpp

--- a/unittests/CppInterOp/ResultTest.cpp
+++ b/unittests/CppInterOp/ResultTest.cpp
@@ -1,0 +1,198 @@
+//===- ResultTest.cpp - Tests for Cpp::Result<T> ---------------*- C++ -*-===//
+//
+// Part of the compiler-research project, under the Apache License v2.0 with
+// LLVM Exceptions.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Value-semantic tests for Cpp::Result<T>: construction, accessors,
+// copy/move (including the Unchecked-flag transfer that catches the
+// moved-from-aborts-in-dtor trap), .ignore() opt-out, and death paths
+// for dropped errors and value()-on-error.
+//
+//===----------------------------------------------------------------------===//
+
+#include "CppInterOp/CppInterOp.h"
+#include "CppInterOp/CppInterOpTypes.h"
+#include "CppInterOp/Error.h"
+
+#include "llvm/Support/Error.h"
+
+#include "gtest/gtest.h"
+
+#include <string>
+#include <utility>
+
+// Size invariants. Each row caps Cpp::Result<T> at llvm::Expected<T>'s
+// size; a refactor that inflates the layout fails the build.
+
+static_assert(sizeof(Cpp::ErrorRef) == sizeof(void*),
+              "ErrorRef must be a single pointer");
+
+// Result<void> in release is just the ErrorRef pointer. Debug adds the
+// Unchecked bit; allow up to llvm::Error's debug-fudge ceiling.
+static_assert(sizeof(Cpp::Result<void>) <= sizeof(llvm::Error) * 2,
+              "Result<void> should not exceed llvm::Error layout");
+
+static_assert(sizeof(Cpp::Result<Cpp::DeclRef>) <=
+                  sizeof(llvm::Expected<void*>),
+              "Result<DeclRef> must not exceed llvm::Expected<void*>");
+
+static_assert(sizeof(Cpp::Result<int>) <= sizeof(llvm::Expected<int>),
+              "Result<int> must not exceed llvm::Expected<int>");
+
+namespace {
+// Address of a file-local sentinel byte serves as a non-null but
+// never-dereferenced ErrorRef state for the tests. Using a real
+// address keeps clang-tidy's int-to-ptr / reinterpret-cast checks
+// happy without weakening the test.
+const char kErrorSentinelByte = 0;
+const void* const kFakeState = &kErrorSentinelByte;
+Cpp::ErrorRef MakeErr() { return Cpp::ErrorRef{kFakeState}; }
+} // namespace
+
+// === Construction + basic accessors =====================================
+
+TEST(ResultTest, Result_OkFromValue) {
+  Cpp::Result<int> R{42};
+  EXPECT_TRUE(R.ok());
+  EXPECT_TRUE(static_cast<bool>(R));
+  EXPECT_EQ(R.status(), Cpp::Status::Ok);
+  EXPECT_TRUE(R.error().isOk());
+  EXPECT_EQ(R.value(), 42);
+  EXPECT_EQ(R.value_or(-1), 42);
+}
+
+TEST(ResultTest, Result_DefaultIsOk) {
+  // Default-constructed Result<T> holds a default-constructed T; ok().
+  Cpp::Result<int> R;
+  EXPECT_TRUE(R.ok());
+  EXPECT_EQ(R.value(), 0);
+}
+
+TEST(ResultTest, Result_ErrorFromErrorRef) {
+  Cpp::Result<int> R{MakeErr()};
+  EXPECT_FALSE(R.ok());
+  EXPECT_FALSE(static_cast<bool>(R));
+  EXPECT_EQ(R.status(), Cpp::Status::Failed);
+  EXPECT_FALSE(R.error().isOk());
+  EXPECT_EQ(R.error().state, kFakeState);
+  EXPECT_EQ(R.value_or(-1), -1);
+}
+
+// === Result<void> ========================================================
+
+TEST(ResultTest, ResultVoid_DefaultIsOk) {
+  Cpp::Result<void> R;
+  EXPECT_TRUE(R.ok());
+  EXPECT_EQ(R.status(), Cpp::Status::Ok);
+  EXPECT_TRUE(R.error().isOk());
+}
+
+TEST(ResultTest, ResultVoid_FromErrorRef) {
+  Cpp::Result<void> R{MakeErr()};
+  EXPECT_FALSE(R.ok());
+  EXPECT_EQ(R.status(), Cpp::Status::Failed);
+  EXPECT_EQ(R.error().state, kFakeState);
+}
+
+// === Copy semantics ======================================================
+
+TEST(ResultTest, Copy_Ok) {
+  Cpp::Result<int> A{7};
+  // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
+  Cpp::Result<int> B{A}; // exercises the copy ctor; do not collapse to a ref
+  EXPECT_TRUE(B.ok());
+  EXPECT_EQ(B.value(), 7);
+  // The source remains usable after copy; we explicitly check it here
+  // so its dtor doesn't trip the must-handle guard.
+  EXPECT_EQ(A.value(), 7);
+}
+
+TEST(ResultTest, Copy_Error) {
+  Cpp::Result<int> A{MakeErr()};
+  // NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
+  Cpp::Result<int> B{A}; // exercises the copy ctor; do not collapse to a ref
+  EXPECT_FALSE(B.ok());
+  EXPECT_FALSE(A.ok()); // mark A checked so its dtor doesn't abort
+}
+
+// === Move semantics ======================================================
+
+TEST(ResultTest, Move_Ok) {
+  Cpp::Result<int> A{11};
+  Cpp::Result<int> B{std::move(A)};
+  EXPECT_TRUE(B.ok());
+  EXPECT_EQ(B.value(), 11);
+  // A was Ok-valued; the move-from state is undefined for the value
+  // but still ok-tagged. No abort on A's dtor.
+}
+
+// Pins the bug where Result<void>'s default move ctor failed to
+// transfer the Unchecked obligation, causing the source's dtor to
+// abort even though the value semantically went to the destination
+// (most visible when threaded through a tracing record() wrapper).
+TEST(ResultTest, MoveCtor_Void_TransfersUncheckedToSource) {
+  Cpp::Result<void> A{MakeErr()};
+  Cpp::Result<void> B{std::move(A)};
+  // Check only B; A must not abort at scope exit despite never being
+  // inspected directly.
+  EXPECT_FALSE(B.ok());
+}
+
+TEST(ResultTest, MoveCtor_NonVoid_TransfersUncheckedToSource) {
+  Cpp::Result<int> A{MakeErr()};
+  Cpp::Result<int> B{std::move(A)};
+  EXPECT_FALSE(B.ok());
+}
+
+// Non-trivial T exercises the placement-new + explicit destructor
+// paths in ctor/dtor. Result<int> alone wouldn't catch a missing
+// T::~T() call -- int has no destructor to miss. ASan / leak checker
+// flags any miss here.
+TEST(ResultTest, Result_NonTrivialT_PlacementNewAndDtor) {
+  {
+    Cpp::Result<std::string> R{std::string("hello")};
+    EXPECT_TRUE(R.ok());
+    EXPECT_EQ(R.value(), "hello");
+  }
+
+  Cpp::Result<std::string> A{std::string("world")};
+  Cpp::Result<std::string> B{std::move(A)};
+  EXPECT_TRUE(B.ok());
+  EXPECT_EQ(B.value(), "world");
+}
+
+// .ignore() silences the dropped-error abort. Without it, the inner
+// blocks would die at scope exit.
+TEST(ResultTest, Ignore_SuppressesDroppedErrorAbort) {
+  {
+    Cpp::Result<int> R{MakeErr()};
+    R.ignore();
+  }
+  {
+    Cpp::Result<void> R{MakeErr()};
+    R.ignore();
+  }
+  SUCCEED();
+}
+
+#ifndef EMSCRIPTEN
+
+#ifndef NDEBUG
+TEST(ResultDeathTest, DroppedError_Aborts) {
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+  EXPECT_DEATH({ (void)Cpp::Result<int>(MakeErr()); },
+               ".*destroyed without check.*");
+}
+#endif // !NDEBUG
+
+// value() on an error always aborts, debug or release.
+TEST(ResultDeathTest, ValueOnError_Aborts) {
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+  EXPECT_DEATH({ (void)Cpp::Result<int>(MakeErr()).value(); },
+               ".*value\\(\\) called on an error-bearing Result.*");
+}
+
+#endif // !EMSCRIPTEN


### PR DESCRIPTION
Fallible CppInterOp APIs today return ad-hoc nulls, out-params, or crash on bad input. Result<T> is the single [[nodiscard]] return shape every future fallible API will use: it carries either a value of T or an ErrorRef, callers check .ok() then read .value() or .error(), and the type is sized at parity with llvm::Expected<T> (pinned by static_assert).

Debug builds enforce must-handle: an error-bearing Result destroyed without being inspected aborts. Explicit .ignore() opts out. Release builds drop the bit and the check.

This PR is only the type plus its tests and a size + Ok-path benchmark. The boundary translator that produces Results, per-call diagnostics, structured payloads, and existing-API migrations are follow-ups -- each landed on top, layered against this contract.

# Description

Please include a summary of changes, motivation and context for this PR.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [ ] I have read the contribution guide recently
