### PR TITLE
FIX: Evaluating assignments on if-else branches

### DIFF
--- a/include/CppInterOp/CppInterOpTypes.h
+++ b/include/CppInterOp/CppInterOpTypes.h
@@ -412,7 +412,10 @@ enum class AllocType : unsigned char {
   NewArr,
   Malloc,
   Unknown,
-  CustomAlloc
+  CustomAlloc,
+  Null,
+  OperatorNew,
+  OperatorNewArr
 };
 
 enum class DeallocType : unsigned char {

--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -1709,6 +1709,9 @@ struct AllocationTraverser : RecursiveASTVisitor<AllocationTraverser> {
   // Result var keeps the combination all possible values of previous return
   // statements
   std::optional<AllocType> result;
+  // A map every branch writes the previous value of overwriten variables
+  std::unordered_map<const clang::VarDecl*, std::optional<AllocType>>* undoLog =
+      nullptr;
 
   AllocationTraverser(std::unordered_map<const clang::FunctionDecl*,
                                          std::optional<AllocType>>& cache)
@@ -1724,6 +1727,109 @@ struct AllocationTraverser : RecursiveASTVisitor<AllocationTraverser> {
     return RecursiveASTVisitor::TraverseDecl(D);
   }
 
+  std::optional<AllocType> join(std::optional<AllocType> a,
+                                std::optional<AllocType> b) {
+    if (a == AllocType::Null)
+      return b;
+
+    if (b == AllocType::Null)
+      return a;
+
+    if (a == b)
+      return a;
+    return AllocType::Unknown;
+  }
+  void undoOnVarMap() {
+    for (auto& [VD, oldVal] : *undoLog) {
+      auto it = varMap.find(VD);
+      if (it == varMap.end())
+        continue;
+      varMap[VD] = oldVal;
+    }
+  }
+
+  bool TraverseIfStmt(clang::IfStmt* IS) {
+    TraverseStmt(IS->getConditionVariableDeclStmt());
+    TraverseStmt(IS->getCond());
+    auto* undoLogCopy = undoLog;
+    std::unordered_map<const clang::VarDecl*, std::optional<AllocType>>
+        undoLogThen;
+    undoLog = &undoLogThen;
+    TraverseStmt(IS->getThen());
+    auto* elseBranch = IS->getElse();
+    // There is no else
+    if (!elseBranch) {
+      for (auto& [VD, val] : undoLogThen) {
+        auto it = varMap.find(VD);
+        if (it == varMap.end())
+          continue;
+        // Overwrite varMap with join of overwriten and previous value
+        it->second = join(val, it->second);
+        // If branch is nested, inform upper branch about your changes
+        if (undoLogCopy)
+          undoLogCopy->try_emplace(VD, val);
+      }
+      undoLog = undoLogCopy;
+      return true;
+    }
+
+    // Save overwriten values in if branch to join
+    std::unordered_map<const clang::VarDecl*, std::optional<AllocType>>
+        valuesInIfBranch;
+    for (auto& [VD, val] : undoLogThen) {
+      auto it = varMap.find(VD);
+      if (it == varMap.end())
+        continue;
+      valuesInIfBranch[VD] = it->second;
+    }
+
+    // Take changes on varMap back before going to else branch
+    undoOnVarMap();
+
+    std::unordered_map<const clang::VarDecl*, std::optional<AllocType>>
+        undoLogElse;
+    undoLog = &undoLogElse;
+    TraverseStmt(elseBranch);
+
+    for (auto& [VD, val] : undoLogElse) {
+      auto it = varMap.find(VD);
+      if (it == varMap.end())
+        continue;
+      auto it2 = valuesInIfBranch.find(VD);
+      // If var is just changed in else branch
+      if (it2 == valuesInIfBranch.end()) {
+        it->second = join(val, it->second);
+        continue;
+      }
+      // If var is changed in both
+      it->second = join(it->second, it2->second);
+    }
+
+    for (auto& [VD, val] : valuesInIfBranch) {
+      auto it = varMap.find(VD);
+      if (it == varMap.end())
+        continue;
+      // If var is just changed in if branch
+      if (undoLogElse.find(VD) == undoLogElse.end()) {
+        it->second = join(val, it->second);
+        continue;
+      }
+      // If var is changed in both, here for extra safety
+      it->second = join(val, it->second);
+    }
+
+    // Inform upper branch about changes done for both inner if and else branch
+    if (undoLogCopy) {
+      for (auto& [VD, val] : undoLogThen)
+        undoLogCopy->try_emplace(VD, val);
+      for (auto& [VD, val] : undoLogElse)
+        undoLogCopy->try_emplace(VD, val);
+    }
+
+    undoLog = undoLogCopy;
+    return true;
+  }
+
   bool VisitVarDecl(VarDecl* VD) {
     Expr* expr = VD->getInit();
     if (expr)
@@ -1734,15 +1840,28 @@ struct AllocationTraverser : RecursiveASTVisitor<AllocationTraverser> {
   }
 
   bool VisitBinaryOperator(clang::BinaryOperator* BO) {
-    if (BO->getOpcode() != BO_Assign)
-      return true;
     Expr* LHS = BO->getLHS();
     LHS = LHS->IgnoreParenCasts();
-    if (auto* DRE = dyn_cast<DeclRefExpr>(LHS)) {
-      if (auto* VD = dyn_cast<VarDecl>(DRE->getDecl())) {
-        Expr* RHS = BO->getRHS();
-        varMap[VD] = handleExpr(RHS);
-      }
+    auto* DRE = dyn_cast<DeclRefExpr>(LHS);
+    if (!DRE)
+      return true;
+
+    auto* VD = dyn_cast<VarDecl>(DRE->getDecl());
+    if (!VD)
+      return true;
+
+    if (BO->getOpcode() == BO_Assign) {
+      if (undoLog)
+        undoLog->try_emplace(VD, varMap[VD]);
+      Expr* RHS = BO->getRHS();
+      varMap[VD] = handleExpr(RHS);
+      return true;
+    }
+    if (BO->isCompoundAssignmentOp()) {
+      if (undoLog)
+        undoLog->try_emplace(VD, varMap[VD]);
+      varMap[VD] = AllocType::Unknown;
+      return true;
     }
     return true;
   }
@@ -1754,14 +1873,15 @@ struct AllocationTraverser : RecursiveASTVisitor<AllocationTraverser> {
     std::optional<AllocType> tmp = handleExpr(retExpr);
     if (!tmp.has_value())
       return true;
-    if (!result.has_value())
+    if (!result.has_value()) {
       result = tmp;
+      return true;
+    }
     // If function's allocation behaviour differs between different cases,
     // analyzer returns unknown.
-    else if (*result != tmp) {
-      result = AllocType::Unknown;
+    result = join(result, tmp);
+    if (result == AllocType::Unknown)
       return false;
-    }
     return true;
   }
 
@@ -1769,6 +1889,19 @@ struct AllocationTraverser : RecursiveASTVisitor<AllocationTraverser> {
     if (const auto* FD = CE->getDirectCallee()) {
       if (FD->getBuiltinID() == Builtin::ID::BImalloc)
         return AllocType::Malloc;
+      if (FD->getBuiltinID() == Builtin::ID::BI__builtin_operator_new)
+        return AllocType::OperatorNew;
+      // Detects operator new/new[]/delete/delete[]
+      if (FD->isReplaceableGlobalAllocationFunction()) {
+        switch (FD->getOverloadedOperator()) {
+        case OO_New:
+          return AllocType::OperatorNew;
+        case OO_Array_New:
+          return AllocType::OperatorNewArr;
+        default:
+          break; // OO_Delete/OO_Array_Delete
+        }
+      }
       auto it = visitedFuncs.find(FD);
       if (it == visitedFuncs.end()) {
         visitedFuncs[FD] = std::nullopt;
@@ -1781,8 +1914,16 @@ struct AllocationTraverser : RecursiveASTVisitor<AllocationTraverser> {
   }
 
   static AllocType handleNew(const clang::CXXNewExpr* CNE) {
-    if (CNE->getNumPlacementArgs() > 0)
-      return AllocType::None;
+    if (CNE->getNumPlacementArgs() > 0) {
+      /*
+      Non-allocating placement allocation functions
+      void* operator new  ( std::size_t count, void* ptr );
+      void* operator new[]( std::size_t count, void* ptr );
+      */
+      const clang::FunctionDecl* OpNew = CNE->getOperatorNew();
+      if (OpNew && OpNew->isReservedGlobalPlacementOperator())
+        return AllocType::None;
+    }
     if (CNE->isArray())
       return AllocType::NewArr;
     return AllocType::New;
@@ -1808,6 +1949,15 @@ struct AllocationTraverser : RecursiveASTVisitor<AllocationTraverser> {
     // Case: malloc or another func call
     if (const auto* CE = dyn_cast<CallExpr>(finExpr))
       return handleCall(CE);
+
+    // Case: NULL, nullptr or (int*)(__integerLiteral__)
+    const clang::Expr* parExpr = expr->IgnoreParens();
+    while (const auto* CE = dyn_cast<CastExpr>(parExpr)) {
+      if (CE->getCastKind() == CK_NullToPointer)
+        return AllocType::Null;
+      parExpr = CE->getSubExpr();
+    }
+
     return AllocType::None;
   }
 };
@@ -1828,6 +1978,8 @@ AnalyzeAllocType(const clang::FunctionDecl* Fn,
   if (!CmpStmt)
     return AllocType::Unknown;
   AllocationTraverser Traverser(visitedFuncs);
+  for (auto* parm : Fn->parameters())
+    Traverser.VisitVarDecl(parm);
   Traverser.TraverseStmt(const_cast<clang::CompoundStmt*>(CmpStmt));
   auto res = Traverser.result;
   visitedFuncs[Fn] = res;

--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -1740,12 +1740,8 @@ struct AllocationTraverser : RecursiveASTVisitor<AllocationTraverser> {
     return AllocType::Unknown;
   }
   void undoOnVarMap() {
-    for (auto& [VD, oldVal] : *undoLog) {
-      auto it = varMap.find(VD);
-      if (it == varMap.end())
-        continue;
+    for (auto& [VD, oldVal] : *undoLog)
       varMap[VD] = oldVal;
-    }
   }
 
   bool TraverseIfStmt(clang::IfStmt* IS) {
@@ -1760,11 +1756,8 @@ struct AllocationTraverser : RecursiveASTVisitor<AllocationTraverser> {
     // There is no else
     if (!elseBranch) {
       for (auto& [VD, val] : undoLogThen) {
-        auto it = varMap.find(VD);
-        if (it == varMap.end())
-          continue;
         // Overwrite varMap with join of overwriten and previous value
-        it->second = join(val, it->second);
+        varMap[VD] = join(val, varMap[VD]);
         // If branch is nested, inform upper branch about your changes
         if (undoLogCopy)
           undoLogCopy->try_emplace(VD, val);
@@ -1776,12 +1769,8 @@ struct AllocationTraverser : RecursiveASTVisitor<AllocationTraverser> {
     // Save overwriten values in if branch to join
     std::unordered_map<const clang::VarDecl*, std::optional<AllocType>>
         valuesInIfBranch;
-    for (auto& [VD, val] : undoLogThen) {
-      auto it = varMap.find(VD);
-      if (it == varMap.end())
-        continue;
-      valuesInIfBranch[VD] = it->second;
-    }
+    for (auto& [VD, val] : undoLogThen)
+      valuesInIfBranch[VD] = varMap[VD];
 
     // Take changes on varMap back before going to else branch
     undoOnVarMap();
@@ -1792,31 +1781,21 @@ struct AllocationTraverser : RecursiveASTVisitor<AllocationTraverser> {
     TraverseStmt(elseBranch);
 
     for (auto& [VD, val] : undoLogElse) {
-      auto it = varMap.find(VD);
-      if (it == varMap.end())
-        continue;
       auto it2 = valuesInIfBranch.find(VD);
       // If var is just changed in else branch
       if (it2 == valuesInIfBranch.end()) {
-        it->second = join(val, it->second);
+        varMap[VD] = join(val, varMap[VD]);
         continue;
       }
       // If var is changed in both
-      it->second = join(it->second, it2->second);
+      varMap[VD] = join(varMap[VD], it2->second);
     }
 
-    for (auto& [VD, val] : valuesInIfBranch) {
-      auto it = varMap.find(VD);
-      if (it == varMap.end())
-        continue;
-      // If var is just changed in if branch
-      if (undoLogElse.find(VD) == undoLogElse.end()) {
-        it->second = join(val, it->second);
-        continue;
-      }
-      // If var is changed in both, here for extra safety
-      it->second = join(val, it->second);
-    }
+    for (auto& [VD, val] : valuesInIfBranch)
+      // If var is changed in both, varMap carries new value from ELSE, if it is
+      // just changed in THEN, varMap carries old value, so both situation
+      // yields to same
+      varMap[VD] = join(val, varMap[VD]);
 
     // Inform upper branch about changes done for both inner if and else branch
     if (undoLogCopy) {
@@ -1847,6 +1826,7 @@ struct AllocationTraverser : RecursiveASTVisitor<AllocationTraverser> {
       return true;
 
     auto* VD = dyn_cast<VarDecl>(DRE->getDecl());
+    // FIXME: BindingDecls are not handled
     if (!VD)
       return true;
 
@@ -1898,6 +1878,7 @@ struct AllocationTraverser : RecursiveASTVisitor<AllocationTraverser> {
           return AllocType::OperatorNew;
         case OO_Array_New:
           return AllocType::OperatorNewArr;
+        // Unreachable code
         default:
           break; // OO_Delete/OO_Array_Delete
         }

--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -1924,6 +1924,9 @@ struct AllocationTraverser : RecursiveASTVisitor<AllocationTraverser> {
           return it->second;
       }
       // FIXME: BindingDecl, NonTypeTemplateParmDecl are not handled
+      if (isa<BindingDecl>(DRE->getDecl()) ||
+          isa<NonTypeTemplateParmDecl>(DRE->getDecl()))
+        return AllocType::Unknown;
       return AllocType::None;
     }
 

--- a/unittests/CppInterOp/FunctionReflectionTest.cpp
+++ b/unittests/CppInterOp/FunctionReflectionTest.cpp
@@ -1730,8 +1730,27 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_GetAllocType) {
     void* func58(){ return __builtin_operator_new(64); }
     void* func59(){int* m = (int*)0; return malloc(sizeof(int));}
 
+    // This test is for testing some lines, does not neccesarily mean something;
+    // But, it also shows how BindingDecls are not handled
+    struct Tuple {
+      int* ptr1;
+      int* ptr2;
+    };
+    int* func70(){
+      int arr[5];
+      arr[0] = 5;
+      arr[1] = 6;
+      int* ptr = (int*)::operator new(sizeof(int));
+      ::operator delete(ptr);
+      Tuple T;
+      T.ptr1 = &arr[0];
+      T.ptr2 = &arr[1];
+      auto [a, b] = T;
+      a = new int;
+      return a;
+    }
     )";
-  TestFixture::CreateInterpreter();
+  TestFixture::CreateInterpreter({"-std=c++17"});
   Interp->declare(code);
 
 #define TESTAC(N, EXP)                                                         \
@@ -1799,6 +1818,7 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_GetAllocType) {
   TESTAC(57, None);
   TESTAC(58, OperatorNew);
   TESTAC(59, Malloc);
+  TESTAC(70, None);
 #undef TESTAC
 
   Cpp::DeleteInterpreter();

--- a/unittests/CppInterOp/FunctionReflectionTest.cpp
+++ b/unittests/CppInterOp/FunctionReflectionTest.cpp
@@ -1818,7 +1818,7 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_GetAllocType) {
   TESTAC(57, None);
   TESTAC(58, OperatorNew);
   TESTAC(59, Malloc);
-  TESTAC(70, None);
+  TESTAC(70, Unknown);
 #undef TESTAC
 
   Cpp::DeleteInterpreter();

--- a/unittests/CppInterOp/FunctionReflectionTest.cpp
+++ b/unittests/CppInterOp/FunctionReflectionTest.cpp
@@ -1469,6 +1469,267 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_GetAllocType) {
       auto lam = []() { return (int*)malloc(sizeof(int)); };
       return new int(n);
     }
+
+    int* func34(int n){
+      int* ptr = nullptr;
+      if(n>0)
+        ptr = new int(n);
+      return ptr;
+    }
+
+    int* func35(int n){
+      int* ptr = nullptr;
+      if(n>0)
+        ptr = new int(n);
+      else
+        ptr = new int(n);
+      return ptr;
+    }
+
+    int* func36(int n){
+      int* ptr = nullptr;
+      if(n>0)
+        ptr = new int(n);
+      else
+        ptr = (int*)malloc(sizeof(int));
+      return ptr;
+    }
+
+    int* func37(int n){
+      int* ptr = nullptr;
+      int* ptr2 = nullptr;
+      if(n>0){
+        ptr = new int(n);
+      } else {
+        ptr2 = new int(n);
+      }
+      return ptr;
+    }
+
+    int* func38(int n){
+      int* ptr = nullptr;
+      if(n>9)
+        ptr = new int(n);
+      else if(n>5)
+        ptr = new int(n);
+      else if(n>2)
+        ptr = new int(n);
+      else
+        ptr = new int(n);
+      return ptr;
+    }
+
+    int* func39(int n){
+      int* ptr = nullptr;
+      if(n>9)
+        ptr = new int(n);
+      else if(n>5)
+        ptr = (int*)malloc(sizeof(int));
+      else if(n>2)
+        ptr = new int(n);
+      else
+        ptr = new int(n);
+      return ptr;
+    }
+
+    int* func40(int n){
+      int* ptr = nullptr;
+      if(n>0){
+        int* tmp = nullptr;
+        if(n>10)
+          tmp = new int(n);
+        else
+          tmp = new int(n);
+        ptr = tmp;
+      }
+      return ptr;
+    }
+
+    int* func41(int n){
+      int* ptr = nullptr;
+      if(n>0){
+        ptr = new int(n);
+        ptr = new int(n);
+      }
+      return ptr;
+    }
+
+    int* func42(int n){
+      int* ptr = nullptr;
+      if(int* tmp = new int(n)){
+        ptr = tmp;
+      }
+      return ptr;
+    }
+
+    int* func43(int n){
+      int* ptr = new int(n);
+      if(n>0){
+        int* tmp = (int*)malloc(sizeof(int));
+        ptr = tmp;
+      }
+      return ptr;
+    }
+
+    int* func44(int n){
+      int* q = NULL;
+      if(n>9){
+
+      }
+      else if(n>5){
+        q = new int(n);
+      }
+      else{
+        q = new int(n);
+      }
+      return q;
+    }
+
+    int* func45(int n){
+      int* x = (int*)0;
+      if(n>5){
+        if(n>8)
+          x = new int(n);
+        else
+          x = new int(n);
+      }
+      return x;
+    }
+
+    int* func46(int n){
+      int* p = nullptr;
+      if(n>20){
+        if(n>15){
+          if(n>10)
+            p = new int(n);
+          else
+            p = new int(n);
+        }
+        else {
+          p = new int(n);
+        }
+      }
+      else {
+        p = new int(n);
+      }
+      return p;
+    }
+
+    int* func47(int n){
+      int* p = nullptr;
+      if(n>20){
+        if(n>15){
+          if(n>10)
+            p = new int(n);
+          else
+            p = new int(n);
+        }
+      }
+      return p;
+    }
+
+    int* func48(int n){
+      int* p = nullptr;
+      int* q = nullptr;
+      if(n>30){
+        q = new int(n);
+        if(n>25){
+          if(n>22)
+            p = new int(n);
+          else
+            p = new int(n);
+        }
+        else {
+          p = new int(n);
+        }
+      }
+      else if(n>20){
+        p = new int(n);
+        if(n>15)
+          q = new int(n);
+        else
+          q = (int*)malloc(sizeof(int));
+      }
+      else {
+        p = new int(n);
+        q = new int(n);
+      }
+      return p;
+    }
+
+    int* func49(int n){
+      int* p = (int*)malloc(sizeof(int));
+      int* q = new int(n);
+      if(n>30){
+        if(n>25){
+          p = (int*)malloc(sizeof(int));
+          if(n>20)
+            q += 1;
+        }
+        else {
+          p = (int*)malloc(sizeof(int));
+        }
+      }
+      return p;
+    }
+
+    int* func50(int n){
+      int* p = nullptr;
+      if(n>40){
+        p = new int(n);
+      }
+      else if(n>30){
+        if(n>25){
+          if(n>20)
+            p = new int(n);
+          else
+            p = (int*)malloc(sizeof(int));
+        }
+      }
+      else if(n>10){
+        p = new int(n);
+      }
+      else {
+        p = new int(n);
+      }
+      return p;
+    }
+
+    int* func51(int n){
+      int* ptr = nullptr;
+      if(ptr = new int(n)){
+
+      }
+      return ptr;
+    }
+
+    int* func52(int n){
+      if(n>0)
+        return new int(n);
+      return NULL;
+    }
+
+    int* func53(int n){
+      int* p = static_cast<int*>(0);
+      if(n>0)
+        p = new int(n);
+      return p;
+    }
+
+    int* func54(int n){
+      int* p;
+      if(n>0)
+        p = new int(n);
+      else
+        p = (int*)malloc(sizeof(int));
+      return p;
+    }
+    void* func55(){ return ::operator new(64); }
+    void* func56(){ return ::operator new[](64); }
+    void* func57(void* buf){ return ::operator new(sizeof(int), buf); }
+    void* func58(){ return __builtin_operator_new(64); }
+    void* func59(){int* m = (int*)0; return malloc(sizeof(int));}
+
     )";
   TestFixture::CreateInterpreter();
   Interp->declare(code);
@@ -1497,7 +1758,7 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_GetAllocType) {
   TESTAC(16, Unknown);
   TESTAC(17, None);
   TESTAC(18, None);
-  TESTAC(19, None);
+  TESTAC(19, Null);
   TESTAC(20, Unknown);
   TESTAC(21, None);
   TESTAC(22, New);
@@ -1505,15 +1766,39 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_GetAllocType) {
   TESTAC(24, New);
   TESTAC(25, NewArr);
   TESTAC(26, Unknown);
-  // FIXME: Pointer overwriten by a non-assignment operator
-  TESTAC(27, NewArr);
+  TESTAC(27, Unknown);
   TESTAC(28, New);
   TESTAC(29, New);
   TESTAC(30, New);
   TESTAC(31, New);
   TESTAC(32, New);
   TESTAC(33, New);
-
+  TESTAC(34, New);
+  TESTAC(35, New);
+  TESTAC(36, Unknown);
+  TESTAC(37, New);
+  TESTAC(38, New);
+  TESTAC(39, Unknown);
+  TESTAC(40, New);
+  TESTAC(41, New);
+  TESTAC(42, New);
+  TESTAC(43, Unknown);
+  TESTAC(44, New);
+  TESTAC(45, New);
+  TESTAC(46, New);
+  TESTAC(47, New);
+  TESTAC(48, New);
+  TESTAC(49, Malloc);
+  TESTAC(50, Unknown);
+  TESTAC(51, New);
+  TESTAC(52, New);
+  TESTAC(53, New);
+  TESTAC(54, Unknown);
+  TESTAC(55, OperatorNew);
+  TESTAC(56, OperatorNewArr);
+  TESTAC(57, None);
+  TESTAC(58, OperatorNew);
+  TESTAC(59, Malloc);
 #undef TESTAC
 
   Cpp::DeleteInterpreter();


### PR DESCRIPTION
Algorithm: 

Instead of copying whole varMap, each branch owns their own undoMap. What undoMap does is, 1)it keeps the original values in varMap to reverse the changes when if branch ends, 2) It keeps the original value of changed variables, and in varMap there is changed version, and when you compare values in varMap and undoMap you find out the deterministic result. undoMap is set as a struct member and keeps the track of undoMap of current branch, it is also kind of like a letter, which inner branches inform their upper branches about what they done, what would be the values if inner did not work.