### PR TITLE
[cmake] Use ExternalProject to generate GTest sub-build config

### DIFF
--- a/cmake/modules/GoogleBenchmark.cmake
+++ b/cmake/modules/GoogleBenchmark.cmake
@@ -1,8 +1,9 @@
 # Build Google Benchmark as an ExternalProject, mirroring GoogleTest.cmake,
 # so the perf-as-validity tests get the library without a system dependency.
-# BUILD_BYPRODUCTS, the explicit -B in CONFIGURE_COMMAND, and IMPORTED_LOCATION
-# (resolved via ExternalProject_Get_Property binary_dir) must agree on where
-# benchmark builds; tracking CMAKE_CURRENT_BINARY_DIR keeps them in sync.
+# BUILD_BYPRODUCTS, the sub-build's binary dir (ExternalProject's default),
+# and IMPORTED_LOCATION (resolved via ExternalProject_Get_Property binary_dir)
+# must agree on where benchmark builds; tracking CMAKE_CURRENT_BINARY_DIR
+# keeps them in sync.
 set(_benchmark_byproduct_binary_dir
   ${CMAKE_CURRENT_BINARY_DIR}/googlebenchmark-prefix/src/googlebenchmark-build)
 set(_benchmark_byproducts
@@ -34,10 +35,7 @@ ExternalProject_Add(
   GIT_SHALLOW FALSE
   GIT_TAG v1.9.5
   UPDATE_COMMAND ""
-  CONFIGURE_COMMAND ${CMAKE_COMMAND} -G ${CMAKE_GENERATOR}
-                -S ${CMAKE_CURRENT_BINARY_DIR}/googlebenchmark-prefix/src/googlebenchmark/
-                -B ${_benchmark_byproduct_binary_dir}/
-                -DCMAKE_BUILD_TYPE=$<CONFIG>
+  CMAKE_ARGS    -DCMAKE_BUILD_TYPE=$<CONFIG>
                 -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
                 -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}
                 -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}

--- a/cmake/modules/GoogleTest.cmake
+++ b/cmake/modules/GoogleTest.cmake
@@ -1,4 +1,5 @@
-# BUILD_BYPRODUCTS, the explicit -B in CONFIGURE_COMMAND, and
+# BUILD_BYPRODUCTS, the sub-build's binary dir (ExternalProject's
+# default, passed as -B explicitly on the emscripten path), and
 # IMPORTED_LOCATION (resolved via ExternalProject_Get_Property
 # binary_dir) all need to agree on where googletest builds.
 # ExternalProject's binary_dir defaults to
@@ -43,8 +44,32 @@ if (EMSCRIPTEN)
     set(build_cmd emmake${EMCC_SUFFIX} make)
   endif()
 else()
-  set(config_cmd ${CMAKE_COMMAND})
   set(build_cmd ${CMAKE_COMMAND} --build ${CMAKE_CURRENT_BINARY_DIR}/googletest-prefix/src/googletest-build/ --config $<CONFIG>)
+endif()
+
+set(_gtest_cmake_args
+  -DCMAKE_BUILD_TYPE=$<CONFIG>
+  -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+  -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}
+  -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+  -DCMAKE_CXX_FLAGS=${GOOGLETEST_CMAKE_CXX_FLAGS}
+  # HandleLLVMOptions puts -stdlib=libc++ / -fsanitize=*
+  # in CMAKE_*_LINKER_FLAGS for LLVM_USE_SANITIZER.
+  -DCMAKE_EXE_LINKER_FLAGS=${CMAKE_EXE_LINKER_FLAGS}
+  -DCMAKE_MODULE_LINKER_FLAGS=${CMAKE_MODULE_LINKER_FLAGS}
+  -DCMAKE_SHARED_LINKER_FLAGS=${CMAKE_SHARED_LINKER_FLAGS}
+  -DCMAKE_AR=${CMAKE_AR}
+  -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
+  ${EXTRA_GTEST_OPTS})
+
+if(EMSCRIPTEN)
+  set(_gtest_configure
+    CONFIGURE_COMMAND ${config_cmd} -G ${CMAKE_GENERATOR}
+      -S ${CMAKE_CURRENT_BINARY_DIR}/googletest-prefix/src/googletest/
+      -B ${CMAKE_CURRENT_BINARY_DIR}/googletest-prefix/src/googletest-build/
+      ${_gtest_cmake_args})
+else()
+  set(_gtest_configure CMAKE_ARGS ${_gtest_cmake_args})
 endif()
 
 ExternalProject_Add(
@@ -53,27 +78,7 @@ ExternalProject_Add(
   GIT_SHALLOW FALSE
   GIT_TAG fa8438ae6b70c57010177de47a9f13d7041a6328
   UPDATE_COMMAND ""
-  # # Force separate output paths for debug and release builds to allow easy
-  # # identification of correct lib in subsequent TARGET_LINK_LIBRARIES commands
-  # CMAKE_ARGS -DCMAKE_ARCHIVE_OUTPUT_DIRECTORY_DEBUG:PATH=DebugLibs
-  #            -DCMAKE_ARCHIVE_OUTPUT_DIRECTORY_RELEASE:PATH=ReleaseLibs
-  #            -Dgtest_force_shared_crt=ON
-  CONFIGURE_COMMAND ${config_cmd} -G ${CMAKE_GENERATOR}
-                -S ${CMAKE_CURRENT_BINARY_DIR}/googletest-prefix/src/googletest/
-                -B ${CMAKE_CURRENT_BINARY_DIR}/googletest-prefix/src/googletest-build/
-                -DCMAKE_BUILD_TYPE=$<CONFIG>
-                -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
-                -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}
-                -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
-                -DCMAKE_CXX_FLAGS=${GOOGLETEST_CMAKE_CXX_FLAGS}
-                # HandleLLVMOptions puts -stdlib=libc++ / -fsanitize=*
-                # in CMAKE_*_LINKER_FLAGS for LLVM_USE_SANITIZER.
-                -DCMAKE_EXE_LINKER_FLAGS=${CMAKE_EXE_LINKER_FLAGS}
-                -DCMAKE_MODULE_LINKER_FLAGS=${CMAKE_MODULE_LINKER_FLAGS}
-                -DCMAKE_SHARED_LINKER_FLAGS=${CMAKE_SHARED_LINKER_FLAGS}
-                -DCMAKE_AR=${CMAKE_AR}
-                -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
-                ${EXTRA_GTEST_OPTS}
+  ${_gtest_configure}
   BUILD_COMMAND ${build_cmd}
   # Disable install step
   INSTALL_COMMAND ""


### PR DESCRIPTION
Use declarative `CMAKE_ARGS`: ExternalProject generates the configure command itself and forwards the parent generator, platform and toolset. Fixes the case where a parent configured with `-A Win32 -Thost=x64` spawned sub-builds on the VS generator's default x64 platform, which tries to link x64 objects against the forwarded /machine:X86 linker flags and fail.

Required by #1051 