### PR TITLE
[ci] Re-enable clang-format and clang-tidy-review on pull_request.

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -1,12 +1,10 @@
 name: clang-format
 
 on:
-  # XXX(ci-root-integration): disabled on this branch; restore before landing.
-  # pull_request:
-  #   paths:
-  #     - '**.h'
-  #     - '**.cpp'
-  workflow_dispatch:
+  pull_request:
+    paths:
+      - '**.h'
+      - '**.cpp'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}

--- a/.github/workflows/clang-tidy-review.yml
+++ b/.github/workflows/clang-tidy-review.yml
@@ -1,12 +1,10 @@
 name: clang-tidy-review
 
 on:
-  # XXX(ci-root-integration): disabled on this branch; restore before landing.
-  # pull_request:
-  #   paths:
-  #     - '**.h'
-  #     - '**.cpp'
-  workflow_dispatch:
+  pull_request:
+    paths:
+      - '**.h'
+      - '**.cpp'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}


### PR DESCRIPTION
#932 disabled both workflows temporarily while landing the ROOT-build CI integration -- the trigger was switched from pull_request to workflow_dispatch with an XXX comment to restore before landing. #932 merged but the restore step was missed, so every PR since has opened without format or tidy feedback.

Re-enable the pull_request trigger on both workflows and drop the XXX placeholder.

# Description

Please include a summary of changes, motivation and context for this PR.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [ ] I have read the contribution guide recently
