### PR TITLE
[interp] Annotate IsFunctionProtoType's exit for tracing

### DIFF
--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -1584,7 +1584,7 @@ bool IsFunctionProtoType(ConstTypeRef TyRef) {
   INTEROP_TRACE(TyRef);
   QualType QT = QualType::getFromOpaquePtr(TyRef.data);
   const auto* T = QT.getTypePtr();
-  return llvm::isa_and_nonnull<clang::FunctionProtoType>(T);
+  return INTEROP_RETURN(llvm::isa_and_nonnull<clang::FunctionProtoType>(T));
 }
 
 void GetFnTypeSignature(ConstTypeRef fn_type, std::vector<TypeRef>& sig) {

--- a/unittests/CppInterOp/TracingTests.cpp
+++ b/unittests/CppInterOp/TracingTests.cpp
@@ -1169,6 +1169,8 @@ TEST_F(TracingTest, ReproducerCompilesViaInterpreter) {
   auto FooType = Cpp::GetTypeFromScope(Foo);
   ASSERT_NE(FooType, nullptr);
 
+  EXPECT_FALSE(Cpp::IsFunctionProtoType(FooType));
+
   Cpp::GetName(Foo);
   Cpp::SizeOf(Foo);
 


### PR DESCRIPTION
Found by running the win32 suite under `CPPINTEROP_LOG=1`. the traced function returns through a bare return instead of `INTEROP_RETURN`, so the tracing layer's unannotated-exit assert aborts the process when the API is called with tracing.