### PR TITLE
Pass a valid SourceLocation in BestOverloadFunctionMatch

### DIFF
--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -1870,8 +1870,12 @@ BestOverloadFunctionMatch(const std::vector<FuncRef>& candidates,
     ExplicitTemplateArgs.addArgument(
         S.getTrivialTemplateArgumentLoc(TA, QualType(), SourceLocation()));
 
+  // ensure valid point of instantiation, SFINAE trap keeps any failure soft
+  SourceLocation Loc = SourceLocation::getFromRawEncoding(1);
+  Sema::SFINAETrap Trap(S, /*ForValidityCheck=*/true);
+
   OverloadCandidateSet Overloads(
-      SourceLocation(), OverloadCandidateSet::CandidateSetKind::CSK_Normal);
+      Loc, OverloadCandidateSet::CandidateSetKind::CSK_Normal);
 
   for (auto i : candidates) {
     auto* D = const_cast<Decl*>(unwrap<Decl>(i));
@@ -1905,7 +1909,7 @@ BestOverloadFunctionMatch(const std::vector<FuncRef>& candidates,
   }
 
   OverloadCandidateSet::iterator Best;
-  Overloads.BestViableFunction(S, SourceLocation(), Best);
+  Overloads.BestViableFunction(S, Loc, Best);
 
   FunctionDecl* Result = Best != Overloads.end() ? Best->Function : nullptr;
   delete[] Exprs;


### PR DESCRIPTION
Overload resolution in `BestOverloadFunctionMatch` can deduce template arguments that complete a class template (e.g. resolving `std::pair`'s converting constructor). That path records a point of instantiation, which Clang asserts must be a **valid** `SourceLocation` — but the interpreter passed `SourceLocation()`, aborting Sema on Clang < 22 (Clang 22 happens to tolerate it).

Use a synthetic valid location (`getFromRawEncoding(1)`, matching the `OpaqueValueExpr`s already used here) for the `OverloadCandidateSet` and `BestViableFunction`, and wrap resolution in a `Sema::SFINAETrap` so any deduction-time instantiation failure stays soft.

Reproducer: cppyy's `test_conversions` tuple→`std::pair` implicit conversion (`m.insert(('a','b'))`) crashes the interpreter on Clang 21 (outside of CI); with this change it resolves cleanly on Clang 21 and 22. (To be clearer, this DOESN'T crash on the CI Clang 21, but in a local Clang 21.x build that... verified that building locally off of Clang 22.x even without this fix was okay, but there is a corner case caught on a local system that isn't covered in CI that this addresses).

## Type of change

- [x] Bug fix

## Testing

Verified on LLVM 21 and 22: the crash is gone and `check-cppinterop` passes (7/7); cppyy's `test_conversions` / `test_templates` / `test_overloads` / `test_stltypes` show no regressions.

## Checklist

- [x] I have read the contribution guide recently

---
🤖 Done with the help of [Claude Code](https://claude.com/claude-code) (Claude Opus 4.8)