### PR TITLE
Fix: Resolve inherited members through implicit UsingShadowDecls

### DIFF
--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -1193,6 +1193,39 @@ clang::NamedDecl* LookupUnqualified(clang::Sema& S,
   return (clang::NamedDecl*)-1;
 }
 
+
+static clang::UsingShadowDecl *CreateInheritedUsingShadow(
+    clang::CXXRecordDecl *Record, clang::NamedDecl *Target) {
+  if (!Record || !Target)
+    return nullptr;
+
+  if (auto *Shadow = llvm::dyn_cast<clang::UsingShadowDecl>(Target))
+    Target = Shadow->getTargetDecl();
+
+  if (!Target)
+    return nullptr;
+
+  if (Target->getDeclContext() == Record)
+    return llvm::dyn_cast<clang::UsingShadowDecl>(Target);
+
+  clang::ASTContext &C = Record->getASTContext();
+  clang::DeclarationNameInfo NameInfo(Target->getDeclName(),
+                                      clang::SourceLocation());
+  auto *Using = clang::UsingDecl::Create(C, Record, clang::SourceLocation(),
+                                         clang::NestedNameSpecifierLoc(),
+                                         NameInfo, false);
+  Using->setImplicit(true);
+
+  auto *Shadow = clang::UsingShadowDecl::Create(
+      C, Record, clang::SourceLocation(), Target->getDeclName(), Using,
+      Target);
+  Using->addShadowDecl(Shadow);
+  Shadow->setAccess(Target->getAccess());
+  Record->addDecl(Shadow);
+
+  return Shadow;
+}
+
 // Cheap probe: does any namespace from `DC` up to TU carry at least
 // one using-directive? Gates the synthetic-DRef-chain build below so
 // the common case (no using-directives anywhere on the path) doesn't
