### PR TITLE
Rebase computation under RASTV and support for recursion

### DIFF
--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -1637,98 +1637,127 @@ bool IsFunctionProtoType(ConstTypeRef TyRef) {
   return INTEROP_RETURN(llvm::isa_and_nonnull<clang::FunctionProtoType>(T));
 }
 
-static AllocType handleNew(const clang::CXXNewExpr* CNE) {
-  if (CNE->getNumPlacementArgs() > 0)
-    return AllocType::None;
-  if (CNE->isArray())
-    return AllocType::NewArr;
-  return AllocType::New;
-}
+static std::optional<AllocType>
+AnalyzeAllocType(const clang::FunctionDecl* Fn,
+                 std::unordered_map<const clang::FunctionDecl*,
+                                    std::optional<AllocType>>& visitedFuncs);
 
-static AllocType AnalyzeAllocType(const clang::FunctionDecl* Fn);
+namespace {
+struct AllocationTraverser : RecursiveASTVisitor<AllocationTraverser> {
+  std::unordered_map<const clang::VarDecl*, std::optional<AllocType>> varMap;
+  std::unordered_map<const clang::FunctionDecl*, std::optional<AllocType>>&
+      visitedFuncs;
+  // Result var keeps the combination all possible values of previous return
+  // statements
+  std::optional<AllocType> result;
 
-static AllocType handleCall(const clang::CallExpr* CE) {
-  if (const auto* FD = CE->getDirectCallee()) {
-    if (FD->getBuiltinID() == Builtin::ID::BImalloc)
-      return AllocType::Malloc;
-    return AnalyzeAllocType(FD);
-  }
-  // Function pointer calle
-  return AllocType::Unknown;
-}
+  AllocationTraverser(std::unordered_map<const clang::FunctionDecl*,
+                                         std::optional<AllocType>>& cache)
+      : visitedFuncs(cache) {}
 
-static AllocType
-handleExpr(const clang::Expr* expr,
-           std::unordered_map<const VarDecl*, AllocType>& varMap) {
-  const clang::Expr* finExpr = expr->IgnoreParenCasts();
-  // Case: return new __type__
-  if (const auto* CNE = dyn_cast<CXXNewExpr>(finExpr))
-    return handleNew(CNE);
+  // Do not analyze lambda functions' bodies.
+  bool TraverseLambdaExpr(clang::LambdaExpr*) { return true; }
 
-  // Case: returns a variable
-  if (const auto* DRE = dyn_cast<DeclRefExpr>(finExpr)) {
-    if (const auto* VD = dyn_cast<VarDecl>(DRE->getDecl())) {
-      auto it = varMap.find(VD);
-      if (it != varMap.end())
-        return it->second;
-    }
-    // FIXME: BindingDecl, NonTypeTemplateParmDecl are not handled
-    return AllocType::None;
+  // Do not analyze inside of TagDecls(structs/unions/class)
+  bool TraverseDecl(clang::Decl* D) {
+    if (llvm::isa_and_nonnull<clang::TagDecl>(D))
+      return true;
+    return RecursiveASTVisitor::TraverseDecl(D);
   }
 
-  // Case: malloc or another func call
-  if (const auto* CE = dyn_cast<CallExpr>(finExpr))
-    return handleCall(CE);
-  return AllocType::None;
-}
+  bool VisitVarDecl(VarDecl* VD) {
+    Expr* expr = VD->getInit();
+    if (expr)
+      varMap[VD] = handleExpr(expr);
+    else
+      varMap[VD] = AllocType::None;
+    return true;
+  }
 
-static std::vector<const ReturnStmt*>
-getAllRetStmt(const clang::CompoundStmt* CS) {
-  struct RetStmtVisitor : RecursiveASTVisitor<RetStmtVisitor> {
-    std::vector<const ReturnStmt*> vec;
-    bool VisitReturnStmt(ReturnStmt* RS) {
-      vec.push_back(RS);
+  bool VisitBinaryOperator(clang::BinaryOperator* BO) {
+    if (BO->getOpcode() != BO_Assign)
       return true;
-    }
-  };
-  RetStmtVisitor Visitor;
-  Visitor.TraverseStmt(const_cast<CompoundStmt*>(CS));
-  return Visitor.vec;
-}
-
-static std::unordered_map<const VarDecl*, AllocType>
-getAllVarDecl(const clang::CompoundStmt* CS) {
-  struct VarVisitor : RecursiveASTVisitor<VarVisitor> {
-    std::unordered_map<const VarDecl*, AllocType> varMap;
-    bool VisitVarDecl(VarDecl* VD) {
-      Expr* expr = VD->getInit();
-      if (expr)
-        varMap[VD] = handleExpr(expr, varMap);
-      else
-        varMap[VD] = AllocType::None;
-      return true;
-    }
-
-    bool VisitBinaryOperator(clang::BinaryOperator* BO) {
-      if (BO->getOpcode() != BO_Assign)
-        return true;
-      Expr* LHS = BO->getLHS();
-      LHS = LHS->IgnoreParenCasts();
-      if (auto* DRE = dyn_cast<DeclRefExpr>(LHS)) {
-        if (auto* VD = dyn_cast<VarDecl>(DRE->getDecl())) {
-          Expr* RHS = BO->getRHS();
-          varMap[VD] = handleExpr(RHS, varMap);
-        }
+    Expr* LHS = BO->getLHS();
+    LHS = LHS->IgnoreParenCasts();
+    if (auto* DRE = dyn_cast<DeclRefExpr>(LHS)) {
+      if (auto* VD = dyn_cast<VarDecl>(DRE->getDecl())) {
+        Expr* RHS = BO->getRHS();
+        varMap[VD] = handleExpr(RHS);
       }
-      return true;
     }
-  };
-  VarVisitor Visitor;
-  Visitor.TraverseStmt(const_cast<CompoundStmt*>(CS));
-  return Visitor.varMap;
-}
+    return true;
+  }
 
-static AllocType AnalyzeAllocType(const clang::FunctionDecl* Fn) {
+  bool VisitReturnStmt(ReturnStmt* RS) {
+    const clang::Expr* retExpr = RS->getRetValue();
+    // Tmp is current return statement's AllocType value, result is combination
+    // of previous return statements
+    std::optional<AllocType> tmp = handleExpr(retExpr);
+    if (!tmp.has_value())
+      return true;
+    if (!result.has_value())
+      result = tmp;
+    // If function's allocation behaviour differs between different cases,
+    // analyzer returns unknown.
+    else if (*result != tmp) {
+      result = AllocType::Unknown;
+      return false;
+    }
+    return true;
+  }
+
+  std::optional<AllocType> handleCall(const clang::CallExpr* CE) {
+    if (const auto* FD = CE->getDirectCallee()) {
+      if (FD->getBuiltinID() == Builtin::ID::BImalloc)
+        return AllocType::Malloc;
+      auto it = visitedFuncs.find(FD);
+      if (it == visitedFuncs.end()) {
+        visitedFuncs[FD] = std::nullopt;
+        return AnalyzeAllocType(FD, visitedFuncs);
+      }
+      return it->second;
+    }
+    // Function pointer calle
+    return AllocType::Unknown;
+  }
+
+  static AllocType handleNew(const clang::CXXNewExpr* CNE) {
+    if (CNE->getNumPlacementArgs() > 0)
+      return AllocType::None;
+    if (CNE->isArray())
+      return AllocType::NewArr;
+    return AllocType::New;
+  }
+
+  std::optional<AllocType> handleExpr(const clang::Expr* expr) {
+    const clang::Expr* finExpr = expr->IgnoreParenCasts();
+    // Case: return new __type__
+    if (const auto* CNE = dyn_cast<CXXNewExpr>(finExpr))
+      return handleNew(CNE);
+
+    // Case: returns a variable
+    if (const auto* DRE = dyn_cast<DeclRefExpr>(finExpr)) {
+      if (const auto* VD = dyn_cast<VarDecl>(DRE->getDecl())) {
+        auto it = varMap.find(VD);
+        if (it != varMap.end())
+          return it->second;
+      }
+      // FIXME: BindingDecl, NonTypeTemplateParmDecl are not handled
+      return AllocType::None;
+    }
+
+    // Case: malloc or another func call
+    if (const auto* CE = dyn_cast<CallExpr>(finExpr))
+      return handleCall(CE);
+    return AllocType::None;
+  }
+};
+} // namespace
+
+static std::optional<AllocType>
+AnalyzeAllocType(const clang::FunctionDecl* Fn,
+                 std::unordered_map<const clang::FunctionDecl*,
+                                    std::optional<AllocType>>& visitedFuncs) {
   const clang::QualType QT = Fn->getReturnType();
   if (!QT->isPointerType())
     return AllocType::None;
@@ -1739,22 +1768,11 @@ static AllocType AnalyzeAllocType(const clang::FunctionDecl* Fn) {
   // FIXME:: try catch blocks are not CompoundStmt, only edge case
   if (!CmpStmt)
     return AllocType::Unknown;
-  std::unordered_map<const VarDecl*, AllocType> varMap = getAllVarDecl(CmpStmt);
-  std::vector<const ReturnStmt*> allRetStmt = getAllRetStmt(CmpStmt);
-  std::optional<AllocType> res;
-  for (const ReturnStmt* retStmt : allRetStmt) {
-    const clang::Expr* retExpr = retStmt->getRetValue();
-    if (retExpr == nullptr)
-      continue;
-    AllocType tmp = handleExpr(retExpr, varMap);
-    if (!res.has_value())
-      res = tmp;
-    // If function's allocation behaviour differs between different cases,
-    // analyzer returns unknown.
-    else if (*res != tmp)
-      return AllocType::Unknown;
-  }
-  return res.value_or(AllocType::None);
+  AllocationTraverser Traverser(visitedFuncs);
+  Traverser.TraverseStmt(const_cast<clang::CompoundStmt*>(CmpStmt));
+  auto res = Traverser.result;
+  visitedFuncs[Fn] = res;
+  return res;
 }
 
 AllocType GetAllocType(ConstFuncRef Fn) {
@@ -1762,7 +1780,11 @@ AllocType GetAllocType(ConstFuncRef Fn) {
   if (Fn) {
     const auto* D = unwrap<Decl>(Fn);
     if (const auto* FD = dyn_cast<FunctionDecl>(D)) {
-      return INTEROP_RETURN(AnalyzeAllocType(FD));
+      std::unordered_map<const clang::FunctionDecl*, std::optional<AllocType>>
+          visitedFuncs;
+      visitedFuncs[FD] = std::nullopt;
+      return INTEROP_RETURN(
+          AnalyzeAllocType(FD, visitedFuncs).value_or(AllocType::None));
     }
   }
   return INTEROP_RETURN(AllocType::None);

--- a/unittests/CppInterOp/FunctionReflectionTest.cpp
+++ b/unittests/CppInterOp/FunctionReflectionTest.cpp
@@ -906,6 +906,45 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_GetAllocType) {
       p += 1;
       return p;
     }
+
+    int* func28(int n){
+      if(n>0)
+        return func28(n-1);
+      return new int;
+    }
+
+    int* func29(int n){
+      if(n>0){
+        int* ptr = func29(n-1);
+        return ptr;
+      }
+      return new int;
+    }
+    int* func31(int n);
+    int* func32(int n);
+
+    int* func30(int n){
+      return func31(n);
+    }
+
+    int* func31(int n){
+      return func32(n-1);
+    }
+
+    int* func32(int n){
+      if(n>0)
+        return func30(n-1);
+      return new int;
+    }
+
+    int* func33(int n){
+      class Klass {
+      public:
+        int* getArr(int m) { return new int[m]; }
+      };                                                   //Inside of struct/class/lambda's are not analyzed
+      auto lam = []() { return (int*)malloc(sizeof(int)); };
+      return new int(n);
+    }
     )";
   TestFixture::CreateInterpreter();
   Interp->declare(code);
@@ -944,6 +983,12 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_GetAllocType) {
   TESTAC(26, Unknown);
   // FIXME: Pointer overwriten by a non-assignment operator
   TESTAC(27, NewArr);
+  TESTAC(28, New);
+  TESTAC(29, New);
+  TESTAC(30, New);
+  TESTAC(31, New);
+  TESTAC(32, New);
+  TESTAC(33, New);
 
 #undef TESTAC
 


### PR DESCRIPTION
I moved helper functions and main analysis mechanism under RASTV struct. Also made almost every AllocType as std::optional, because to represent whether a variable or functions' AllocType value is still under computation or analysis hit a cycle, we needed another enum value, instead of this I made things std::optional . 

Solves #1057 

@Vipul-Cariappa @vgvassilev @aaronj0 