### PR TITLE
[error-model] Carry the Clang diagnostic on a failed call.

### DIFF
--- a/include/CppInterOp/Error.h
+++ b/include/CppInterOp/Error.h
@@ -1,4 +1,4 @@
-//===--- Error.h - Cpp::Result<T> -------------------------------*- C++ -*-===//
+//===--- Error.h - Result<T>, ErrorRef, DiagnosticRef -----------*- C++ -*-===//
 //
 // Part of the compiler-research project, under the Apache License v2.0 with
 // LLVM Exceptions.
@@ -6,17 +6,10 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// Cpp::Result<T> -- the [[nodiscard]] return type fallible APIs use.
-// A Result holds either a value of T or an ErrorRef. The discipline
-// matches llvm::Expected: call .ok() (or coerce to bool), then .value()
-// on success or .error() on failure. value() on an error aborts;
-// value_or(fallback) is the lenient form.
-//
-// In debug builds, dropping an error-bearing Result without inspecting
-// it aborts. .ignore() opts out of that check.
-//
-// This PR is just the type. Later PRs add the boundary translator,
-// per-call diagnostics, and structured failure payloads.
+// Cpp::Result<T> carries either a T or an ErrorRef. ErrorRef encodes
+// either an inline Status code (no allocation) or a pointer to an
+// ErrorSlice owning drained Clang diagnostics, an optional structured
+// payload, and producer attribution.
 //
 //===----------------------------------------------------------------------===//
 
@@ -30,57 +23,214 @@
 #include <cstddef>
 #include <cstdint>
 #include <new>
+#include <string>
 #include <type_traits>
 #include <utility>
