### PR TITLE
[ci] Bump the OS X compiler toolchain to llvm21

### DIFF
--- a/.github/actions/Miscellaneous/Setup_Compiler/action.yml
+++ b/.github/actions/Miscellaneous/Setup_Compiler/action.yml
@@ -26,14 +26,9 @@ runs:
           echo "CC=gcc-${vers}" >> $GITHUB_ENV
           echo "CXX=g++-${vers}" >> $GITHUB_ENV
         else
-          if [[ "$(uname -m)" == "x86_64" ]]; then
-            brew install llvm@15
-            echo "CC=/usr/local/opt/llvm@20/bin/clang" >> $GITHUB_ENV
-            echo "CXX=/usr/local/opt/llvm@20/bin/clang++" >> $GITHUB_ENV
-          else
-            echo "CC=/opt/homebrew/opt/llvm@20/bin/clang" >> $GITHUB_ENV
-            echo "CXX=/opt/homebrew/opt/llvm@20/bin/clang++" >> $GITHUB_ENV
-          fi
+          brew list llvm@21 &>/dev/null || brew install llvm@21
+          echo "CC=$(brew --prefix llvm@21)/bin/clang" >> $GITHUB_ENV
+          echo "CXX=$(brew --prefix llvm@21)/bin/clang++" >> $GITHUB_ENV
         fi
         echo "SDKROOT=$(xcrun --sdk macosx --show-sdk-path)" >> $GITHUB_ENV
       env:


### PR DESCRIPTION
llvm-cov 20's gcov emulation fabricates out-of-range line records. See: https://github.com/compiler-research/CppInterOp/actions/runs/28658480421/job/85005593960?pr=1041. I was also able to reproduce it with a similar TU locally with llvm-cov 20. This mechanism was fixed in llvm-cov 21, and testing locally, it was able to parse the header cleanly. Bump the toolchain in OS X and drop the stale llvm15 install for x86 mac which is no longer tested.