### PR TITLE
[cmake] Keep libLLVM.so out of DT_NEEDED in dylib-mode builds

### DIFF
--- a/lib/CppInterOp/CMakeLists.txt
+++ b/lib/CppInterOp/CMakeLists.txt
@@ -56,6 +56,15 @@ endif()
 
 # Get rid of libLLVM-X.so which is appended to the list of static libraries.
 if (LLVM_LINK_LLVM_DYLIB)
+  # These make up for symbols the stripped libLLVM.so used to provide. Seed them
+  # before the walk below, not after: the walk only drops the shared LLVM
+  # dependency from the targets it visits, and clangStaticAnalyzerCore is not
+  # reachable from the other link_libs -- appending it later leaves libLLVM.so
+  # in DT_NEEDED.
+  list(APPEND link_libs
+    clangCodeGen
+    clangStaticAnalyzerCore
+    )
   set(new_libs ${link_libs})
   set(libs ${new_libs})
   while(NOT "${new_libs}" STREQUAL "")
@@ -95,12 +104,8 @@ if (LLVM_LINK_LLVM_DYLIB)
     Coverage
     FrontendHLSL
     LTO
-    )
-  # We will need to append the missing dependencies to pull in the right
-  # LLVM library dependencies.
-  list(APPEND link_libs
-    clangCodeGen
-    clangStaticAnalyzerCore
+    Option
+    TargetParser
     )
 endif(LLVM_LINK_LLVM_DYLIB)
 


### PR DESCRIPTION
When the LLVM toolchain ships a shared libLLVM.so (LLVM_LINK_LLVM_DYLIB), we deliberately link CppInterOp against the static LLVM libraries instead, walking the clang targets and rewriting their interfaces to drop the shared LLVM dependency. The two make-up libraries, clangCodeGen and clangStaticAnalyzerCore, were appended after that walk, so clangStaticAnalyzerCore -- which nothing else pulls in -- never had its shared LLVM dependency rewritten and dragged libLLVM.so back into DT_NEEDED.

Seed both make-up libraries before the walk so their interfaces are rewritten too, and add the Option and TargetParser components that the static link then needs but the shared library used to satisfy. The result is a CppInterOp that links the static LLVM libraries with no libLLVM.so in DT_NEEDED, regardless of how the toolchain ships LLVM.

Verified on the Linux x86 LLVM 22 dylib cell: a full build links cleanly and no produced artifact lists libLLVM.so or libclang-cpp.so in DT_NEEDED.

# Description

Please include a summary of changes, motivation and context for this PR.

Fixes # (issue)

## Type of change

Please tick all options which are relevant.

- [ ] Bug fix
- [ ] New feature
- [ ] Requires documentation updates

## Testing

Please describe the test(s) that you added and ran to verify your changes.

## Checklist

- [ ] I have read the contribution guide recently