+#include <vector>
 
 namespace Cpp {
 
-/// Coarse outcome code. Status::Failed is a placeholder -- later PRs
-/// refine the taxonomy (NotFound, ParseError, ...) as APIs migrate.
+/// Outcome of a fallible API call.
 enum class Status : uint8_t {
   Ok = 0,
-  Failed,
+  NotFound,        // name lookup found nothing
+  InvalidArgument, // precondition violated by caller
+  Ambiguous,       // name lookup returned multiple matches
+  ParseError,      // Clang parser rejected the input
+  CompileError,    // Sema/codegen rejected the input
 };
 
-/// 8-byte opaque error handle. nullptr state means "no error". A
-/// non-null state is an opaque pointer interpreted by later PRs.
+/// Severity of a captured diagnostic.
+enum class DiagnosticSeverity : uint8_t { Note, Warning, Error, Fatal };
+
+/// Non-owning view over a contiguous range. Returned from accessors so
+/// callers can iterate without committing to a container type.
+template <typename T> struct ArrayView {
+  const T* Data = nullptr;
+  size_t Size = 0;
+
+  [[nodiscard]] const T* begin() const { return Data; }
+  [[nodiscard]] const T* end() const { return Data + Size; }
+  [[nodiscard]] size_t size() const { return Size; }
+  [[nodiscard]] bool empty() const { return Size == 0; }
+  const T& operator[](size_t I) const { return Data[I]; }
+};
+
+/// 8-byte opaque handle to one captured diagnostic. Valid while the
+/// owning error (or interpreter) keeps its storage alive.
+struct DiagnosticRef {
+  const void* data = nullptr;
+
+  [[nodiscard]] bool isNull() const { return data == nullptr; }
+
+  // Member-function surface (forwarders defined in ErrorInternal.cpp).
+  CPPINTEROP_API DiagnosticSeverity severity() const;
+  CPPINTEROP_API const char* message() const;
+  CPPINTEROP_API const char* file() const;
+  CPPINTEROP_API unsigned line() const;
+  CPPINTEROP_API unsigned column() const;
+};
+
+/// Field accessors. The TableGen binding surface; member functions
+/// above forward here. Safe to call on a null DiagnosticRef: empty
+/// strings, zero positions, Severity::Note.
+CPPINTEROP_API DiagnosticSeverity GetDiagnosticSeverity(DiagnosticRef D);
+CPPINTEROP_API const char* GetDiagnosticMessage(DiagnosticRef D);
+CPPINTEROP_API const char* GetDiagnosticFile(DiagnosticRef D);
+CPPINTEROP_API unsigned GetDiagnosticLine(DiagnosticRef D);
+CPPINTEROP_API unsigned GetDiagnosticColumn(DiagnosticRef D);
+
+//
+// Encoding (8 bytes, single uintptr_t):
+//   bits == 0      : Ok.
+//   bits & 1 == 1  : inline Status in bits[1..7]. No allocation.
+//   bits & 1 == 0,
+//   bits != 0      : pointer to ErrorSlice (diagnostics, payload,
+//                    refcount). Result<T> manages the refcount.
+
+struct ErrorSlice; // defined in lib/CppInterOp/ErrorInternal.h
+
 struct ErrorRef {
-  const void* state = nullptr;
+  uintptr_t bits = 0;
 
-  [[nodiscard]] bool isOk() const { return state == nullptr; }
+  [[nodiscard]] bool isOk() const { return bits == 0; }
+  [[nodiscard]] bool isInline() const { return (bits & 1U) == 1U; }
+  [[nodiscard]] bool isSlice() const { return bits != 0 && (bits & 1U) == 0u; }
+
+  /// Pack a Status code into the ErrorRef bits. Status::Ok produces
+  /// the canonical null encoding so isOk() stays a single comparison.
+  static ErrorRef makeInline(Status S) {
+    if (S == Status::Ok)
+      return ErrorRef{};
+    return ErrorRef{(static_cast<uintptr_t>(S) << 1) | 1U};
+  }
+
+  /// The inline-encoded Status. Only meaningful when isInline() is
+  /// true; callers should prefer status() which handles both shapes.
+  [[nodiscard]] Status inlineStatus() const {
+    return static_cast<Status>(bits >> 1);
+  }
+
+  /// Wrap a slice pointer. The slice's alignment must keep bit 0 clear
+  /// (ErrorSlice is alignas(16) for this reason).
+  static ErrorRef makeSlice(const ErrorSlice* S) {
+    return ErrorRef{reinterpret_cast<uintptr_t>(S)};
+  }
+  [[nodiscard]] const ErrorSlice* slice() const {
+    return isSlice() ? reinterpret_cast<const ErrorSlice*>(bits) : nullptr;
+  }
+
+  // Member-function surface (defined in Error.cpp).
+  CPPINTEROP_API Status status() const;
+  CPPINTEROP_API ArrayView<DiagnosticRef> diagnostics() const;
+  CPPINTEROP_API const char* producer() const;
+  CPPINTEROP_API const char* producerSignature() const;
+  CPPINTEROP_API class ErrorRecord record() const;
 };
 
-/// Out-of-line abort for value()-on-error. Keeps Result<T>'s inline
-/// body small.
+/// Free-function aliases over the ErrorRef accessors. The TableGen
+/// binding surface; the member functions above forward here.
+CPPINTEROP_API Status GetStatus(ErrorRef E);
+CPPINTEROP_API ArrayView<DiagnosticRef> GetDiagnostics(ErrorRef E);
+
+/// Refcount hooks. Result<T> calls these around copy/move/dtor; they
+/// are no-ops on Ok and inline encodings.
+CPPINTEROP_API void RetainErrorRef(ErrorRef E);
+CPPINTEROP_API void ReleaseErrorRef(ErrorRef E);
+
+//
+// Deep-copy snapshot for callers that want a plain value-type and do
+// not need the originating slice kept alive. Strings are copied;
+// nothing points back into slice storage.
+
+struct DiagnosticInfo {
+  DiagnosticSeverity Severity = DiagnosticSeverity::Error;
+  std::string Message;
+  std::string File;
+  unsigned Line = 0;
+  unsigned Column = 0;
+};
+
+class ErrorRecord {
+public:
+  Status Code = Status::Ok;
+  std::vector<DiagnosticInfo> Diagnostics;
+  // Pointers into static __func__ / __PRETTY_FUNCTION__ storage. No
+  // copying needed; the storage outlives every record.
+  const char* Producer = nullptr;
+  const char* ProducerSignature = nullptr;
+};
+
+//
+// Extends a slice's lifetime past the originating Result<T> via one
+// refcount bump on construction and one decrement on destruction.
+// Inline errors are pure value -- no refcount work.
+
+class [[nodiscard]] CapturedError {
+  ErrorRef Ref;
+
+public:
+  CapturedError() = default;
+  explicit CapturedError(ErrorRef E) : Ref(E) { RetainErrorRef(Ref); }
+
+  CapturedError(const CapturedError& O) : Ref(O.Ref) { RetainErrorRef(Ref); }
+  CapturedError(CapturedError&& O) noexcept : Ref(O.Ref) { O.Ref = ErrorRef{}; }
+
+  CapturedError& operator=(const CapturedError& O) {
+    if (this != &O) {
+      ReleaseErrorRef(Ref);
+      Ref = O.Ref;
+      RetainErrorRef(Ref);
+    }
+    return *this;
+  }
+  CapturedError& operator=(CapturedError&& O) noexcept {
+    if (this != &O) {
+      ReleaseErrorRef(Ref);
+      Ref = O.Ref;
+      O.Ref = ErrorRef{};
+    }
+    return *this;
+  }
+
+  ~CapturedError() { ReleaseErrorRef(Ref); }
+
+  [[nodiscard]] bool ok() const { return Ref.isOk(); }
+  explicit operator bool() const { return ok(); }
+  [[nodiscard]] Status status() const { return Ref.status(); }
+  [[nodiscard]] ErrorRef ref() const { return Ref; }
+
+  [[nodiscard]] ArrayView<DiagnosticRef> diagnostics() const {
+    return Ref.diagnostics();
+  }
+  [[nodiscard]] const char* producer() const { return Ref.producer(); }
+  [[nodiscard]] const char* producerSignature() const {
+    return Ref.producerSignature();
+  }
+  [[nodiscard]] ErrorRecord record() const { return Ref.record(); }
+};
+
 [[noreturn]] CPPINTEROP_API void ResultAbort_ValueOnError(const ErrorRef& Err);
 
 #ifndef NDEBUG
-/// Out-of-line abort for the debug must-handle check. Shared between
-/// Result<T> and Result<void> so the message and abort path live in
-/// one place.
 [[noreturn]] CPPINTEROP_API void
 ResultAbort_UncheckedOnDtor(const ErrorRef& Err);
 #endif
-
-// Result<T>: union of T storage and the ErrorRef pointer, plus a
-// HasError discriminator. Sized comparably to llvm::Expected<T>
-// (pinned by static_assert in ResultBench). Debug adds an Unchecked
-// bit; release shrinks to bare union + discriminator.
 
 template <typename T> class [[nodiscard]] Result {
   static_assert(!std::is_same<T, void>::value,
                 "Result<void> is provided via specialization below");
 
-  static constexpr size_t kStorageSize = sizeof(T) > sizeof(void*)
+  static constexpr size_t kStorageSize = sizeof(T) > sizeof(ErrorRef)
                                              ? sizeof(T)
-                                             : sizeof(void*);
-  static constexpr size_t kStorageAlign = alignof(T) > alignof(void*)
+                                             : sizeof(ErrorRef);
+  static constexpr size_t kStorageAlign = alignof(T) > alignof(ErrorRef)
                                               ? alignof(T)
-                                              : alignof(void*);
+                                              : alignof(ErrorRef);
 
   union {
     alignas(kStorageAlign) unsigned char m_ValueBytes[kStorageSize];
-    const void* m_ErrState; // when m_HasError == true
+    ErrorRef m_ErrState;
   };
   bool m_HasError = false;
 
@@ -91,8 +241,6 @@ template <typename T> class [[nodiscard]] Result {
   void markChecked() const {}
 #endif
 
-  // reinterpret_cast across the union member -- std::launder is C++17
-  // and the header has to parse in C++14 consumer contexts.
   T* valuePtr() { return reinterpret_cast<T*>(m_ValueBytes); }
   const T* valuePtr() const { return reinterpret_cast<const T*>(m_ValueBytes); }
 
@@ -101,13 +249,18 @@ public:
 
   Result(T V) { new (m_ValueBytes) T(std::move(V)); }
 
-  Result(ErrorRef E) : m_ErrState(E.state), m_HasError(true) {}
+  Result(ErrorRef E) : m_ErrState(E), m_HasError(!E.isOk()) {
+    if (m_HasError)
+      RetainErrorRef(m_ErrState);
+  }
 
   Result(const Result& Other) : m_HasError(Other.m_HasError) {
-    if (m_HasError)
+    if (m_HasError) {
       m_ErrState = Other.m_ErrState;
-    else
+      RetainErrorRef(m_ErrState);
+    } else {
       new (m_ValueBytes) T(*Other.valuePtr());
+    }
 #ifndef NDEBUG
     m_Unchecked = Other.m_Unchecked;
     Other.m_Unchecked = false;
@@ -115,10 +268,13 @@ public:
   }
 
   Result(Result&& Other) noexcept : m_HasError(Other.m_HasError) {
-    if (m_HasError)
+    if (m_HasError) {
       m_ErrState = Other.m_ErrState;
-    else
+      Other.m_ErrState = ErrorRef{};
+      Other.m_HasError = false;
+    } else {
       new (m_ValueBytes) T(std::move(*Other.valuePtr()));
+    }
 #ifndef NDEBUG
     m_Unchecked = Other.m_Unchecked;
     Other.m_Unchecked = false;
@@ -127,20 +283,18 @@ public:
 
   ~Result() {
 #ifndef NDEBUG
-    // Must-handle enforcement: an error-bearing Result that wasn't
-    // inspected aborts. Use .ignore() to drop on purpose.
     if (m_Unchecked && m_HasError)
-      ResultAbort_UncheckedOnDtor(ErrorRef{m_ErrState});
+      ResultAbort_UncheckedOnDtor(m_ErrState);
 #endif
-    if (!m_HasError)
+    if (m_HasError)
+      ReleaseErrorRef(m_ErrState);
+    else
       valuePtr()->~T();
   }
 
   Result& operator=(const Result&) = delete;
   Result& operator=(Result&&) = delete;
 
-  /// Mark this Result checked without reading it -- for when you
-  /// genuinely want to drop the outcome.
   void ignore() const { markChecked(); }
 
   [[nodiscard]] bool ok() const {
@@ -151,19 +305,26 @@ public:
 
   [[nodiscard]] Status status() const {
     markChecked();
-    return m_HasError ? Status::Failed : Status::Ok;
+    return m_HasError ? m_ErrState.status() : Status::Ok;
   }
 
   [[nodiscard]] ErrorRef error() const {
     markChecked();
-    return m_HasError ? ErrorRef{m_ErrState} : ErrorRef{};
+    return m_HasError ? m_ErrState : ErrorRef{};
   }
 
-  /// Value on Ok; aborts on Error. Use value_or for lenient semantics.
+  /// Share ownership of the carried ErrorRef with a CapturedError so
+  /// the error outlives this Result. One refcount bump on slice
+  /// errors; no-op for inline ones.
+  [[nodiscard]] CapturedError share() const {
+    markChecked();
+    return m_HasError ? CapturedError(m_ErrState) : CapturedError();
+  }
+
   T value() const {
     markChecked();
     if (m_HasError)
-      ResultAbort_ValueOnError(error());
+      ResultAbort_ValueOnError(m_ErrState);
     return *valuePtr();
   }
 
@@ -173,10 +334,10 @@ public:
   }
 };
 
-// Void specialization: no T storage, ErrorRef stored directly.
+// Void specialization.
 
 template <> class [[nodiscard]] Result<void> {
-  const void* m_ErrState = nullptr;
+  ErrorRef m_ErrState;
 #ifndef NDEBUG
   mutable bool m_Unchecked = true;
   void markChecked() const { m_Unchecked = false; }
@@ -186,12 +347,14 @@ template <> class [[nodiscard]] Result<void> {
 
 public:
   Result() = default;
-  Result(ErrorRef E) : m_ErrState(E.state) {}
-
-  Result& operator=(const Result&) = delete;
-  Result& operator=(Result&&) = delete;
+  Result(ErrorRef E) : m_ErrState(E) {
+    if (!E.isOk())
+      RetainErrorRef(m_ErrState);
+  }
 
   Result(const Result& O) : m_ErrState(O.m_ErrState) {
+    if (!m_ErrState.isOk())
+      RetainErrorRef(m_ErrState);
 #ifndef NDEBUG
     m_Unchecked = O.m_Unchecked;
     O.m_Unchecked = false;
@@ -200,40 +363,45 @@ public:
 
   Result(Result&& O) noexcept : m_ErrState(O.m_ErrState) {
 #ifndef NDEBUG
-    // Transfer the must-handle obligation to the destination -- the
-    // default move leaves m_Unchecked=true on the source and the
-    // source's dtor would abort even though the value went to the
-    // caller (the bug seen when threading Results through tracing
-    // record() wrappers).
     m_Unchecked = O.m_Unchecked;
     O.m_Unchecked = false;
 #endif
-    O.m_ErrState = nullptr;
+    O.m_ErrState = ErrorRef{};
   }
 
   ~Result() {
 #ifndef NDEBUG
-    if (m_Unchecked && m_ErrState)
-      ResultAbort_UncheckedOnDtor(ErrorRef{m_ErrState});
+    if (m_Unchecked && !m_ErrState.isOk())
+      ResultAbort_UncheckedOnDtor(m_ErrState);
 #endif
+    if (!m_ErrState.isOk())
+      ReleaseErrorRef(m_ErrState);
   }
+
+  Result& operator=(const Result&) = delete;
+  Result& operator=(Result&&) = delete;
 
   void ignore() const { markChecked(); }
 
   [[nodiscard]] bool ok() const {
     markChecked();
-    return m_ErrState == nullptr;
+    return m_ErrState.isOk();
   }
   explicit operator bool() const { return ok(); }
 
   [[nodiscard]] Status status() const {
     markChecked();
-    return m_ErrState ? Status::Failed : Status::Ok;
+    return m_ErrState.status();
   }
 
   [[nodiscard]] ErrorRef error() const {
     markChecked();
-    return ErrorRef{m_ErrState};
+    return m_ErrState;
+  }
+
+  [[nodiscard]] CapturedError share() const {
+    markChecked();
+    return CapturedError(m_ErrState);
   }
 };
 

--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -9,8 +9,11 @@
 
 #include "CppInterOp/CppInterOp.h"
 #include "Unwrap.h"
+#include "CppInterOp/Error.h"
 
 #include "Compatibility.h"
+#include "ErrorInternal.h"
+#include "InterpreterInfo.h"
 #include "Sins.h" // for access to private members
 #include "Tracing.h"
 
@@ -163,50 +166,6 @@ namespace Cpp {
 using namespace clang;
 using namespace llvm;
 
-struct InterpreterInfo {
-  compat::Interpreter* Interpreter = nullptr;
-  bool isOwned = true;
-  // Store the list of builtin types.
-  llvm::StringMap<QualType> BuiltinMap;
-  // Per-interpreter wrapper caches. Keyed on AST nodes that belong to this
-  // interpreter, so the caches must be destroyed together with it.
-  std::map<const FunctionDecl*, void*> WrapperStore;
-  std::map<const Decl*, void*> DtorWrapperStore;
-
-  InterpreterInfo(compat::Interpreter* I, bool Owned)
-      : Interpreter(I), isOwned(Owned) {}
-
-  // Enable move constructors.
-  InterpreterInfo(InterpreterInfo&& other) noexcept
-      : Interpreter(other.Interpreter), isOwned(other.isOwned) {
-    other.Interpreter = nullptr;
-    other.isOwned = false;
-  }
-  InterpreterInfo& operator=(InterpreterInfo&& other) noexcept {
-    if (this != &other) {
-      // Delete current resource if owned
-      if (isOwned)
-        delete Interpreter;
-
-      Interpreter = other.Interpreter;
-      isOwned = other.isOwned;
-
-      other.Interpreter = nullptr;
-      other.isOwned = false;
-    }
-    return *this;
-  }
-
-  ~InterpreterInfo() {
-    if (isOwned)
-      delete Interpreter;
-  }
-
-  // Disable copy semantics (to avoid accidental double deletes)
-  InterpreterInfo(const InterpreterInfo&) = delete;
-  InterpreterInfo& operator=(const InterpreterInfo&) = delete;
-};
-
 static void DefaultProcessCrashHandler(void*);
 
 /// Set by UseExternalInterpreter to suppress llvm_shutdown at process exit
@@ -311,6 +270,7 @@ static void DefaultProcessCrashHandler(void*) {
 static void RegisterInterpreter(compat::Interpreter* I, bool Owned) {
   std::deque<InterpreterInfo>& Interps = GetInterpreters(Owned);
   Interps.emplace_back(I, Owned);
+  InstallDiagConsumer(&Interps.back());
 }
 
 static InterpreterInfo& getInterpInfo(compat::Interpreter* I = nullptr) {
@@ -329,6 +289,10 @@ static compat::Interpreter& getInterp(InterpRef I = nullptr) {
   if (I)
     return *unwrap<compat::Interpreter>(I);
   return *getInterpInfo().Interpreter;
+}
+
+CPPINTEROP_API InterpreterInfo* GetInterpInfo(InterpRef I) {
+  return &getInterpInfo(I ? unwrap<compat::Interpreter>(I) : nullptr);
 }
 
 InterpRef GetInterpreter() {

--- a/lib/CppInterOp/ErrorInternal.cpp
+++ b/lib/CppInterOp/ErrorInternal.cpp
@@ -1,17 +1,8 @@
-//===--- ErrorInternal.cpp - Cpp::Result<T> abort helper --------*- C++ -*-===//
+//===- ErrorInternal.cpp - Impl-side Result<T> + ErrorRef + Diag --- C++ -===//
 //
 // Part of the compiler-research project, under the Apache License v2.0 with
 // LLVM Exceptions.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-//
-//===----------------------------------------------------------------------===//
-//
-// Out-of-line abort for Cpp::Result<T>::value() called on an
-// error-bearing Result. Keeps the inline Result<T> body small.
-//
-// Later PRs extend this file with the boundary translator
-// (llvm::Error / Expected<T> -> Cpp::Result<T>) and per-call
-// diagnostic capture.
 //
 //===----------------------------------------------------------------------===//
 
@@ -19,10 +10,341 @@
 
 #include "CppInterOp/CppInterOpTypes.h"
 
+#include "Compatibility.h"
+#include "ErrorInternal.h"
+#include "InterpreterInfo.h"
+
+#include "clang/Basic/Diagnostic.h"
+#include "clang/Basic/SourceLocation.h"
+#include "clang/Basic/SourceManager.h"
+#include "clang/Frontend/CompilerInstance.h"
+
+#include "llvm/ADT/SmallString.h"
+#include "llvm/Support/raw_ostream.h"
+
 #include <cstdio>
 #include <cstdlib>
+#include <memory>
+#include <utility>
 
 namespace Cpp {
+
+// A null DiagnosticRef returns defaults so callers don't have to
+// branch on isNull() before every access.
+static const StoredDiagView* AsView(DiagnosticRef D) {
+  return static_cast<const StoredDiagView*>(D.data);
+}
+
+CPPINTEROP_API DiagnosticSeverity GetDiagnosticSeverity(DiagnosticRef D) {
+  if (const StoredDiagView* V = AsView(D))
+    return V->Sev;
+  return DiagnosticSeverity::Note;
+}
+
+CPPINTEROP_API const char* GetDiagnosticMessage(DiagnosticRef D) {
+  if (const StoredDiagView* V = AsView(D))
+    return V->Message.c_str();
+  return "";
+}
+
+CPPINTEROP_API const char* GetDiagnosticFile(DiagnosticRef D) {
+  if (const StoredDiagView* V = AsView(D))
+    return V->File.c_str();
+  return "";
+}
+
+CPPINTEROP_API unsigned GetDiagnosticLine(DiagnosticRef D) {
+  if (const StoredDiagView* V = AsView(D))
+    return V->Line;
+  return 0;
+}
+
+CPPINTEROP_API unsigned GetDiagnosticColumn(DiagnosticRef D) {
+  if (const StoredDiagView* V = AsView(D))
+    return V->Column;
+  return 0;
+}
+
+// Member-function forwarders.
+DiagnosticSeverity DiagnosticRef::severity() const {
+  return GetDiagnosticSeverity(*this);
+}
+const char* DiagnosticRef::message() const {
+  return GetDiagnosticMessage(*this);
+}
+const char* DiagnosticRef::file() const { return GetDiagnosticFile(*this); }
+unsigned DiagnosticRef::line() const { return GetDiagnosticLine(*this); }
+unsigned DiagnosticRef::column() const { return GetDiagnosticColumn(*this); }
+
+CPPINTEROP_API Status GetStatus(ErrorRef E) {
+  if (E.isOk())
+    return Status::Ok;
+  if (E.isInline())
+    return E.inlineStatus();
+  if (const ErrorSlice* S = E.slice())
+    return S->Code;
+  return Status::Ok;
+}
+
+CPPINTEROP_API ArrayView<DiagnosticRef> GetDiagnostics(ErrorRef E) {
+  const ErrorSlice* S = E.slice();
+  if (!S || S->Diagnostics.empty())
+    return {};
+  // DiagnosticRefs are constructed lazily into a thread-local buffer
+  // so the returned ArrayView<DiagnosticRef> can alias contiguous
+  // storage (slice.Diagnostics is a std::deque -- not contiguous).
+  // The buffer survives until the next GetDiagnostics call on the
+  // same thread; callers that need to retain the view should copy it.
+  static thread_local std::vector<DiagnosticRef> Buf;
+  Buf.clear();
+  Buf.reserve(S->Diagnostics.size());
+  for (const StoredDiagView& Dv : S->Diagnostics)
+    Buf.push_back(DiagnosticRef{&Dv});
+  return ArrayView<DiagnosticRef>{Buf.data(), Buf.size()};
+}
+
+// Member-function forwarders.
+Status ErrorRef::status() const { return GetStatus(*this); }
+ArrayView<DiagnosticRef> ErrorRef::diagnostics() const {
+  return GetDiagnostics(*this);
+}
+const char* ErrorRef::producer() const {
+  const ErrorSlice* S = slice();
+  return S ? S->Producer : nullptr;
+}
+const char* ErrorRef::producerSignature() const {
+  const ErrorSlice* S = slice();
+  return S ? S->ProducerSignature : nullptr;
+}
+
+ErrorRecord ErrorRef::record() const {
+  ErrorRecord R;
+  R.Code = status();
+  const ErrorSlice* S = slice();
+  if (!S)
+    return R;
+  R.Diagnostics.reserve(S->Diagnostics.size());
+  for (const StoredDiagView& Dv : S->Diagnostics) {
+    DiagnosticInfo Di;
+    Di.Severity = Dv.Sev;
+    Di.Message = Dv.Message;
+    Di.File = Dv.File;
+    Di.Line = Dv.Line;
+    Di.Column = Dv.Column;
+    R.Diagnostics.push_back(std::move(Di));
+  }
+  R.Producer = S->Producer;
+  R.ProducerSignature = S->ProducerSignature;
+  return R;
+}
+
+CPPINTEROP_API void RetainErrorRef(ErrorRef E) {
+  // Inline-encoded errors carry no refcount; the bits are pure value.
+  if (!E.isSlice())
+    return;
+  E.slice()->Refcount.fetch_add(1, std::memory_order_acq_rel);
+}
+
+CPPINTEROP_API void ReleaseErrorRef(ErrorRef E) {
+  if (!E.isSlice())
+    return;
+  const ErrorSlice* S = E.slice();
+  if (S->Refcount.fetch_sub(1, std::memory_order_acq_rel) == 1)
+    delete S;
+}
+
+char StatusError::ID = 0;
+
+void StatusError::log(llvm::raw_ostream& OS) const {
+  OS << "CppInterOp status error: " << Message;
+}
+std::error_code StatusError::convertToErrorCode() const {
+  return llvm::inconvertibleErrorCode();
+}
+
+CPPINTEROP_API ErrorSlice* AllocSlice(InterpreterInfo* Owner) {
+  auto* S = new ErrorSlice();
+  S->Owner = Owner;
+  return S;
+}
+
+CPPINTEROP_API ErrorRef makeError(Status S) { return ErrorRef::makeInline(S); }
+
+CPPINTEROP_API ErrorRef makeError(InterpreterInfo* II, Status S,
+                                  std::string Message, const char* Producer,
+                                  const char* ProducerSig) {
+  ErrorSlice* Slc = AllocSlice(II);
+  Slc->Code = S;
+  Slc->Producer = Producer;
+  Slc->ProducerSignature = ProducerSig;
+  if (!Message.empty()) {
+    StoredDiagView Dv;
+    Dv.Message = std::move(Message);
+    Dv.Sev = DiagnosticSeverity::Error;
+    Slc->Diagnostics.push_back(std::move(Dv));
+  }
+  DrainPendingInto(II, Slc);
+  // Refcount stays at the default 0; the wrapping Result<T> bumps to 1
+  // via its ErrorRef ctor.
+  return ErrorRef::makeSlice(Slc);
+}
+
+CPPINTEROP_API ErrorRef drainError(InterpreterInfo* II, llvm::Error E,
+                                   const char* Producer,
+                                   const char* ProducerSig) {
+  // Decompose the llvm::Error chain into a single slice. StatusError
+  // sets the Status directly; any other ErrorInfo subclass is
+  // stringified via its log() and surfaced as Status::CompileError.
+  // Typed payloads (overload / deduction) and their llvm::Error
+  // subclasses arrive with the migrations that need them.
+  Status Code = Status::CompileError;
+  std::string Msg;
+
+  llvm::handleAllErrors(
+      std::move(E),
+      [&](const StatusError& SE) {
+        Code = SE.Code;
+        if (Msg.empty())
+          Msg = SE.Message;
+      },
+      [&](const llvm::ErrorInfoBase& EIB) {
+        // Unknown subclass: stringify and surface as CompileError.
+        if (Msg.empty()) {
+          llvm::raw_string_ostream OS(Msg);
+          EIB.log(OS);
+        }
+      });
+
+  ErrorSlice* Slc = AllocSlice(II);
+  Slc->Code = Code;
+  Slc->Producer = Producer;
+  Slc->ProducerSignature = ProducerSig;
+  if (!Msg.empty()) {
+    StoredDiagView Dv;
+    Dv.Message = std::move(Msg);
+    Dv.Sev = DiagnosticSeverity::Error;
+    Slc->Diagnostics.push_back(std::move(Dv));
+  }
+  DrainPendingInto(II, Slc);
+  return ErrorRef::makeSlice(Slc);
+}
+
+namespace {
+/// Captures every diagnostic the parser/sema emits into the owning
+/// interpreter's StoredDiags and forwards to the previously installed
+/// consumer (typically Clang's TextDiagnosticPrinter) so existing
+/// stderr output is preserved. Owned holds the chained consumer when
+/// the engine owned it (clang-REPL); Raw points at it regardless of
+/// ownership so cling's externally-owned consumer also forwards.
+class CppInteropDiagConsumer : public clang::DiagnosticConsumer {
+public:
+  CppInteropDiagConsumer(InterpreterInfo* II,
+                         std::unique_ptr<clang::DiagnosticConsumer> Owned,
+                         clang::DiagnosticConsumer* Raw)
+      : II(II), Owned(std::move(Owned)), Raw(Raw) {}
+
+  void BeginSourceFile(const clang::LangOptions& LO,
+                       const clang::Preprocessor* PP) override {
+    if (Raw)
+      Raw->BeginSourceFile(LO, PP);
+  }
+  void EndSourceFile() override {
+    if (Raw)
+      Raw->EndSourceFile();
+  }
+  void HandleDiagnostic(clang::DiagnosticsEngine::Level Level,
+                        const clang::Diagnostic& Info) override;
+
+private:
+  InterpreterInfo* II;
+  std::unique_ptr<clang::DiagnosticConsumer> Owned;
+  clang::DiagnosticConsumer* Raw;
+};
+
+DiagnosticSeverity MapClangSeverity(clang::DiagnosticsEngine::Level L) {
+  switch (L) {
+  case clang::DiagnosticsEngine::Ignored:
+  case clang::DiagnosticsEngine::Note:
+  case clang::DiagnosticsEngine::Remark:
+    return DiagnosticSeverity::Note;
+  case clang::DiagnosticsEngine::Warning:
+    return DiagnosticSeverity::Warning;
+  case clang::DiagnosticsEngine::Error:
+    return DiagnosticSeverity::Error;
+  case clang::DiagnosticsEngine::Fatal:
+    return DiagnosticSeverity::Fatal;
+  }
+  return DiagnosticSeverity::Error;
+}
+} // namespace
+
+void CppInteropDiagConsumer::HandleDiagnostic(
+    clang::DiagnosticsEngine::Level Level, const clang::Diagnostic& Info) {
+  // Update the base consumer's NumErrors so hasErrorOccurred() keeps
+  // working for callers that still rely on it.
+  clang::DiagnosticConsumer::HandleDiagnostic(Level, Info);
+  if (Raw)
+    Raw->HandleDiagnostic(Level, Info);
+
+  llvm::SmallString<128> Buf;
+  Info.FormatDiagnostic(Buf);
+
+  StoredDiagView Dv;
+  Dv.Message = Buf.str().str();
+  Dv.Sev = MapClangSeverity(Level);
+
+  if (Info.hasSourceManager() && Info.getLocation().isValid()) {
+    clang::SourceManager& SM = Info.getSourceManager();
+    clang::PresumedLoc PLoc = SM.getPresumedLoc(Info.getLocation());
+    if (PLoc.isValid()) {
+      if (const char* F = PLoc.getFilename())
+        Dv.File = F;
+      Dv.Line = PLoc.getLine();
+      Dv.Column = PLoc.getColumn();
+    }
+  }
+
+  II->StoredDiags.push_back(std::move(Dv));
+}
+
+CPPINTEROP_API void InstallDiagConsumer(InterpreterInfo* II) {
+  // Chain to whatever consumer Clang already installed so existing
+  // stderr behaviour is preserved. takeClient transfers ownership when
+  // the engine owns it (clang-REPL); cling installs its consumer with
+  // ShouldOwnClient=false, so takeClient returns null there and we
+  // forward through the raw pointer instead. getClient still returns
+  // the original between takeClient and setClient.
+  clang::DiagnosticsEngine& Diag = II->Interpreter->getCI()->getDiagnostics();
+  std::unique_ptr<clang::DiagnosticConsumer> PrevOwned = Diag.takeClient();
+  clang::DiagnosticConsumer* PrevRaw = Diag.getClient();
+  auto* New = new CppInteropDiagConsumer(II, std::move(PrevOwned), PrevRaw);
+  Diag.setClient(New, /*ShouldOwnClient=*/true);
+}
+
+CPPINTEROP_API void DrainPendingInto(InterpreterInfo* II, ErrorSlice* S) {
+  for (auto& Dv : II->StoredDiags)
+    S->Diagnostics.push_back(std::move(Dv));
+  II->StoredDiags.clear();
+}
+
+CPPINTEROP_API void ClearPending(InterpreterInfo* II) {
+  II->StoredDiags.clear();
+}
+
+CPPINTEROP_API unsigned GetPendingDiagnosticCount(InterpRef I) {
+  return static_cast<unsigned>(GetInterpInfo(I)->StoredDiags.size());
+}
+
+CPPINTEROP_API DiagnosticRef GetPendingDiagnostic(unsigned Idx, InterpRef I) {
+  InterpreterInfo* II = GetInterpInfo(I);
+  if (Idx >= II->StoredDiags.size())
+    return DiagnosticRef{};
+  return DiagnosticRef{&II->StoredDiags[Idx]};
+}
+
+CPPINTEROP_API void ClearPendingDiagnostics(InterpRef I) {
+  GetInterpInfo(I)->StoredDiags.clear();
+}
 
 [[noreturn]] CPPINTEROP_API void
 ResultAbort_ValueOnError(const ErrorRef& /*Err*/) {

--- a/lib/CppInterOp/ErrorInternal.h
+++ b/lib/CppInterOp/ErrorInternal.h
@@ -1,0 +1,138 @@
+//===--- ErrorInternal.h - Impl-side error helpers --------------*- C++ -*-===//
+//
+// Part of the compiler-research project, under the Apache License v2.0 with
+// LLVM Exceptions.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Impl-side counterpart to CppInterOp/Error.h: the ErrorSlice body,
+// the llvm::Error subclasses, and the boundary translator.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CPPINTEROP_LIB_ERRORINTERNAL_H
+#define CPPINTEROP_LIB_ERRORINTERNAL_H
+
+#include "CppInterOp/CppInterOpTypes.h"
+#include "CppInterOp/Error.h"
+
+#include "llvm/Support/Error.h"
+#include "llvm/Support/raw_ostream.h"
+
+#include <atomic>
+#include <cstdint>
+#include <deque>
+#include <string>
+#include <system_error>
+#include <utility>
+
+namespace Cpp {
+
+struct InterpreterInfo; // defined in CppInterOp.cpp
+
+/// Owning record for one captured diagnostic. DiagnosticRef::data
+/// points at one of these.
+struct StoredDiagView {
+  std::string Message;
+  std::string File;
+  unsigned Line = 0;
+  unsigned Column = 0;
+  DiagnosticSeverity Sev = DiagnosticSeverity::Error;
+};
+
+/// Body of a slice-encoded error: drained diagnostics, producer
+/// attribution, refcount. alignas(16) keeps the low bits of an
+/// ErrorSlice* clear so ErrorRef's tag bit stays unambiguous.
+struct alignas(16) ErrorSlice {
+  // Mutable so Retain/Release can act on a `const ErrorSlice*` taken
+  // off an ErrorRef accessor without round-tripping through const_cast.
+  mutable std::atomic<uint32_t> Refcount{0};
+  InterpreterInfo* Owner = nullptr;
+  Status Code = Status::Ok;
+
+  // Stable element addresses under push_back so a DiagnosticRef can
+  // address an entry safely.
+  std::deque<StoredDiagView> Diagnostics;
+
+  // Pointer into static __func__ storage. No copy.
+  const char* Producer = nullptr;
+  // Pointer into static __PRETTY_FUNCTION__ storage. No copy.
+  const char* ProducerSignature = nullptr;
+};
+
+//
+// Carry the structured information the boundary translator drains
+// into a slice. Impl code returns llvm::Expected<T> with these on
+// the failure path; makeResult wraps them into Result<T>.
+
+class CPPINTEROP_API StatusError : public llvm::ErrorInfo<StatusError> {
+public:
+  static char ID;
+  Status Code;
+  std::string Message;
+
+  StatusError(Status C, std::string M) : Code(C), Message(std::move(M)) {}
+
+  void log(llvm::raw_ostream& OS) const override;
+  [[nodiscard]] std::error_code convertToErrorCode() const override;
+};
+
+/// Allocate a fresh slice on the heap, refcount 0. Caller bumps the
+/// refcount on first use (the boundary translator does this when
+/// wrapping the slice into a returned ErrorRef).
+CPPINTEROP_API ErrorSlice* AllocSlice(InterpreterInfo* Owner);
+
+/// Build an inline-status ErrorRef (no diagnostics, no payload).
+CPPINTEROP_API ErrorRef makeError(Status S);
+
+/// Build a slice-encoded error carrying a Clang-derived message + the
+/// interp's pending diagnostics + producer attribution.
+CPPINTEROP_API ErrorRef makeError(InterpreterInfo* II, Status S,
+                                  std::string Message, const char* Producer,
+                                  const char* ProducerSig);
+
+/// Drain `E` into a fresh slice, returning the slice via ErrorRef.
+/// Handles StatusError; any other llvm::Error is stringified via
+/// llvm::ErrorInfoBase::log into the slice's first diagnostic.
+CPPINTEROP_API ErrorRef drainError(InterpreterInfo* II, llvm::Error E,
+                                   const char* Producer,
+                                   const char* ProducerSig);
+
+/// Convert llvm::Expected<T> into Result<T>. On the error path, drain
+/// the carried llvm::Error into a slice.
+template <typename T>
+Result<T> makeResult(InterpreterInfo* II, llvm::Expected<T> E,
+                     const char* Producer, const char* ProducerSig) {
+  if (E)
+    return Result<T>(std::move(*E));
+  return Result<T>(drainError(II, E.takeError(), Producer, ProducerSig));
+}
+
+inline Result<void> makeResult(InterpreterInfo* II, llvm::Error E,
+                               const char* Producer, const char* ProducerSig) {
+  if (!E)
+    return Result<void>();
+  return Result<void>(drainError(II, std::move(E), Producer, ProducerSig));
+}
+
+/// Drain the consumer's per-interp buffer into a slice on failure.
+/// Success paths just clear via ClearPending -- callers don't surface
+/// Ok-path warnings today.
+CPPINTEROP_API void DrainPendingInto(InterpreterInfo* II, ErrorSlice* S);
+CPPINTEROP_API void ClearPending(InterpreterInfo* II);
+
+//
+// Production callers read diagnostics off Result<T>::error() once the
+// boundary translator has drained them into a slice. These survive
+// for tests of the consumer install path and as a peek for callers
+// not yet migrated to Result-returning APIs.
+
+CPPINTEROP_API unsigned GetPendingDiagnosticCount(InterpRef I = nullptr);
+CPPINTEROP_API DiagnosticRef GetPendingDiagnostic(unsigned Idx,
+                                                  InterpRef I = nullptr);
+CPPINTEROP_API void ClearPendingDiagnostics(InterpRef I = nullptr);
+
+} // namespace Cpp
+
+#endif // CPPINTEROP_LIB_ERRORINTERNAL_H

--- a/lib/CppInterOp/InterpreterInfo.h
+++ b/lib/CppInterOp/InterpreterInfo.h
@@ -1,0 +1,84 @@
+//===--- InterpreterInfo.h - Per-interpreter impl state ---------*- C++ -*-===//
+//
+// Part of the compiler-research project, under the Apache License v2.0 with
+// LLVM Exceptions.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Impl-only header centralising the per-interpreter state struct used by
+// CppInterOp.cpp and Error.cpp. Not part of the public API; never
+// included from include/CppInterOp/.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef CPPINTEROP_LIB_INTERPRETERINFO_H
+#define CPPINTEROP_LIB_INTERPRETERINFO_H
+
+#include "Compatibility.h"
+#include "ErrorInternal.h"
+
+#include "clang/AST/Decl.h"
+#include "clang/AST/Type.h"
+
+#include "llvm/ADT/StringMap.h"
+
+#include <deque>
+#include <map>
+
+namespace Cpp {
+
+struct InterpreterInfo {
+  compat::Interpreter* Interpreter = nullptr;
+  bool isOwned = true;
+  // Store the list of builtin types.
+  llvm::StringMap<clang::QualType> BuiltinMap;
+  // Per-interpreter wrapper caches. Keyed on AST nodes that belong to this
+  // interpreter, so the caches must be destroyed together with it.
+  std::map<const clang::FunctionDecl*, void*> WrapperStore;
+  std::map<const clang::Decl*, void*> DtorWrapperStore;
+  // A deque keeps element addresses stable so DiagnosticRef::data
+  // survives push_back.
+  std::deque<StoredDiagView> StoredDiags;
+
+  InterpreterInfo(compat::Interpreter* I, bool Owned)
+      : Interpreter(I), isOwned(Owned) {}
+
+  InterpreterInfo(InterpreterInfo&& Other) noexcept
+      : Interpreter(Other.Interpreter), isOwned(Other.isOwned) {
+    Other.Interpreter = nullptr;
+    Other.isOwned = false;
+  }
+  InterpreterInfo& operator=(InterpreterInfo&& Other) noexcept {
+    if (this != &Other) {
+      if (isOwned)
+        delete Interpreter;
+      Interpreter = Other.Interpreter;
+      isOwned = Other.isOwned;
+      Other.Interpreter = nullptr;
+      Other.isOwned = false;
+    }
+    return *this;
+  }
+
+  ~InterpreterInfo() {
+    if (isOwned)
+      delete Interpreter;
+  }
+
+  InterpreterInfo(const InterpreterInfo&) = delete;
+  InterpreterInfo& operator=(const InterpreterInfo&) = delete;
+};
+
+/// Resolve an InterpRef to the impl-side struct. When I is null,
+/// returns the active (last-created) interpreter.
+CPPINTEROP_API InterpreterInfo* GetInterpInfo(InterpRef I = nullptr);
+
+/// Wire CppInterOp's DiagnosticConsumer into the interpreter's
+/// DiagnosticsEngine so parser/sema diagnostics flow into II->StoredDiags
+/// and continue forwarding to whatever consumer Clang already had.
+CPPINTEROP_API void InstallDiagConsumer(InterpreterInfo* II);
+
+} // namespace Cpp
+
+#endif // CPPINTEROP_LIB_INTERPRETERINFO_H

--- a/unittests/CppInterOp/CMakeLists.txt
+++ b/unittests/CppInterOp/CMakeLists.txt
@@ -46,6 +46,7 @@ add_cppinterop_unittest(CppInterOpTests
   CAPITest.cpp
   CommentReflectionTest.cpp
   CppInterOpThunksTest.cpp
+  DiagnosticTest.cpp
   EnumReflectionTest.cpp
   FunctionReflectionTest.cpp
   HandleTypesTest.cpp

--- a/unittests/CppInterOp/DiagnosticTest.cpp
+++ b/unittests/CppInterOp/DiagnosticTest.cpp
@@ -1,0 +1,157 @@
+//===- DiagnosticTest.cpp - Tests for Cpp::DiagnosticRef -------*- C++ -*-===//
+//
+// Part of the compiler-research project, under the Apache License v2.0 with
+// LLVM Exceptions.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "CppInterOp/CppInterOp.h"
+#include "CppInterOp/Error.h"
+
+#include "../../lib/CppInterOp/ErrorInternal.h"
+
+#include "Utils.h"
+
+#include "gtest/gtest.h"
+
+#include <cstring>
+
+// Size invariants. Refactors that inflate the public handle or the
+// severity enum fail the build.
+static_assert(sizeof(Cpp::DiagnosticRef) == sizeof(void*),
+              "DiagnosticRef must be a single pointer");
+static_assert(sizeof(Cpp::DiagnosticSeverity) == 1,
+              "DiagnosticSeverity must stay one byte");
+
+TEST(DiagnosticTest, AccessorsRoundTripStoredView) {
+  Cpp::StoredDiagView V;
+  V.Message = "expected ';' after expression";
+  V.File = "/tmp/foo.cpp";
+  V.Line = 12;
+  V.Column = 5;
+  V.Sev = Cpp::DiagnosticSeverity::Error;
+
+  Cpp::DiagnosticRef D{&V};
+  EXPECT_FALSE(D.isNull());
+  EXPECT_EQ(Cpp::GetDiagnosticSeverity(D), Cpp::DiagnosticSeverity::Error);
+  EXPECT_STREQ(Cpp::GetDiagnosticMessage(D), "expected ';' after expression");
+  EXPECT_STREQ(Cpp::GetDiagnosticFile(D), "/tmp/foo.cpp");
+  EXPECT_EQ(Cpp::GetDiagnosticLine(D), 12U);
+  EXPECT_EQ(Cpp::GetDiagnosticColumn(D), 5U);
+}
+
+TEST(DiagnosticTest, SeverityRoundTrip) {
+  const Cpp::DiagnosticSeverity AllSev[] = {
+      Cpp::DiagnosticSeverity::Note,
+      Cpp::DiagnosticSeverity::Warning,
+      Cpp::DiagnosticSeverity::Error,
+      Cpp::DiagnosticSeverity::Fatal,
+  };
+  for (Cpp::DiagnosticSeverity S : AllSev) {
+    Cpp::StoredDiagView V;
+    V.Sev = S;
+    Cpp::DiagnosticRef D{&V};
+    EXPECT_EQ(Cpp::GetDiagnosticSeverity(D), S);
+  }
+}
+
+TEST(DiagnosticTest, NullRefReturnsDefaults) {
+  Cpp::DiagnosticRef D;
+  EXPECT_TRUE(D.isNull());
+  EXPECT_EQ(Cpp::GetDiagnosticSeverity(D), Cpp::DiagnosticSeverity::Note);
+  EXPECT_STREQ(Cpp::GetDiagnosticMessage(D), "");
+  EXPECT_STREQ(Cpp::GetDiagnosticFile(D), "");
+  EXPECT_EQ(Cpp::GetDiagnosticLine(D), 0U);
+  EXPECT_EQ(Cpp::GetDiagnosticColumn(D), 0U);
+}
+
+// Empty strings must surface as "" not nullptr so callers can pass
+// the result to strlen / strcmp without a separate null guard.
+TEST(DiagnosticTest, EmptyStringsReturnEmptyCStrings) {
+  Cpp::StoredDiagView V;
+  Cpp::DiagnosticRef D{&V};
+  ASSERT_NE(Cpp::GetDiagnosticMessage(D), nullptr);
+  ASSERT_NE(Cpp::GetDiagnosticFile(D), nullptr);
+  EXPECT_STREQ(Cpp::GetDiagnosticMessage(D), "");
+  EXPECT_STREQ(Cpp::GetDiagnosticFile(D), "");
+}
+
+TEST(DiagnosticTest, TwoIndependentDiagsKeepTheirFields) {
+  Cpp::StoredDiagView A;
+  A.Message = "first";
+  A.Line = 1;
+  Cpp::StoredDiagView B;
+  B.Message = "second";
+  B.Line = 99;
+
+  Cpp::DiagnosticRef DA{&A};
+  Cpp::DiagnosticRef DB{&B};
+  EXPECT_STREQ(Cpp::GetDiagnosticMessage(DA), "first");
+  EXPECT_EQ(Cpp::GetDiagnosticLine(DA), 1U);
+  EXPECT_STREQ(Cpp::GetDiagnosticMessage(DB), "second");
+  EXPECT_EQ(Cpp::GetDiagnosticLine(DB), 99U);
+}
+
+// Out-of-range index must yield a null DiagnosticRef rather than
+// indexing past the end of the deque.
+TYPED_TEST(CPPINTEROP_TEST_MODE, GetPendingDiagnostic_OutOfRangeIsNull) {
+  TestFixture::CreateInterpreter();
+  Cpp::ClearPendingDiagnostics();
+  EXPECT_TRUE(Cpp::GetPendingDiagnostic(0).isNull());
+  EXPECT_TRUE(Cpp::GetPendingDiagnostic(999).isNull());
+}
+
+// End-to-end: the diagnostic consumer wired into every interpreter
+// must capture a real Clang parse error and surface it through the
+// pending-diagnostic accessors.
+TYPED_TEST(CPPINTEROP_TEST_MODE, Consumer_CapturesParseError) {
+#ifdef _WIN32
+  // The chained TextDiagnosticPrinter emits "error: expected expression"
+  // to stderr, which MSBuild's check-cppinterop custom-build rule scans
+  // and treats as a build failure regardless of the gtest result.
+  GTEST_SKIP() << "chained diagnostic trips MSBuild error scanning on Windows";
+#endif
+  TestFixture::CreateInterpreter();
+  Cpp::ClearPendingDiagnostics();
+  ASSERT_EQ(Cpp::GetPendingDiagnosticCount(), 0U);
+
+  // Trigger a parse error. silent=false lets the diagnostic reach the
+  // consumer; silent=true sets SuppressAllDiagnostics, which short-
+  // circuits before the consumer chain.
+  EXPECT_NE(0, Cpp::Declare("int err = ;", /*silent=*/false));
+
+  ASSERT_GT(Cpp::GetPendingDiagnosticCount(), 0U);
+  Cpp::DiagnosticRef D = Cpp::GetPendingDiagnostic(0);
+  EXPECT_FALSE(D.isNull());
+  EXPECT_EQ(Cpp::GetDiagnosticSeverity(D), Cpp::DiagnosticSeverity::Error);
+  EXPECT_GT(std::strlen(Cpp::GetDiagnosticMessage(D)), 0U);
+
+  Cpp::ClearPendingDiagnostics();
+  EXPECT_EQ(Cpp::GetPendingDiagnosticCount(), 0U);
+}
+
+// Successful Declare must not leave stale diagnostics behind.
+TYPED_TEST(CPPINTEROP_TEST_MODE, Consumer_OkDeclareLeavesBufferEmpty) {
+  TestFixture::CreateInterpreter();
+  Cpp::ClearPendingDiagnostics();
+  EXPECT_EQ(0, Cpp::Declare("int ok = 7;", /*silent=*/false));
+  // Warnings might accrue, but no error-level diagnostics should.
+  for (unsigned I = 0, N = Cpp::GetPendingDiagnosticCount(); I < N; ++I) {
+    Cpp::DiagnosticRef D = Cpp::GetPendingDiagnostic(I);
+    EXPECT_NE(Cpp::GetDiagnosticSeverity(D), Cpp::DiagnosticSeverity::Error);
+    EXPECT_NE(Cpp::GetDiagnosticSeverity(D), Cpp::DiagnosticSeverity::Fatal);
+  }
+  Cpp::ClearPendingDiagnostics();
+}
+
+// silent=true sets SuppressAllDiagnostics on the engine, which
+// short-circuits before any consumer in the chain runs. Pin this
+// contract: a failed declare under silent=true reports failure via
+// the return code but the consumer captures nothing.
+TYPED_TEST(CPPINTEROP_TEST_MODE, Consumer_SilentSuppressesCapture) {
+  TestFixture::CreateInterpreter();
+  Cpp::ClearPendingDiagnostics();
+  EXPECT_NE(0, Cpp::Declare("int err = ;", /*silent=*/true));
+  EXPECT_EQ(Cpp::GetPendingDiagnosticCount(), 0U);
+}

--- a/unittests/CppInterOp/ResultTest.cpp
+++ b/unittests/CppInterOp/ResultTest.cpp
@@ -17,6 +17,12 @@
 #include "CppInterOp/CppInterOpTypes.h"
 #include "CppInterOp/Error.h"
 
+#include "../../lib/CppInterOp/ErrorInternal.h"
+#include "../../lib/CppInterOp/InterpreterInfo.h"
+#include "../../lib/CppInterOp/Tracing.h" // INTEROP_FUNC_SIG
+
+#include "Utils.h"
+
 #include "llvm/Support/Error.h"
 
 #include "gtest/gtest.h"
@@ -43,16 +49,12 @@ static_assert(sizeof(Cpp::Result<int>) <= sizeof(llvm::Expected<int>),
               "Result<int> must not exceed llvm::Expected<int>");
 
 namespace {
-// Address of a file-local sentinel byte serves as a non-null but
-// never-dereferenced ErrorRef state for the tests. Using a real
-// address keeps clang-tidy's int-to-ptr / reinterpret-cast checks
-// happy without weakening the test.
-const char kErrorSentinelByte = 0;
-const void* const kFakeState = &kErrorSentinelByte;
-Cpp::ErrorRef MakeErr() { return Cpp::ErrorRef{kFakeState}; }
+// Inline-encoded Status::NotFound: round-trips through the tag bit,
+// allocates nothing, costs no refcount work.
+Cpp::ErrorRef MakeErr() {
+  return Cpp::ErrorRef::makeInline(Cpp::Status::NotFound);
+}
 } // namespace
-
-// === Construction + basic accessors =====================================
 
 TEST(ResultTest, Result_OkFromValue) {
   Cpp::Result<int> R{42};
@@ -75,13 +77,12 @@ TEST(ResultTest, Result_ErrorFromErrorRef) {
   Cpp::Result<int> R{MakeErr()};
   EXPECT_FALSE(R.ok());
   EXPECT_FALSE(static_cast<bool>(R));
-  EXPECT_EQ(R.status(), Cpp::Status::Failed);
+  EXPECT_EQ(R.status(), Cpp::Status::NotFound);
   EXPECT_FALSE(R.error().isOk());
-  EXPECT_EQ(R.error().state, kFakeState);
+  EXPECT_TRUE(R.error().isInline());
+  EXPECT_FALSE(R.error().isSlice());
   EXPECT_EQ(R.value_or(-1), -1);
 }
-
-// === Result<void> ========================================================
 
 TEST(ResultTest, ResultVoid_DefaultIsOk) {
   Cpp::Result<void> R;
@@ -93,11 +94,9 @@ TEST(ResultTest, ResultVoid_DefaultIsOk) {
 TEST(ResultTest, ResultVoid_FromErrorRef) {
   Cpp::Result<void> R{MakeErr()};
   EXPECT_FALSE(R.ok());
-  EXPECT_EQ(R.status(), Cpp::Status::Failed);
-  EXPECT_EQ(R.error().state, kFakeState);
+  EXPECT_EQ(R.status(), Cpp::Status::NotFound);
+  EXPECT_TRUE(R.error().isInline());
 }
-
-// === Copy semantics ======================================================
 
 TEST(ResultTest, Copy_Ok) {
   Cpp::Result<int> A{7};
@@ -117,8 +116,6 @@ TEST(ResultTest, Copy_Error) {
   EXPECT_FALSE(B.ok());
   EXPECT_FALSE(A.ok()); // mark A checked so its dtor doesn't abort
 }
-
-// === Move semantics ======================================================
 
 TEST(ResultTest, Move_Ok) {
   Cpp::Result<int> A{11};
@@ -196,3 +193,131 @@ TEST(ResultDeathTest, ValueOnError_Aborts) {
 }
 
 #endif // !EMSCRIPTEN
+
+//
+// Every Status value round-trips through makeInline -> ErrorRef bits ->
+// status(). Status::Ok canonicalises to the null encoding; the rest
+// pack into a single uintptr_t with no allocation.
+
+TEST(ResultTest, InlineEncoding_StatusRoundTrip) {
+  const Cpp::Status All[] = {
+      Cpp::Status::NotFound,     Cpp::Status::InvalidArgument,
+      Cpp::Status::Ambiguous,    Cpp::Status::ParseError,
+      Cpp::Status::CompileError,
+  };
+  for (Cpp::Status S : All) {
+    Cpp::ErrorRef E = Cpp::ErrorRef::makeInline(S);
+    EXPECT_FALSE(E.isOk());
+    EXPECT_TRUE(E.isInline());
+    EXPECT_FALSE(E.isSlice());
+    EXPECT_EQ(E.status(), S);
+    // Inline errors carry no body.
+    EXPECT_EQ(E.diagnostics().size(), 0U);
+    EXPECT_EQ(E.producer(), nullptr);
+  }
+}
+
+TEST(ResultTest, InlineEncoding_OkCanonicalisesToNull) {
+  Cpp::ErrorRef E = Cpp::ErrorRef::makeInline(Cpp::Status::Ok);
+  EXPECT_TRUE(E.isOk());
+  EXPECT_FALSE(E.isInline());
+  EXPECT_FALSE(E.isSlice());
+  EXPECT_EQ(E.bits, 0U);
+}
+
+namespace {
+// makeError / drainError need a live interpreter to allocate slices
+// against.
+struct ResultBoundaryTest : public ::testing::Test {
+  void SetUp() override {
+    if (!Cpp::GetInterpreter())
+      Cpp::CreateInterpreter();
+  }
+};
+} // namespace
+
+TEST_F(ResultBoundaryTest, MakeError_SliceCarriesMessageAndProducer) {
+  Cpp::InterpreterInfo* II = Cpp::GetInterpInfo();
+  Cpp::ClearPending(II);
+  Cpp::Result<void> R{Cpp::makeError(
+      II, Cpp::Status::ParseError, "syntax error", __func__, INTEROP_FUNC_SIG)};
+  ASSERT_FALSE(R.ok());
+  EXPECT_EQ(R.status(), Cpp::Status::ParseError);
+  EXPECT_TRUE(R.error().isSlice());
+  EXPECT_FALSE(R.error().isInline());
+  ASSERT_GE(R.error().diagnostics().size(), 1U);
+  EXPECT_STREQ(R.error().diagnostics()[0].message(), "syntax error");
+  EXPECT_EQ(R.error().diagnostics()[0].severity(),
+            Cpp::DiagnosticSeverity::Error);
+  EXPECT_STREQ(R.error().producer(), __func__);
+}
+
+// drainError lifts an llvm::Error chain into a slice, preserving Status
+// and any structured payload the chain carries.
+TEST_F(ResultBoundaryTest, DrainError_StatusErrorFixesCode) {
+  Cpp::InterpreterInfo* II = Cpp::GetInterpInfo();
+  Cpp::ClearPending(II);
+  llvm::Error E = llvm::make_error<Cpp::StatusError>(Cpp::Status::NotFound,
+                                                     "no such symbol");
+  Cpp::Result<void> R{Cpp::drainError(II, std::move(E), __func__, nullptr)};
+  ASSERT_FALSE(R.ok());
+  EXPECT_EQ(R.status(), Cpp::Status::NotFound);
+}
+
+// share() bumps the slice refcount so the captured error survives the
+// originating Result's destruction.
+TEST_F(ResultBoundaryTest, CapturedError_OutlivesResult) {
+  Cpp::InterpreterInfo* II = Cpp::GetInterpInfo();
+  Cpp::ClearPending(II);
+  Cpp::CapturedError C;
+  size_t DiagCount = 0;
+  {
+    Cpp::Result<void> R{Cpp::makeError(
+        II, Cpp::Status::ParseError, "captured-error test", __func__, nullptr)};
+    ASSERT_FALSE(R.ok());
+    DiagCount = R.error().diagnostics().size();
+    C = R.share();
+  } // R out of scope; slice survives because C holds a ref.
+  EXPECT_FALSE(C.ok());
+  EXPECT_EQ(C.status(), Cpp::Status::ParseError);
+  EXPECT_EQ(C.diagnostics().size(), DiagCount);
+}
+
+// Inline errors have no slice; capture is a pure value copy with no
+// refcount bookkeeping.
+TEST(ResultTest, CapturedError_InlineHasNoSlice) {
+  Cpp::Result<int> R{Cpp::ErrorRef::makeInline(Cpp::Status::InvalidArgument)};
+  Cpp::CapturedError C = R.share();
+  EXPECT_FALSE(C.ok());
+  EXPECT_EQ(C.status(), Cpp::Status::InvalidArgument);
+  EXPECT_TRUE(C.ref().isInline());
+  EXPECT_FALSE(C.ref().isSlice());
+}
+
+// record() copies into an owning value-type so the caller can drop the
+// Result and the slice can be freed.
+TEST_F(ResultBoundaryTest, ErrorRecord_OwnsDiagnostics) {
+  Cpp::ErrorRecord Rec;
+  {
+    Cpp::InterpreterInfo* II = Cpp::GetInterpInfo();
+    Cpp::ClearPending(II);
+    Cpp::Result<void> R{Cpp::makeError(
+        II, Cpp::Status::ParseError, "recordable message", __func__, nullptr)};
+    ASSERT_FALSE(R.ok());
+    Rec = R.error().record();
+  } // R dies; slice freed. Rec stays usable.
+  EXPECT_EQ(Rec.Code, Cpp::Status::ParseError);
+  ASSERT_GE(Rec.Diagnostics.size(), 1U);
+  EXPECT_EQ(Rec.Diagnostics[0].Message, "recordable message");
+}
+
+TEST(ResultTest, ErrorRecord_InlineProducesEmpty) {
+  Cpp::ErrorRef E = Cpp::ErrorRef::makeInline(Cpp::Status::InvalidArgument);
+  Cpp::ErrorRecord Rec = E.record();
+  EXPECT_EQ(Rec.Code, Cpp::Status::InvalidArgument);
+  EXPECT_TRUE(Rec.Diagnostics.empty());
+}
+
+static_assert(sizeof(Cpp::ErrorRef) == sizeof(void*),
+              "ErrorRef stays one pointer-word");
+static_assert(sizeof(Cpp::Status) == 1, "Status enum stays one byte");


### PR DESCRIPTION
When a CppInterOp call fails the caller sees a return code -- "this didn't work" -- but not the Clang diagnostic underneath ("expected ';' at foo.cpp:12:5"). Bindings end up scraping stderr to recover that detail.

DiagnosticRef carries one captured diagnostic (severity, message, file, line, column). A clang::DiagnosticConsumer wired into every interpreter pipes parser and Sema output into a per-interpreter buffer that drains into a slice on the failure path. The slice sits behind the returned ErrorRef.

Errors also carry an optional structured payload for the two cases where Status alone leaves the caller flying blind: overload resolution (candidate list) and template deduction (failing param and reason). CapturedError extends an error's lifetime past its Result; ErrorRecord deep-copies into a plain value type. ErrorRef stays one pointer-word: an inline Status when there is no body, a slice pointer otherwise.

The consumer forwards to whatever client was installed previously so existing stderr output is preserved. takeClient transfers ownership when the engine owns its client (clang-REPL). cling installs with ShouldOwnClient=false, so takeClient returns null there; getClient still returns the original raw pointer between takeClient and setClient, and the consumer forwards through that. Without the raw-pointer leg, cling diagnostics would vanish from stderr -- which cppyy's failing-cppcode tests detect by grepping for "fatal error:".