### PR TITLE
[test] Skip OverlayAddsNoPerCallCost on macOS.

### DIFF
--- a/unittests/CppInterOp/VTableOverlayCrossTUBench.cpp
+++ b/unittests/CppInterOp/VTableOverlayCrossTUBench.cpp
@@ -92,6 +92,9 @@ TEST(VTableOverlayCrossTU, OverlayAddsNoPerCallCost) {
 #if !defined(NDEBUG) || defined(__SANITIZE_ADDRESS__)
   GTEST_SKIP() << "Perf assertions need a Release, non-sanitizer build.";
 #endif
+#ifdef __APPLE__
+  GTEST_SKIP() << "Flaky on macOS runners (ratio noise around the 0.9 floor).";
+#endif
   EXPECT_NOT_SLOWER_THAN(BM_XTU_OverlayDirectFn, BM_XTU_BareVirtual);
 }
 


### PR DESCRIPTION
The overlay-vs-bare-virtual ratio assertion is structurally noisy on the macOS CI runners: both benchmarks measure sub-4 ns work, and the runner's per-call jitter routinely drags the ratio under the 0.9 floor (observed 0.89). The test passes on Linux runners where the noise envelope is tighter.

Skip on __APPLE__ next to the existing Debug/ASan skip. The Linux runners still pin the perf claim that motivates VTableOverlay.

# Description

Please include a summary of changes, motivation and context for this PR.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [ ] I have read the contribution guide recently
