### PR TITLE
Do not instantiate non-template static data members in GetVariableOffset

### DIFF
--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -2779,9 +2779,21 @@ intptr_t GetVariableOffset(compat::Interpreter& I, Decl* D,
       address = I.getAddressOfGlobal(GD);
     if (!address) {
       if (!VD->hasInit()) {
-        compat::SynthesizingCodeRAII RAII(&getInterp());
-        getSema().InstantiateVariableDefinition(SourceLocation(), VD);
-        VD = VD->getDefinition();
+        // The initializer feeding the constexpr fast path below may live on
+        // an already-parsed out-of-line definition (a non-template class's
+        // static data member, e.g. std::partial_ordering::less): prefer it,
+        // with no Sema work at all. Only a variable instantiated from a
+        // template can need Sema::InstantiateVariableDefinition — and
+        // without an instantiation pattern that call dereferences a null
+        // VarDecl in release builds.
+        if (VarDecl* Def = VD->getDefinition()) {
+          VD = Def;
+        } else if (VD->getTemplateInstantiationPattern()) {
+          compat::SynthesizingCodeRAII RAII(&getInterp());
+          getSema().InstantiateVariableDefinition(SourceLocation(), VD);
+          if (VarDecl* Inst = VD->getDefinition())
+            VD = Inst;
+        }
       }
       if (VD->hasInit() &&
           (VD->isConstexpr() || VD->getType().isConstQualified())) {

--- a/unittests/CppInterOp/VariableReflectionTest.cpp
+++ b/unittests/CppInterOp/VariableReflectionTest.cpp
@@ -340,6 +340,42 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, VariableReflection_GetVariableOffset) {
   EXPECT_TRUE(Cpp::GetVariableOffset(var));
 }
 
+TYPED_TEST(CPPINTEROP_TEST_MODE,
+           VariableReflection_GetVariableOffset_NonTemplateStaticNoInit) {
+  // A non-template class's static data member declared in-class and defined
+  // out-of-line reaches the no-initializer branch with no template
+  // instantiation pattern. Sema::InstantiateVariableDefinition requires a
+  // pattern and dereferences null without one (std::partial_ordering::less
+  // is the in-the-wild shape). Must not crash; must resolve the definition.
+  TestFixture::CreateInterpreter();
+  Cpp::Declare(R"(
+    struct NonTemplateStatic {
+      static const NonTemplateStatic less;
+      int value;
+    };
+    inline constexpr NonTemplateStatic NonTemplateStatic::less{-1};
+  )");
+  Cpp::DeclRef klass = Cpp::GetNamed("NonTemplateStatic");
+  EXPECT_TRUE(klass);
+  Cpp::DeclRef var = Cpp::GetNamed("less", klass);
+  EXPECT_TRUE(var);
+  EXPECT_TRUE(Cpp::GetVariableOffset(var));
+
+  // Declared and never defined: still no pattern and now no definition
+  // either — the query must fail cleanly, not crash.
+  Cpp::Declare(R"(
+    struct NeverDefined {
+      static const NeverDefined missing;
+      int value;
+    };
+  )");
+  Cpp::DeclRef klass2 = Cpp::GetNamed("NeverDefined");
+  EXPECT_TRUE(klass2);
+  Cpp::DeclRef var2 = Cpp::GetNamed("missing", klass2);
+  EXPECT_TRUE(var2);
+  EXPECT_FALSE(Cpp::GetVariableOffset(var2));
+}
+
 #define CODE                                                                   \
   class BaseA {                                                                \
   public:                                                                      \


### PR DESCRIPTION
`Cpp::GetVariableOffset` calls `Sema::InstantiateVariableDefinition` on any static data member whose address is not found and whose declaration has no initializer. That Sema entry point requires a *templated* variable: for a non-template class's static member, `getTemplateInstantiationPattern()` returns null, the assert is compiled out in release builds, and clang dereferences null (`this == nullptr` inside `VarDecl::getDefinition`).

The libstdc++ `<compare>` ordering types hit the exact triple condition — declared in-class without an initializer, defined out-of-line as `inline constexpr` (so no exported symbol to find), not yet JIT-emitted. Minimal repro on a release build:

```cpp
Cpp::Declare("#include <compare>");
Cpp::GetVariableOffset(Cpp::GetNamed("less", Cpp::GetScope("std::partial_ordering")));  // SIGSEGV
```

Per review (keeping the constexpr fast path cheap): an already-parsed out-of-line definition is now resolved *first* — it may carry the initializer the constexpr evaluation consumes, with no Sema work at all — and the pattern-guarded `InstantiateVariableDefinition` is only the fallback for genuinely templated statics. `getDefinition()` is null-checked in both arms; the existing fallthrough then does the right thing for these variables (discardable-ODR linkage → codegen emission → real address). The regression test crashes at exactly this stack without the fix and passes with it.

🤖 Done with the help of [Claude Code](https://claude.com/claude-code) (Fable 5, human in the loop)