@@ -1229,6 +1262,40 @@ DeclRef GetNamed(const std::string& name, ConstDeclRef parent /*= nullptr*/) {
   auto* ND = CppInternal::utils::Lookup::Named(&getSema(), name, Within);
   if (ND && ND != (clang::NamedDecl*)-1)
     return INTEROP_RETURN(ND->getCanonicalDecl());
+
+  // Qualified lookup can miss inherited members in class scope. Try the
+  // record's own lookup, which includes direct members, and then fall back
+  // to unqualified lookup inside the record to honor base-class member
+  // visibility semantics.
+  if (Within) {
+    if (auto* RD = llvm::dyn_cast<clang::CXXRecordDecl>(Within)) {
+      clang::DeclarationName DName = &getSema().Context.Idents.get(name);
+      auto Decls = RD->lookup(DName);
+      clang::NamedDecl* FoundND = nullptr;
+      for (auto* D : Decls) {
+        if (auto* Named = llvm::dyn_cast<clang::NamedDecl>(D)) {
+          if (!FoundND)
+            FoundND = Named;
+          else
+            return INTEROP_RETURN(nullptr);
+        }
+      }
+      if (FoundND)
+        return INTEROP_RETURN((TCppScope_t)(FoundND->getCanonicalDecl()));
+
+      // Qualified lookup may still miss inherited class members in some
+      // record contexts. Use unqualified lookup from a synthesized point
+      // inside the class to traverse base classes and find the member.
+      auto* ND2 = LookupUnqualified(getSema(), DName, Within);
+      if (ND2 && ND2 != (clang::NamedDecl*)-1) {
+        if (auto* Shadow = CreateInheritedUsingShadow(RD, ND2))
+          return INTEROP_RETURN((TCppScope_t)(Shadow->getCanonicalDecl()));
+        return INTEROP_RETURN((TCppScope_t)(ND2->getCanonicalDecl()));
+      }
+      if (ND2 == (clang::NamedDecl*)-1)
+        return INTEROP_RETURN(nullptr);
+    }
+  }
 
   // Slow path: only when qualified lookup missed AND `Within` is a
   // namespace whose enclosing chain carries at least one using-directive

--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -1215,6 +1215,7 @@ static clang::UsingShadowDecl *CreateInheritedUsingShadow(
                                          clang::NestedNameSpecifierLoc(),
                                          NameInfo, false);
   Using->setImplicit(true);
+  Using->setAccess(Target->getAccess());
 
   auto *Shadow = clang::UsingShadowDecl::Create(
       C, Record, clang::SourceLocation(), Target->getDeclName(), Using,
@@ -1222,6 +1223,7 @@ static clang::UsingShadowDecl *CreateInheritedUsingShadow(
   Using->addShadowDecl(Shadow);
   Shadow->setAccess(Target->getAccess());
   Record->addDecl(Shadow);
+  Record->addDecl(Using);
 
   return Shadow;
 }

--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -1215,15 +1215,13 @@ static clang::UsingShadowDecl *CreateInheritedUsingShadow(
                                          clang::NestedNameSpecifierLoc(),
                                          NameInfo, false);
   Using->setImplicit(true);
-  Using->setAccess(Target->getAccess());
 
   auto *Shadow = clang::UsingShadowDecl::Create(
       C, Record, clang::SourceLocation(), Target->getDeclName(), Using,
       Target);
+
   Using->addShadowDecl(Shadow);
-  Shadow->setAccess(Target->getAccess());
   Record->addDecl(Shadow);
-  Record->addDecl(Using);
 
   return Shadow;
 }
@@ -1263,7 +1261,7 @@ DeclRef GetNamed(const std::string& name, ConstDeclRef parent /*= nullptr*/) {
   // null, so TU-level using-directives are already handled there.
   auto* ND = CppInternal::utils::Lookup::Named(&getSema(), name, Within);
   if (ND && ND != (clang::NamedDecl*)-1)
-    return INTEROP_RETURN(ND->getCanonicalDecl());
+    return INTEROP_RETURN(ND);
 
   // Qualified lookup can miss inherited members in class scope. Try the
   // record's own lookup, which includes direct members, and then fall back
@@ -1283,16 +1281,18 @@ DeclRef GetNamed(const std::string& name, ConstDeclRef parent /*= nullptr*/) {
         }
       }
       if (FoundND)
-        return INTEROP_RETURN((FoundND->getCanonicalDecl()));
+        return INTEROP_RETURN((FoundND));
 
       // Qualified lookup may still miss inherited class members in some
       // record contexts. Use unqualified lookup from a synthesized point
       // inside the class to traverse base classes and find the member.
       auto* ND2 = LookupUnqualified(getSema(), DName, Within);
-      if (ND2 && ND2 != (clang::NamedDecl*)-1) {
+      if (ND2 == reinterpret_cast<clang::NamedDecl*>(-1))
+        return INTEROP_RETURN(nullptr);
+      if (ND2) {
         if (auto* Shadow = CreateInheritedUsingShadow(RD, ND2))
-          return INTEROP_RETURN((Shadow->getCanonicalDecl()));
-        return INTEROP_RETURN((ND2->getCanonicalDecl()));
+          return INTEROP_RETURN(Shadow);
+        return INTEROP_RETURN(ND2);
       }
       if (ND2 == (clang::NamedDecl*)-1)
         return INTEROP_RETURN(nullptr);
@@ -1309,7 +1309,7 @@ DeclRef GetNamed(const std::string& name, ConstDeclRef parent /*= nullptr*/) {
   clang::DeclarationName DName = &getSema().Context.Idents.get(name);
   ND = LookupUnqualified(getSema(), DName, Within);
   if (ND && ND != (clang::NamedDecl*)-1)
-    return INTEROP_RETURN(ND->getCanonicalDecl());
+    return INTEROP_RETURN(ND);
 
   return INTEROP_RETURN(nullptr);
 }

--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -1281,7 +1281,7 @@ DeclRef GetNamed(const std::string& name, ConstDeclRef parent /*= nullptr*/) {
         }
       }
       if (FoundND)
-        return INTEROP_RETURN((TCppScope_t)(FoundND->getCanonicalDecl()));
+        return INTEROP_RETURN((FoundND->getCanonicalDecl()));
 
       // Qualified lookup may still miss inherited class members in some
       // record contexts. Use unqualified lookup from a synthesized point
@@ -1289,8 +1289,8 @@ DeclRef GetNamed(const std::string& name, ConstDeclRef parent /*= nullptr*/) {
       auto* ND2 = LookupUnqualified(getSema(), DName, Within);
       if (ND2 && ND2 != (clang::NamedDecl*)-1) {
         if (auto* Shadow = CreateInheritedUsingShadow(RD, ND2))
-          return INTEROP_RETURN((TCppScope_t)(Shadow->getCanonicalDecl()));
-        return INTEROP_RETURN((TCppScope_t)(ND2->getCanonicalDecl()));
+          return INTEROP_RETURN((Shadow->getCanonicalDecl()));
+        return INTEROP_RETURN((ND2->getCanonicalDecl()));
       }
       if (ND2 == (clang::NamedDecl*)-1)
         return INTEROP_RETURN(nullptr);

--- a/unittests/CppInterOp/ScopeReflectionTest.cpp
+++ b/unittests/CppInterOp/ScopeReflectionTest.cpp
@@ -702,7 +702,6 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, ScopeReflection_GetNamed) {
   EXPECT_EQ(Cpp::GetQualifiedName(std_ns), "std");
   EXPECT_EQ(Cpp::GetQualifiedName(std_string_class), "std::string");
   EXPECT_EQ(Cpp::GetQualifiedName(std_string_npos_var), "std::basic_string<char>::npos");
-
   Interp->declare(R"(
     struct S {
       typedef int Val;
@@ -713,15 +712,15 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, ScopeReflection_GetNamed) {
     };
   )");
 
-Cpp::TCppScope_t strt_S = Cpp::GetNamed("S", nullptr);
-Cpp::TCppScope_t strt_S_Val = Cpp::GetNamed("Val", strt_S);
-Cpp::TCppScope_t strt_S1 = Cpp::GetNamed("S1", nullptr);
-Cpp::TCppScope_t strt_S1_Val = Cpp::GetNamed("Val", strt_S1);
+  Cpp::DeclRef strt_S = Cpp::GetNamed("S", nullptr);
+  Cpp::DeclRef strt_S_Val = Cpp::GetNamed("Val", strt_S);
+  Cpp::DeclRef strt_S1 = Cpp::GetNamed("S1", nullptr);
+  Cpp::DeclRef strt_S1_Val = Cpp::GetNamed("Val", strt_S1);
 
-EXPECT_EQ(Cpp::GetQualifiedName(strt_S), "S");
-EXPECT_EQ(Cpp::GetQualifiedName(strt_S_Val), "S::Val");
-EXPECT_EQ(Cpp::GetQualifiedName(strt_S1), "S1");
-EXPECT_EQ(Cpp::GetQualifiedName(strt_S1_Val), "S1::Val");
+  EXPECT_EQ(Cpp::GetQualifiedName(strt_S), "S");
+  EXPECT_EQ(Cpp::GetQualifiedName(strt_S_Val), "S::Val");
+  EXPECT_EQ(Cpp::GetQualifiedName(strt_S1), "S1");
+  EXPECT_EQ(Cpp::GetQualifiedName(strt_S1_Val), "S1::Val");
 }
 
 TYPED_TEST(CPPINTEROP_TEST_MODE, ScopeReflection_GetNamedWithUsing) {

--- a/unittests/CppInterOp/ScopeReflectionTest.cpp
+++ b/unittests/CppInterOp/ScopeReflectionTest.cpp
@@ -702,6 +702,26 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, ScopeReflection_GetNamed) {
   EXPECT_EQ(Cpp::GetQualifiedName(std_ns), "std");
   EXPECT_EQ(Cpp::GetQualifiedName(std_string_class), "std::string");
   EXPECT_EQ(Cpp::GetQualifiedName(std_string_npos_var), "std::basic_string<char>::npos");
+
+  Interp->declare(R"(
+    struct S {
+      typedef int Val;
+    };
+
+    struct S1 : public S {
+      /* empty */
+    };
+  )");
+
+Cpp::TCppScope_t strt_S = Cpp::GetNamed("S", nullptr);
+Cpp::TCppScope_t strt_S_Val = Cpp::GetNamed("Val", strt_S);
+Cpp::TCppScope_t strt_S1 = Cpp::GetNamed("S1", nullptr);
+Cpp::TCppScope_t strt_S1_Val = Cpp::GetNamed("Val", strt_S1);
+
+EXPECT_EQ(Cpp::GetQualifiedName(strt_S), "S");
+EXPECT_EQ(Cpp::GetQualifiedName(strt_S_Val), "S::Val");
+EXPECT_EQ(Cpp::GetQualifiedName(strt_S1), "S1");
+EXPECT_EQ(Cpp::GetQualifiedName(strt_S1_Val), "S1::Val");
 }
 
 TYPED_TEST(CPPINTEROP_TEST_MODE, ScopeReflection_GetNamedWithUsing) {


### PR DESCRIPTION
# Description

Please include a summary of changes, motivation and context for this PR.
Member lookup considered declarations could miss members inherited from base classes in some record lookup contexts.

The change adds a fallback to unqualified lookup when direct record lookup fails. This allows lookup to traverse base classes and find inherited members. When an inherited member is found, an implicit UsingShadowDecl is created in the derived class to represent that inherited member as if it were introduced into the derived class scope
UsingShadowDecl mechanism should handle inherited typedefs as well.

Fixes # (issue)
https://github.com/compiler-research/CppInterOp/pull/93 fixes this issue.
## Type of change

Please tick all options which are relevant.

- [ X ] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.
https://github.com/compiler-research/CppInterOp/pull/123/changes
this is the reproducible test, which gets passed after this patch.

## Checklist

- [ ] I have read the contribution guide recently
