### PR TITLE
IsAllocator redesigned and intercommunicating with GetAllocType

### DIFF
--- a/include/CppInterOp/CppInterOpTypes.h
+++ b/include/CppInterOp/CppInterOpTypes.h
@@ -90,6 +90,8 @@ typedef struct CppConstFuncRef {
 
 #else // __cplusplus
 
+#include <optional>
+
 namespace Cpp {
 
 struct DeclRef {
@@ -412,7 +414,6 @@ enum class AllocType : unsigned char {
   NewArr,
   Malloc,
   Unknown,
-  CustomAlloc,
   Null,
   OperatorNew,
   OperatorNewArr

--- a/include/CppInterOp/CppInterOpTypes.h
+++ b/include/CppInterOp/CppInterOpTypes.h
@@ -412,7 +412,10 @@ enum class AllocType : unsigned char {
   NewArr,
   Malloc,
   Unknown,
-  CustomAlloc
+  CustomAlloc,
+  Null,
+  OperatorNew,
+  OperatorNewArr
 };
 
 inline QualKind operator|(QualKind a, QualKind b) {

--- a/include/CppInterOp/CppInterOpTypes.h
+++ b/include/CppInterOp/CppInterOpTypes.h
@@ -413,10 +413,10 @@ enum class AllocType : unsigned char {
   New,
   NewArr,
   Malloc,
-  Unknown,
-  Null,
   OperatorNew,
-  OperatorNewArr
+  OperatorNewArr,
+  Null,
+  Unknown
 };
 
 enum class DeallocType : unsigned char {

--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -1798,7 +1798,7 @@ struct AllocationTraverser : RecursiveASTVisitor<AllocationTraverser> {
       varMap[VD] = handleExpr(RHS);
       return true;
     }
-    if (BO->isCompoundAssignmentOp()) {
+    if (VD->getType()->isPointerType() && BO->isCompoundAssignmentOp()) {
       if (undoLog)
         undoLog->try_emplace(VD, varMap[VD]);
       varMap[VD] = AllocType::Unknown;
@@ -1870,6 +1870,20 @@ struct AllocationTraverser : RecursiveASTVisitor<AllocationTraverser> {
     return AllocType::New;
   }
 
+  static bool isNullOpt(const clang::CXXConstructExpr* CCE) {
+    // Expected: std/cpp::optional constructor
+    const clang::CXXConstructorDecl* CCD = CCE->getConstructor();
+    // optional(nullopt_t) noexcept; -> one arg
+    if (CCD->getNumParams() != 1)
+      return false;
+    clang::QualType ParamTy =
+        CCD->getParamDecl(0)->getType().getNonReferenceType();
+    // FIXME: Copy constructor of optional is not handled
+    if (const auto* CRD = ParamTy->getAsCXXRecordDecl())
+      return CRD->getName() == "nullopt_t";
+    return false;
+  }
+
   std::optional<AllocType> handleExpr(const clang::Expr* expr) {
     const clang::Expr* finExpr = expr->IgnoreParenCasts();
     // Case: return new __type__
@@ -1888,10 +1902,20 @@ struct AllocationTraverser : RecursiveASTVisitor<AllocationTraverser> {
     }
 
     // Case: malloc or another func call
-    if (const auto* CE = dyn_cast<CallExpr>(finExpr))
+    if (const auto* CE = dyn_cast<CallExpr>(finExpr)) {
+      // Case: std::optional<int*> ptr = new int; return *ptr;
+      if (const auto* COCE = dyn_cast<clang::CXXOperatorCallExpr>(CE)) {
+        if (COCE->getOperator() == OverloadedOperatorKind::OO_Star &&
+            !COCE->isInfixBinaryOp())
+          return handleExpr(COCE->getArg(0));
+      }
       return handleCall(CE);
+    }
 
     // Case: NULL, nullptr or (int*)(__integerLiteral__)
+    if (llvm::isa<clang::CXXNullPtrLiteralExpr>(finExpr) ||
+        llvm::isa<clang::GNUNullExpr>(finExpr))
+      return AllocType::Null;
     const clang::Expr* parExpr = expr->IgnoreParens();
     while (const auto* CE = dyn_cast<CastExpr>(parExpr)) {
       if (CE->getCastKind() == CK_NullToPointer)
@@ -1899,6 +1923,23 @@ struct AllocationTraverser : RecursiveASTVisitor<AllocationTraverser> {
       parExpr = CE->getSubExpr();
     }
 
+    // Case: constructor cast
+    if (const auto* CCE = dyn_cast<clang::CXXConstructExpr>(finExpr)) {
+      // std::nullopt or cpp::nullopt
+      if (isNullOpt(CCE))
+        return AllocType::Null;
+      const clang::Expr* stripped = expr->IgnoreParens();
+      // ExprWithCleanups -> ImplicitCastExpr -> CXXConstructExpr pattern
+      if (const auto* EWC = dyn_cast<clang::ExprWithCleanups>(stripped))
+        stripped = EWC->getSubExpr();
+      // We do not want to analyze explicit conversions
+      const auto* ICE = dyn_cast<clang::ImplicitCastExpr>(stripped);
+      bool isImplicitConv =
+          ICE && ICE->getCastKind() == CK_ConstructorConversion;
+      // ImplicitCastExpr -> CXXConstructExpr pattern
+      if (isImplicitConv)
+        return handleExpr(CCE->getArg(0));
+    }
     return AllocType::None;
   }
 };
@@ -1908,8 +1949,8 @@ static std::optional<AllocType>
 AnalyzeAllocType(const clang::FunctionDecl* Fn,
                  std::unordered_map<const clang::FunctionDecl*,
                                     std::optional<AllocType>>& visitedFuncs) {
-  const clang::QualType QT = Fn->getReturnType();
-  if (!QT->isPointerType())
+  QualType QT = Fn->getReturnType();
+  if (!QT->isPointerType() && !QT->isRecordType())
     return AllocType::None;
   const Stmt* fnBody = Fn->getBody();
   if (!fnBody)

--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -1650,6 +1650,9 @@ struct AllocationTraverser : RecursiveASTVisitor<AllocationTraverser> {
   // Result var keeps the combination all possible values of previous return
   // statements
   std::optional<AllocType> result;
+  // A map every branch writes the previous value of overwriten variables
+  std::unordered_map<const clang::VarDecl*, std::optional<AllocType>>* undoLog =
+      nullptr;
 
   AllocationTraverser(std::unordered_map<const clang::FunctionDecl*,
                                          std::optional<AllocType>>& cache)
@@ -1665,6 +1668,109 @@ struct AllocationTraverser : RecursiveASTVisitor<AllocationTraverser> {
     return RecursiveASTVisitor::TraverseDecl(D);
   }
 
+  std::optional<AllocType> join(std::optional<AllocType> a,
+                                std::optional<AllocType> b) {
+    if (a == AllocType::Null)
+      return b;
+
+    if (b == AllocType::Null)
+      return a;
+
+    if (a == b)
+      return a;
+    return AllocType::Unknown;
+  }
+  void undoOnVarMap() {
+    for (auto& [VD, oldVal] : *undoLog) {
+      auto it = varMap.find(VD);
+      if (it == varMap.end())
+        continue;
+      varMap[VD] = oldVal;
+    }
+  }
+
+  bool TraverseIfStmt(clang::IfStmt* IS) {
+    TraverseStmt(IS->getConditionVariableDeclStmt());
+    TraverseStmt(IS->getCond());
+    auto* undoLogCopy = undoLog;
+    std::unordered_map<const clang::VarDecl*, std::optional<AllocType>>
+        undoLogThen;
+    undoLog = &undoLogThen;
+    TraverseStmt(IS->getThen());
+    auto* elseBranch = IS->getElse();
+    // There is no else
+    if (!elseBranch) {
+      for (auto& [VD, val] : undoLogThen) {
+        auto it = varMap.find(VD);
+        if (it == varMap.end())
+          continue;
+        // Overwrite varMap with join of overwriten and previous value
+        it->second = join(val, it->second);
+        // If branch is nested, inform upper branch about your changes
+        if (undoLogCopy)
+          undoLogCopy->try_emplace(VD, val);
+      }
+      undoLog = undoLogCopy;
+      return true;
+    }
+
+    // Save overwriten values in if branch to join
+    std::unordered_map<const clang::VarDecl*, std::optional<AllocType>>
+        valuesInIfBranch;
+    for (auto& [VD, val] : undoLogThen) {
+      auto it = varMap.find(VD);
+      if (it == varMap.end())
+        continue;
+      valuesInIfBranch[VD] = it->second;
+    }
+
+    // Take changes on varMap back before going to else branch
+    undoOnVarMap();
+
+    std::unordered_map<const clang::VarDecl*, std::optional<AllocType>>
+        undoLogElse;
+    undoLog = &undoLogElse;
+    TraverseStmt(elseBranch);
+
+    for (auto& [VD, val] : undoLogElse) {
+      auto it = varMap.find(VD);
+      if (it == varMap.end())
+        continue;
+      auto it2 = valuesInIfBranch.find(VD);
+      // If var is just changed in else branch
+      if (it2 == valuesInIfBranch.end()) {
+        it->second = join(val, it->second);
+        continue;
+      }
+      // If var is changed in both
+      it->second = join(it->second, it2->second);
+    }
+
+    for (auto& [VD, val] : valuesInIfBranch) {
+      auto it = varMap.find(VD);
+      if (it == varMap.end())
+        continue;
+      // If var is just changed in if branch
+      if (undoLogElse.find(VD) == undoLogElse.end()) {
+        it->second = join(val, it->second);
+        continue;
+      }
+      // If var is changed in both, here for extra safety
+      it->second = join(val, it->second);
+    }
+
+    // Inform upper branch about changes done for both inner if and else branch
+    if (undoLogCopy) {
+      for (auto& [VD, val] : undoLogThen)
+        undoLogCopy->try_emplace(VD, val);
+      for (auto& [VD, val] : undoLogElse)
+        undoLogCopy->try_emplace(VD, val);
+    }
+
+    undoLog = undoLogCopy;
+    return true;
+  }
+
   bool VisitVarDecl(VarDecl* VD) {
     Expr* expr = VD->getInit();
     if (expr)
@@ -1675,15 +1781,28 @@ struct AllocationTraverser : RecursiveASTVisitor<AllocationTraverser> {
   }
 
   bool VisitBinaryOperator(clang::BinaryOperator* BO) {
-    if (BO->getOpcode() != BO_Assign)
-      return true;
     Expr* LHS = BO->getLHS();
     LHS = LHS->IgnoreParenCasts();
-    if (auto* DRE = dyn_cast<DeclRefExpr>(LHS)) {
-      if (auto* VD = dyn_cast<VarDecl>(DRE->getDecl())) {
-        Expr* RHS = BO->getRHS();
-        varMap[VD] = handleExpr(RHS);
-      }
+    auto* DRE = dyn_cast<DeclRefExpr>(LHS);
+    if (!DRE)
+      return true;
+
+    auto* VD = dyn_cast<VarDecl>(DRE->getDecl());
+    if (!VD)
+      return true;
+
+    if (BO->getOpcode() == BO_Assign) {
+      if (undoLog)
+        undoLog->try_emplace(VD, varMap[VD]);
+      Expr* RHS = BO->getRHS();
+      varMap[VD] = handleExpr(RHS);
+      return true;
+    }
+    if (BO->isCompoundAssignmentOp()) {
+      if (undoLog)
+        undoLog->try_emplace(VD, varMap[VD]);
+      varMap[VD] = AllocType::Unknown;
+      return true;
     }
     return true;
   }
@@ -1695,14 +1814,15 @@ struct AllocationTraverser : RecursiveASTVisitor<AllocationTraverser> {
     std::optional<AllocType> tmp = handleExpr(retExpr);
     if (!tmp.has_value())
       return true;
-    if (!result.has_value())
+    if (!result.has_value()) {
       result = tmp;
+      return true;
+    }
     // If function's allocation behaviour differs between different cases,
     // analyzer returns unknown.
-    else if (*result != tmp) {
-      result = AllocType::Unknown;
+    result = join(result, tmp);
+    if (result == AllocType::Unknown)
       return false;
-    }
     return true;
   }
 
@@ -1710,6 +1830,19 @@ struct AllocationTraverser : RecursiveASTVisitor<AllocationTraverser> {
     if (const auto* FD = CE->getDirectCallee()) {
       if (FD->getBuiltinID() == Builtin::ID::BImalloc)
         return AllocType::Malloc;
+      if (FD->getBuiltinID() == Builtin::ID::BI__builtin_operator_new)
+        return AllocType::OperatorNew;
+      // Detects operator new/new[]/delete/delete[]
+      if (FD->isReplaceableGlobalAllocationFunction()) {
+        switch (FD->getOverloadedOperator()) {
+        case OO_New:
+          return AllocType::OperatorNew;
+        case OO_Array_New:
+          return AllocType::OperatorNewArr;
+        default:
+          break; // OO_Delete/OO_Array_Delete
+        }
+      }
       auto it = visitedFuncs.find(FD);
       if (it == visitedFuncs.end()) {
         visitedFuncs[FD] = std::nullopt;
@@ -1722,8 +1855,16 @@ struct AllocationTraverser : RecursiveASTVisitor<AllocationTraverser> {
   }
 
   static AllocType handleNew(const clang::CXXNewExpr* CNE) {
-    if (CNE->getNumPlacementArgs() > 0)
-      return AllocType::None;
+    if (CNE->getNumPlacementArgs() > 0) {
+      /*
+      Non-allocating placement allocation functions
+      void* operator new  ( std::size_t count, void* ptr );
+      void* operator new[]( std::size_t count, void* ptr );
+      */
+      const clang::FunctionDecl* OpNew = CNE->getOperatorNew();
+      if (OpNew && OpNew->isReservedGlobalPlacementOperator())
+        return AllocType::None;
+    }
     if (CNE->isArray())
       return AllocType::NewArr;
     return AllocType::New;
@@ -1749,6 +1890,15 @@ struct AllocationTraverser : RecursiveASTVisitor<AllocationTraverser> {
     // Case: malloc or another func call
     if (const auto* CE = dyn_cast<CallExpr>(finExpr))
       return handleCall(CE);
+
+    // Case: NULL, nullptr or (int*)(__integerLiteral__)
+    const clang::Expr* parExpr = expr->IgnoreParens();
+    while (const auto* CE = dyn_cast<CastExpr>(parExpr)) {
+      if (CE->getCastKind() == CK_NullToPointer)
+        return AllocType::Null;
+      parExpr = CE->getSubExpr();
+    }
+
     return AllocType::None;
   }
 };
@@ -1769,6 +1919,8 @@ AnalyzeAllocType(const clang::FunctionDecl* Fn,
   if (!CmpStmt)
     return AllocType::Unknown;
   AllocationTraverser Traverser(visitedFuncs);
+  for (auto* parm : Fn->parameters())
+    Traverser.VisitVarDecl(parm);
   Traverser.TraverseStmt(const_cast<clang::CompoundStmt*>(CmpStmt));
   auto res = Traverser.result;
   visitedFuncs[Fn] = res;

--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -1771,7 +1771,9 @@ AllocType IsAllocator(ConstFuncRef Fn) {
   INTEROP_TRACE(Fn);
   if (!Fn)
     return INTEROP_RETURN(AllocType::Unknown);
-  const auto* D = unwrap<clang::Decl>(Fn);
+  const auto* D = UnwrapUsingShadowToFunction(unwrap<clang::Decl>(Fn));
+  if (const auto* FTD = dyn_cast<FunctionTemplateDecl>(D))
+    D = FTD->getTemplatedDecl();
   if (const auto* FD = dyn_cast<FunctionDecl>(D)) {
     if (FD->getBuiltinID() == Builtin::ID::BImalloc)
       return INTEROP_RETURN(AllocType::Malloc);
@@ -1814,8 +1816,6 @@ AllocType IsAllocator(ConstFuncRef Fn) {
     }
   }
 
-  // Nullopt is returned because when analyzer calls this API it should know
-  // whether an attribute injected before or FD has a meaningful attribute
   return INTEROP_RETURN(AllocType::Unknown);
 }
 

--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -1767,31 +1767,52 @@ TypeRef GetFunctionReturnType(ConstFuncRef func) {
   return INTEROP_RETURN(nullptr);
 }
 
-bool IsAllocator(ConstFuncRef Fn) {
+std::optional<AllocType> IsAllocator(ConstFuncRef Fn) {
   INTEROP_TRACE(Fn);
   if (!Fn)
-    return INTEROP_RETURN(false);
+    return INTEROP_RETURN(AllocType::Unknown);
   const auto* D = unwrap<clang::Decl>(Fn);
   if (const auto* FD = dyn_cast<FunctionDecl>(D)) {
     if (FD->getBuiltinID() == Builtin::ID::BImalloc)
-      return INTEROP_RETURN(true);
+      return INTEROP_RETURN(AllocType::Malloc);
     if (const auto* FDA = FD->getAttr<RestrictAttr>()) {
       if (FDA->getSemanticSpelling() != RestrictAttr::Declspec_restrict)
-        return INTEROP_RETURN(true);
+        return INTEROP_RETURN(AllocType::Malloc);
     }
 
     if (const auto* FDA = FD->getAttr<OwnershipAttr>()) {
       if (FDA->getOwnKind() == OwnershipAttr::Returns)
-        return INTEROP_RETURN(true);
+        return INTEROP_RETURN(AllocType::Malloc);
     }
 
     if (FD->hasAttr<CFReturnsRetainedAttr>() ||
         FD->hasAttr<NSReturnsRetainedAttr>() ||
         FD->hasAttr<OSReturnsRetainedAttr>())
-      return INTEROP_RETURN(true);
+      return INTEROP_RETURN(AllocType::Malloc);
+    for (const auto* attr : FD->specific_attrs<clang::AnnotateAttr>()) {
+      llvm::StringRef attrName = attr->getAnnotation();
+      if (attrName == "cppAllocNone")
+        return INTEROP_RETURN(AllocType::None);
+      if (attrName == "cppAllocNew")
+        return INTEROP_RETURN(AllocType::New);
+      if (attrName == "cppAllocNewArr")
+        return INTEROP_RETURN(AllocType::NewArr);
+      if (attrName == "cppAllocMalloc")
+        return INTEROP_RETURN(AllocType::Malloc);
+      if (attrName == "cppAllocUnknown")
+        return INTEROP_RETURN(AllocType::Unknown);
+      if (attrName == "cppAllocNull")
+        return INTEROP_RETURN(AllocType::Null);
+      if (attrName == "cppAllocOperatorNew")
+        return INTEROP_RETURN(AllocType::OperatorNew);
+      if (attrName == "cppAllocOperatorNewArr")
+        return INTEROP_RETURN(AllocType::OperatorNewArr);
+    }
   }
 
-  return INTEROP_RETURN(false);
+  // Nullopt is returned because when analyzer calls this API it should know
+  // whether an attribute injected before or FD has a meaningful attribute
+  return INTEROP_RETURN(std::nullopt);
 }
 
 bool IsDeallocator(ConstFuncRef Fn) {
@@ -1819,7 +1840,7 @@ bool IsFunctionProtoType(ConstTypeRef TyRef) {
 }
 
 static std::optional<AllocType>
-AnalyzeAllocType(const clang::FunctionDecl* Fn,
+AnalyzeAllocType(clang::FunctionDecl* Fn,
                  std::unordered_map<const clang::FunctionDecl*,
                                     std::optional<AllocType>>& visitedFuncs);
 
@@ -1987,8 +2008,8 @@ struct AllocationTraverser : RecursiveASTVisitor<AllocationTraverser> {
     return true;
   }
 
-  std::optional<AllocType> handleCall(const clang::CallExpr* CE) {
-    if (const auto* FD = CE->getDirectCallee()) {
+  std::optional<AllocType> handleCall(clang::CallExpr* CE) {
+    if (auto* FD = CE->getDirectCallee()) {
       if (FD->getBuiltinID() == Builtin::ID::BImalloc)
         return AllocType::Malloc;
       if (FD->getBuiltinID() == Builtin::ID::BI__builtin_operator_new)
@@ -2007,7 +2028,10 @@ struct AllocationTraverser : RecursiveASTVisitor<AllocationTraverser> {
       }
       auto it = visitedFuncs.find(FD);
       if (it == visitedFuncs.end()) {
-        visitedFuncs[FD] = std::nullopt;
+        auto storedResult = IsAllocator(wrap<ConstFuncRef>(FD));
+        visitedFuncs[FD] = storedResult;
+        if (storedResult != std::nullopt)
+          return storedResult;
         return AnalyzeAllocType(FD, visitedFuncs);
       }
       return it->second;
@@ -2054,7 +2078,7 @@ struct AllocationTraverser : RecursiveASTVisitor<AllocationTraverser> {
 
     // Case: malloc or another func call
     if (const auto* CE = dyn_cast<CallExpr>(finExpr))
-      return handleCall(CE);
+      return handleCall(const_cast<CallExpr*>(CE));
 
     // Case: NULL, nullptr or (int*)(__integerLiteral__)
     const clang::Expr* parExpr = expr->IgnoreParens();
@@ -2070,33 +2094,33 @@ struct AllocationTraverser : RecursiveASTVisitor<AllocationTraverser> {
 } // namespace
 
 static std::optional<AllocType>
-AnalyzeAllocType(const clang::FunctionDecl* Fn,
+AnalyzeAllocType(clang::FunctionDecl* Fn,
                  std::unordered_map<const clang::FunctionDecl*,
                                     std::optional<AllocType>>& visitedFuncs) {
   const clang::QualType QT = Fn->getReturnType();
   if (!QT->isPointerType())
     return AllocType::None;
-  const Stmt* fnBody = Fn->getBody();
+  Stmt* fnBody = Fn->getBody();
   if (!fnBody)
     return AllocType::Unknown;
-  const auto* CmpStmt = dyn_cast<clang::CompoundStmt>(fnBody);
+  auto* CmpStmt = dyn_cast<clang::CompoundStmt>(fnBody);
   // FIXME:: try catch blocks are not CompoundStmt, only edge case
   if (!CmpStmt)
     return AllocType::Unknown;
   AllocationTraverser Traverser(visitedFuncs);
   for (auto* parm : Fn->parameters())
     Traverser.VisitVarDecl(parm);
-  Traverser.TraverseStmt(const_cast<clang::CompoundStmt*>(CmpStmt));
+  Traverser.TraverseStmt(CmpStmt);
   auto res = Traverser.result;
   visitedFuncs[Fn] = res;
   return res;
 }
 
-AllocType GetAllocType(ConstFuncRef Fn) {
+AllocType GetAllocType(FuncRef Fn) {
   INTEROP_TRACE(Fn);
   if (Fn) {
-    const auto* D = unwrap<Decl>(Fn);
-    if (const auto* FD = dyn_cast<FunctionDecl>(D)) {
+    auto* D = unwrap<Decl>(Fn);
+    if (auto* FD = dyn_cast<FunctionDecl>(D)) {
       std::unordered_map<const clang::FunctionDecl*, std::optional<AllocType>>
           visitedFuncs;
       visitedFuncs[FD] = std::nullopt;

--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -1767,7 +1767,7 @@ TypeRef GetFunctionReturnType(ConstFuncRef func) {
   return INTEROP_RETURN(nullptr);
 }
 
-std::optional<AllocType> IsAllocator(ConstFuncRef Fn) {
+AllocType IsAllocator(ConstFuncRef Fn) {
   INTEROP_TRACE(Fn);
   if (!Fn)
     return INTEROP_RETURN(AllocType::Unknown);
@@ -1789,8 +1789,16 @@ std::optional<AllocType> IsAllocator(ConstFuncRef Fn) {
         FD->hasAttr<NSReturnsRetainedAttr>() ||
         FD->hasAttr<OSReturnsRetainedAttr>())
       return INTEROP_RETURN(AllocType::Malloc);
-    for (const auto* attr : FD->specific_attrs<clang::AnnotateAttr>()) {
-      llvm::StringRef attrName = attr->getAnnotation();
+
+    for (const auto* attr : FD->attrs()) {
+      llvm::StringRef attrName;
+      if (const auto* swiftAttr = dyn_cast<clang::SwiftAttrAttr>(attr))
+        attrName = swiftAttr->getAttribute();
+      else if (const auto* annotateAttr = dyn_cast<clang::AnnotateAttr>(attr))
+        attrName = annotateAttr->getAnnotation();
+      else
+        continue;
+      attrName.consume_front("returns_");
       if (attrName == "cppAllocNone")
         return INTEROP_RETURN(AllocType::None);
       if (attrName == "cppAllocNew")
@@ -1799,10 +1807,6 @@ std::optional<AllocType> IsAllocator(ConstFuncRef Fn) {
         return INTEROP_RETURN(AllocType::NewArr);
       if (attrName == "cppAllocMalloc")
         return INTEROP_RETURN(AllocType::Malloc);
-      if (attrName == "cppAllocUnknown")
-        return INTEROP_RETURN(AllocType::Unknown);
-      if (attrName == "cppAllocNull")
-        return INTEROP_RETURN(AllocType::Null);
       if (attrName == "cppAllocOperatorNew")
         return INTEROP_RETURN(AllocType::OperatorNew);
       if (attrName == "cppAllocOperatorNewArr")
@@ -1812,7 +1816,7 @@ std::optional<AllocType> IsAllocator(ConstFuncRef Fn) {
 
   // Nullopt is returned because when analyzer calls this API it should know
   // whether an attribute injected before or FD has a meaningful attribute
-  return INTEROP_RETURN(std::nullopt);
+  return INTEROP_RETURN(AllocType::Unknown);
 }
 
 bool IsDeallocator(ConstFuncRef Fn) {
@@ -1840,7 +1844,7 @@ bool IsFunctionProtoType(ConstTypeRef TyRef) {
 }
 
 static std::optional<AllocType>
-AnalyzeAllocType(clang::FunctionDecl* Fn,
+AnalyzeAllocType(const clang::FunctionDecl* Fn,
                  std::unordered_map<const clang::FunctionDecl*,
                                     std::optional<AllocType>>& visitedFuncs);
 
@@ -2008,8 +2012,8 @@ struct AllocationTraverser : RecursiveASTVisitor<AllocationTraverser> {
     return true;
   }
 
-  std::optional<AllocType> handleCall(clang::CallExpr* CE) {
-    if (auto* FD = CE->getDirectCallee()) {
+  std::optional<AllocType> handleCall(const clang::CallExpr* CE) {
+    if (const auto* FD = CE->getDirectCallee()) {
       if (FD->getBuiltinID() == Builtin::ID::BImalloc)
         return AllocType::Malloc;
       if (FD->getBuiltinID() == Builtin::ID::BI__builtin_operator_new)
@@ -2030,7 +2034,7 @@ struct AllocationTraverser : RecursiveASTVisitor<AllocationTraverser> {
       if (it == visitedFuncs.end()) {
         auto storedResult = IsAllocator(wrap<ConstFuncRef>(FD));
         visitedFuncs[FD] = storedResult;
-        if (storedResult != std::nullopt)
+        if (storedResult != AllocType::Unknown)
           return storedResult;
         return AnalyzeAllocType(FD, visitedFuncs);
       }
@@ -2078,7 +2082,7 @@ struct AllocationTraverser : RecursiveASTVisitor<AllocationTraverser> {
 
     // Case: malloc or another func call
     if (const auto* CE = dyn_cast<CallExpr>(finExpr))
-      return handleCall(const_cast<CallExpr*>(CE));
+      return handleCall(CE);
 
     // Case: NULL, nullptr or (int*)(__integerLiteral__)
     const clang::Expr* parExpr = expr->IgnoreParens();
@@ -2094,33 +2098,33 @@ struct AllocationTraverser : RecursiveASTVisitor<AllocationTraverser> {
 } // namespace
 
 static std::optional<AllocType>
-AnalyzeAllocType(clang::FunctionDecl* Fn,
+AnalyzeAllocType(const clang::FunctionDecl* Fn,
                  std::unordered_map<const clang::FunctionDecl*,
                                     std::optional<AllocType>>& visitedFuncs) {
   const clang::QualType QT = Fn->getReturnType();
   if (!QT->isPointerType())
     return AllocType::None;
-  Stmt* fnBody = Fn->getBody();
+  const Stmt* fnBody = Fn->getBody();
   if (!fnBody)
     return AllocType::Unknown;
-  auto* CmpStmt = dyn_cast<clang::CompoundStmt>(fnBody);
+  const auto* CmpStmt = dyn_cast<clang::CompoundStmt>(fnBody);
   // FIXME:: try catch blocks are not CompoundStmt, only edge case
   if (!CmpStmt)
     return AllocType::Unknown;
   AllocationTraverser Traverser(visitedFuncs);
   for (auto* parm : Fn->parameters())
     Traverser.VisitVarDecl(parm);
-  Traverser.TraverseStmt(CmpStmt);
+  Traverser.TraverseStmt(const_cast<clang::CompoundStmt*>(CmpStmt));
   auto res = Traverser.result;
   visitedFuncs[Fn] = res;
   return res;
 }
 
-AllocType GetAllocType(FuncRef Fn) {
+AllocType GetAllocType(ConstFuncRef Fn) {
   INTEROP_TRACE(Fn);
   if (Fn) {
-    auto* D = unwrap<Decl>(Fn);
-    if (auto* FD = dyn_cast<FunctionDecl>(D)) {
+    const auto* D = unwrap<Decl>(Fn);
+    if (const auto* FD = dyn_cast<FunctionDecl>(D)) {
       std::unordered_map<const clang::FunctionDecl*, std::optional<AllocType>>
           visitedFuncs;
       visitedFuncs[FD] = std::nullopt;

--- a/lib/CppInterOp/CppInterOp.td
+++ b/lib/CppInterOp/CppInterOp.td
@@ -788,7 +788,7 @@ def GetAllocType: CppInterOpAPI {
 
   let ReturnType = "AllocType";
   let Args = [
-    Arg<"ConstFuncRef", "Fn">
+    Arg<"FuncRef", "Fn">
   ];
 }
 
@@ -1304,7 +1304,7 @@ def GetFunctionReturnType : CppInterOpAPI {
 
 def IsAllocator : CppInterOpAPI {
   let Doc = "Checks if the provided function is an allocator function";
-  let ReturnType = "bool";
+  let ReturnType = "std::optional<AllocType>";
   let Args = [
     Arg<"ConstFuncRef", "func">
   ];

--- a/lib/CppInterOp/CppInterOp.td
+++ b/lib/CppInterOp/CppInterOp.td
@@ -788,7 +788,7 @@ def GetAllocType: CppInterOpAPI {
 
   let ReturnType = "AllocType";
   let Args = [
-    Arg<"FuncRef", "Fn">
+    Arg<"ConstFuncRef", "Fn">
   ];
 }
 
@@ -1304,7 +1304,7 @@ def GetFunctionReturnType : CppInterOpAPI {
 
 def IsAllocator : CppInterOpAPI {
   let Doc = "Checks if the provided function is an allocator function";
-  let ReturnType = "std::optional<AllocType>";
+  let ReturnType = "AllocType";
   let Args = [
     Arg<"ConstFuncRef", "func">
   ];

--- a/unittests/CppInterOp/APINotes/TestAttributeMerge.h
+++ b/unittests/CppInterOp/APINotes/TestAttributeMerge.h
@@ -1,0 +1,14 @@
+#ifndef UNITTESTS_CPPINTEROP_TESTATTRIBUTEMERGE_H
+#define UNITTESTS_CPPINTEROP_TESTATTRIBUTEMERGE_H
+
+[[clang::annotate("cppAllocMalloc")]] void* mergeFunc();
+
+#pragma clang attribute push([[clang::annotate("cppAllocNew")]],               \
+                             apply_to = function)
+int* overloadFunc();
+int* overloadFunc(int n);
+#pragma clang attribute pop
+
+[[clang::annotate("cppAllocMalloc")]] void* func71_helper();
+
+#endif

--- a/unittests/CppInterOp/APINotes/TestHeader.apinotes
+++ b/unittests/CppInterOp/APINotes/TestHeader.apinotes
@@ -4,3 +4,17 @@ Functions:
     RetainCountConvention: CFReturnsRetained
   - Name: testNotAlloc
     RetainCountConvention: CFReturnsNotRetained
+  - Name: testMalloc
+    SwiftReturnOwnership: cppAllocMalloc
+  - Name: testNew
+    SwiftReturnOwnership: cppAllocNew
+  - Name: testNewArr
+    SwiftReturnOwnership: cppAllocNewArr
+  - Name: testOperatorNew
+    SwiftReturnOwnership: cppAllocOperatorNew
+  - Name: testOperatorNewArr
+    SwiftReturnOwnership: cppAllocOperatorNewArr
+  - Name: testNone
+    SwiftReturnOwnership: cppAllocNone
+  - Name: testWeirdAttr
+    SwiftReturnOwnership: someWeirdAttr

--- a/unittests/CppInterOp/APINotes/TestHeader.h
+++ b/unittests/CppInterOp/APINotes/TestHeader.h
@@ -4,4 +4,11 @@
 void* testAlloc(int value);
 void testNotAlloc(void* ptr);
 
+void* testMalloc();
+void* testNew();
+void* testNewArr();
+void* testOperatorNew();
+void* testOperatorNewArr();
+void* testNone();
+void* testWeirdAttr();
 #endif

--- a/unittests/CppInterOp/FunctionReflectionTest.cpp
+++ b/unittests/CppInterOp/FunctionReflectionTest.cpp
@@ -833,6 +833,7 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_GetAllocType) {
   std::string code = R"(
     #include <new>
     #include <stdlib.h>
+    #include <optional>
 
     int* func0(int n){ return new int(n); }
 
@@ -1206,8 +1207,79 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_GetAllocType) {
     void* func58(){ return __builtin_operator_new(64); }
     void* func59(){int* m = (int*)0; return malloc(sizeof(int));}
 
+    template <typename T>
+    std::optional<T*> func60_helper(){
+      T* ptr = new T;
+      return ptr;
+    }
+
+    std::optional<int*> func60(){
+      return func60_helper<int>();
+    }
+
+    std::optional<int*> func61(int n){
+      if(n>0)
+        return std::nullopt;
+      return new int;
+    }
+
+    struct Empty { Empty() {} };
+    Empty func62() {
+      Empty e;
+      return e;
+    }
+
+    struct Wrapper { int a, b; Wrapper(int x, int y) : a(x), b(y) {} };
+    Wrapper func63() {
+      int a = 1, b = 2;
+      return Wrapper(a, b);
+    }
+
+    Wrapper func64() {
+      int a = 1, b = 2;
+      return {a, b};
+    }
+
+    int* func65(){
+      auto ptr = func61(10);
+      if(ptr)
+        return *ptr;
+      return nullptr;
+    }
+
+    struct Box {
+    int* p;
+    Box(int* p) : p(p) {}
+    Box operator*(const Box& o) const { return Box(nullptr); }
+    };
+    Box func66() {
+      Box a(new int);
+      Box b(nullptr);
+      return a * b;
+    }
+
+    std::optional<int*> func67(){
+      return nullptr;
+    }
+
+    int* func68(){
+      int tmp = 10;
+      int* m = (int*)tmp;
+      for(int i = 0; i < 10; m+=1){
+        return m;
+      }
+      return m;
+    }
+
+    std::optional<int*> func69() {
+      std::optional<int*> a = new int;
+      //FIXME: Copy constructor is called, which takes one arg but is not nullopt constructor
+      //so it returns none, look at isNullOpt(const clang::CXXConstructExpr* CCE) function
+      std::optional<int*> b = a;
+      return b;
+    }
     )";
-  TestFixture::CreateInterpreter();
+  TestFixture::CreateInterpreter({"-std=c++17"});
   Interp->declare(code);
 
 #define TESTAC(N, EXP)                                                         \
@@ -1275,6 +1347,16 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_GetAllocType) {
   TESTAC(57, None);
   TESTAC(58, OperatorNew);
   TESTAC(59, Malloc);
+  TESTAC(60, New);
+  TESTAC(61, New);
+  TESTAC(62, None);
+  TESTAC(63, None);
+  TESTAC(64, None);
+  TESTAC(65, New);
+  TESTAC(66, None);
+  TESTAC(67, Null);
+  TESTAC(68, Unknown);
+  TESTAC(69, None);
 #undef TESTAC
 
   Cpp::DeleteInterpreter();

--- a/unittests/CppInterOp/FunctionReflectionTest.cpp
+++ b/unittests/CppInterOp/FunctionReflectionTest.cpp
@@ -945,6 +945,267 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_GetAllocType) {
       auto lam = []() { return (int*)malloc(sizeof(int)); };
       return new int(n);
     }
+
+    int* func34(int n){
+      int* ptr = nullptr;
+      if(n>0)
+        ptr = new int(n);
+      return ptr;
+    }
+
+    int* func35(int n){
+      int* ptr = nullptr;
+      if(n>0)
+        ptr = new int(n);
+      else
+        ptr = new int(n);
+      return ptr;
+    }
+
+    int* func36(int n){
+      int* ptr = nullptr;
+      if(n>0)
+        ptr = new int(n);
+      else
+        ptr = (int*)malloc(sizeof(int));
+      return ptr;
+    }
+
+    int* func37(int n){
+      int* ptr = nullptr;
+      int* ptr2 = nullptr;
+      if(n>0){
+        ptr = new int(n);
+      } else {
+        ptr2 = new int(n);
+      }
+      return ptr;
+    }
+
+    int* func38(int n){
+      int* ptr = nullptr;
+      if(n>9)
+        ptr = new int(n);
+      else if(n>5)
+        ptr = new int(n);
+      else if(n>2)
+        ptr = new int(n);
+      else
+        ptr = new int(n);
+      return ptr;
+    }
+
+    int* func39(int n){
+      int* ptr = nullptr;
+      if(n>9)
+        ptr = new int(n);
+      else if(n>5)
+        ptr = (int*)malloc(sizeof(int));
+      else if(n>2)
+        ptr = new int(n);
+      else
+        ptr = new int(n);
+      return ptr;
+    }
+
+    int* func40(int n){
+      int* ptr = nullptr;
+      if(n>0){
+        int* tmp = nullptr;
+        if(n>10)
+          tmp = new int(n);
+        else
+          tmp = new int(n);
+        ptr = tmp;
+      }
+      return ptr;
+    }
+
+    int* func41(int n){
+      int* ptr = nullptr;
+      if(n>0){
+        ptr = new int(n);
+        ptr = new int(n);
+      }
+      return ptr;
+    }
+
+    int* func42(int n){
+      int* ptr = nullptr;
+      if(int* tmp = new int(n)){
+        ptr = tmp;
+      }
+      return ptr;
+    }
+
+    int* func43(int n){
+      int* ptr = new int(n);
+      if(n>0){
+        int* tmp = (int*)malloc(sizeof(int));
+        ptr = tmp;
+      }
+      return ptr;
+    }
+
+    int* func44(int n){
+      int* q = NULL;
+      if(n>9){
+
+      }
+      else if(n>5){
+        q = new int(n);
+      }
+      else{
+        q = new int(n);
+      }
+      return q;
+    }
+
+    int* func45(int n){
+      int* x = (int*)0;
+      if(n>5){
+        if(n>8)
+          x = new int(n);
+        else
+          x = new int(n);
+      }
+      return x;
+    }
+
+    int* func46(int n){
+      int* p = nullptr;
+      if(n>20){
+        if(n>15){
+          if(n>10)
+            p = new int(n);
+          else
+            p = new int(n);
+        }
+        else {
+          p = new int(n);
+        }
+      }
+      else {
+        p = new int(n);
+      }
+      return p;
+    }
+
+    int* func47(int n){
+      int* p = nullptr;
+      if(n>20){
+        if(n>15){
+          if(n>10)
+            p = new int(n);
+          else
+            p = new int(n);
+        }
+      }
+      return p;
+    }
+
+    int* func48(int n){
+      int* p = nullptr;
+      int* q = nullptr;
+      if(n>30){
+        q = new int(n);
+        if(n>25){
+          if(n>22)
+            p = new int(n);
+          else
+            p = new int(n);
+        }
+        else {
+          p = new int(n);
+        }
+      }
+      else if(n>20){
+        p = new int(n);
+        if(n>15)
+          q = new int(n);
+        else
+          q = (int*)malloc(sizeof(int));
+      }
+      else {
+        p = new int(n);
+        q = new int(n);
+      }
+      return p;
+    }
+
+    int* func49(int n){
+      int* p = (int*)malloc(sizeof(int));
+      int* q = new int(n);
+      if(n>30){
+        if(n>25){
+          p = (int*)malloc(sizeof(int));
+          if(n>20)
+            q += 1;
+        }
+        else {
+          p = (int*)malloc(sizeof(int));
+        }
+      }
+      return p;
+    }
+
+    int* func50(int n){
+      int* p = nullptr;
+      if(n>40){
+        p = new int(n);
+      }
+      else if(n>30){
+        if(n>25){
+          if(n>20)
+            p = new int(n);
+          else
+            p = (int*)malloc(sizeof(int));
+        }
+      }
+      else if(n>10){
+        p = new int(n);
+      }
+      else {
+        p = new int(n);
+      }
+      return p;
+    }
+
+    int* func51(int n){
+      int* ptr = nullptr;
+      if(ptr = new int(n)){
+
+      }
+      return ptr;
+    }
+
+    int* func52(int n){
+      if(n>0)
+        return new int(n);
+      return NULL;
+    }
+
+    int* func53(int n){
+      int* p = static_cast<int*>(0);
+      if(n>0)
+        p = new int(n);
+      return p;
+    }
+
+    int* func54(int n){
+      int* p;
+      if(n>0)
+        p = new int(n);
+      else
+        p = (int*)malloc(sizeof(int));
+      return p;
+    }
+    void* func55(){ return ::operator new(64); }
+    void* func56(){ return ::operator new[](64); }
+    void* func57(void* buf){ return ::operator new(sizeof(int), buf); }
+    void* func58(){ return __builtin_operator_new(64); }
+    void* func59(){int* m = (int*)0; return malloc(sizeof(int));}
+
     )";
   TestFixture::CreateInterpreter();
   Interp->declare(code);
@@ -973,7 +1234,7 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_GetAllocType) {
   TESTAC(16, Unknown);
   TESTAC(17, None);
   TESTAC(18, None);
-  TESTAC(19, None);
+  TESTAC(19, Null);
   TESTAC(20, Unknown);
   TESTAC(21, None);
   TESTAC(22, New);
@@ -981,15 +1242,39 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_GetAllocType) {
   TESTAC(24, New);
   TESTAC(25, NewArr);
   TESTAC(26, Unknown);
-  // FIXME: Pointer overwriten by a non-assignment operator
-  TESTAC(27, NewArr);
+  TESTAC(27, Unknown);
   TESTAC(28, New);
   TESTAC(29, New);
   TESTAC(30, New);
   TESTAC(31, New);
   TESTAC(32, New);
   TESTAC(33, New);
-
+  TESTAC(34, New);
+  TESTAC(35, New);
+  TESTAC(36, Unknown);
+  TESTAC(37, New);
+  TESTAC(38, New);
+  TESTAC(39, Unknown);
+  TESTAC(40, New);
+  TESTAC(41, New);
+  TESTAC(42, New);
+  TESTAC(43, Unknown);
+  TESTAC(44, New);
+  TESTAC(45, New);
+  TESTAC(46, New);
+  TESTAC(47, New);
+  TESTAC(48, New);
+  TESTAC(49, Malloc);
+  TESTAC(50, Unknown);
+  TESTAC(51, New);
+  TESTAC(52, New);
+  TESTAC(53, New);
+  TESTAC(54, Unknown);
+  TESTAC(55, OperatorNew);
+  TESTAC(56, OperatorNewArr);
+  TESTAC(57, None);
+  TESTAC(58, OperatorNew);
+  TESTAC(59, Malloc);
 #undef TESTAC
 
   Cpp::DeleteInterpreter();

--- a/unittests/CppInterOp/FunctionReflectionTest.cpp
+++ b/unittests/CppInterOp/FunctionReflectionTest.cpp
@@ -864,8 +864,6 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_IsAllocator) {
     void __attribute__((annotate("cppAllocNew"))) NewFunc();
     void __attribute__((annotate("cppAllocNewArr"))) NewArrFunc();
     void __attribute__((annotate("cppAllocMalloc"))) MallocFunc();
-    void __attribute__((annotate("cppAllocUnknown"))) UnknownFunc();
-    void __attribute__((annotate("cppAllocNull"))) NullFunc();
     void __attribute__((annotate("cppAllocOperatorNew"))) OpNewFunc();
     void __attribute__((annotate("cppAllocOperatorNewArr"))) OpNewArrFunc();
     void __attribute__((annotate("unrelatedAttr"))) UnrelatedFunc();
@@ -880,26 +878,24 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_IsAllocator) {
   TESTIA(malloc, Cpp::AllocType::Malloc);
   TESTIA(Allocator, Cpp::AllocType::Malloc);
   TESTIA(Allocator2, Cpp::AllocType::Malloc);
-  TESTIA(foo, std::nullopt);
-  TESTIA(Deallocator, std::nullopt);
+  TESTIA(foo, Cpp::AllocType::Unknown);
+  TESTIA(Deallocator, Cpp::AllocType::Unknown);
   TESTIA(CFAllocFunc, Cpp::AllocType::Malloc);
   TESTIA(NoneFunc, Cpp::AllocType::None);
   TESTIA(NewFunc, Cpp::AllocType::New);
   TESTIA(NewArrFunc, Cpp::AllocType::NewArr);
   TESTIA(MallocFunc, Cpp::AllocType::Malloc);
-  TESTIA(UnknownFunc, Cpp::AllocType::Unknown);
-  TESTIA(NullFunc, Cpp::AllocType::Null);
   TESTIA(OpNewFunc, Cpp::AllocType::OperatorNew);
   TESTIA(OpNewArrFunc, Cpp::AllocType::OperatorNewArr);
-  TESTIA(UnrelatedFunc, std::nullopt);
-  TESTIA(DeclspecRestrictFunc, std::nullopt);
+  TESTIA(UnrelatedFunc, Cpp::AllocType::Unknown);
+  TESTIA(DeclspecRestrictFunc, Cpp::AllocType::Unknown);
 
   //! Fn coverage
   EXPECT_EQ(Cpp::IsAllocator(Cpp::ConstFuncRef{nullptr}),
             Cpp::AllocType::Unknown);
   // casting coverage
   EXPECT_EQ(Cpp::IsAllocator(Cpp::ConstFuncRef{Cpp::GetNamed("Klass").data}),
-            std::nullopt);
+            Cpp::AllocType::Unknown);
 
   Cpp::DeleteInterpreter();
 #ifdef EMSCRIPTEN
@@ -920,7 +916,14 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_IsAllocator) {
   Interp->process(code);
 
   TESTIA(testAlloc, Cpp::AllocType::Malloc);
-  TESTIA(testNotAlloc, std::nullopt);
+  TESTIA(testNotAlloc, Cpp::AllocType::Unknown);
+  TESTIA(testMalloc, Cpp::AllocType::Malloc);
+  TESTIA(testNew, Cpp::AllocType::New);
+  TESTIA(testNewArr, Cpp::AllocType::NewArr);
+  TESTIA(testOperatorNew, Cpp::AllocType::OperatorNew);
+  TESTIA(testOperatorNewArr, Cpp::AllocType::OperatorNewArr);
+  TESTIA(testNone, Cpp::AllocType::None);
+  TESTIA(testWeirdAttr, Cpp::AllocType::Unknown);
 
   Cpp::DeleteInterpreter();
 #endif

--- a/unittests/CppInterOp/FunctionReflectionTest.cpp
+++ b/unittests/CppInterOp/FunctionReflectionTest.cpp
@@ -856,24 +856,59 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_IsAllocator) {
       return obj;
     }
     void foo();
-    )";
-  GetAllTopLevelDecls(code, Decls, true);
-  EXPECT_TRUE(Cpp::IsAllocator(Decls[1]));
-  EXPECT_TRUE(Cpp::IsAllocator(Decls[2]));
-  EXPECT_FALSE(Cpp::IsAllocator(Decls[3]));
-  // Builtin check
-  code = R"(
-  //There is nothing lstdlib.h is included at args
-  )";
-  TestFixture::CreateInterpreter({"-include", "stdlib.h"});
-  Interp->process(code);
-  auto mallocDecl = Cpp::GetNamed("malloc");
-  EXPECT_TRUE(Cpp::IsAllocator(Cpp::ConstFuncRef{mallocDecl.data}));
-  Cpp::DeleteInterpreter();
 
+    void __attribute__((ownership_takes(malloc, 1))) Deallocator(void* p);
+    void* __attribute__((cf_returns_retained)) CFAllocFunc();
+
+    void __attribute__((annotate("cppAllocNone"))) NoneFunc();
+    void __attribute__((annotate("cppAllocNew"))) NewFunc();
+    void __attribute__((annotate("cppAllocNewArr"))) NewArrFunc();
+    void __attribute__((annotate("cppAllocMalloc"))) MallocFunc();
+    void __attribute__((annotate("cppAllocUnknown"))) UnknownFunc();
+    void __attribute__((annotate("cppAllocNull"))) NullFunc();
+    void __attribute__((annotate("cppAllocOperatorNew"))) OpNewFunc();
+    void __attribute__((annotate("cppAllocOperatorNewArr"))) OpNewArrFunc();
+    void __attribute__((annotate("unrelatedAttr"))) UnrelatedFunc();
+    __declspec(restrict) void* DeclspecRestrictFunc();
+  )";
+  TestFixture::CreateInterpreter(
+      {"-std=c++17", "-include", "stdlib.h", "-fdeclspec"});
+  Interp->declare(code);
+#define TESTIA(N, EXP)                                                         \
+  EXPECT_EQ(Cpp::IsAllocator(Cpp::ConstFuncRef { Cpp::GetNamed(#N).data }), EXP)
+
+  TESTIA(malloc, Cpp::AllocType::Malloc);
+  TESTIA(Allocator, Cpp::AllocType::Malloc);
+  TESTIA(Allocator2, Cpp::AllocType::Malloc);
+  TESTIA(foo, std::nullopt);
+  TESTIA(Deallocator, std::nullopt);
+  TESTIA(CFAllocFunc, Cpp::AllocType::Malloc);
+  TESTIA(NoneFunc, Cpp::AllocType::None);
+  TESTIA(NewFunc, Cpp::AllocType::New);
+  TESTIA(NewArrFunc, Cpp::AllocType::NewArr);
+  TESTIA(MallocFunc, Cpp::AllocType::Malloc);
+  TESTIA(UnknownFunc, Cpp::AllocType::Unknown);
+  TESTIA(NullFunc, Cpp::AllocType::Null);
+  TESTIA(OpNewFunc, Cpp::AllocType::OperatorNew);
+  TESTIA(OpNewArrFunc, Cpp::AllocType::OperatorNewArr);
+  TESTIA(UnrelatedFunc, std::nullopt);
+  TESTIA(DeclspecRestrictFunc, std::nullopt);
+
+  //! Fn coverage
+  EXPECT_EQ(Cpp::IsAllocator(Cpp::ConstFuncRef{nullptr}),
+            Cpp::AllocType::Unknown);
+  // casting coverage
+  EXPECT_EQ(Cpp::IsAllocator(Cpp::ConstFuncRef{Cpp::GetNamed("Klass").data}),
+            std::nullopt);
+
+  Cpp::DeleteInterpreter();
+#ifdef EMSCRIPTEN
+  GTEST_SKIP() << "Test fails for Emscipten builds";
+#endif
+  std::string include_flag;
   // APINotes check
-#if !defined(CPPINTEROP_USE_CLING) && !defined(__EMSCRIPTEN__)
-  std::string include_flag =
+#ifndef CPPINTEROP_USE_CLING
+  include_flag =
       "-I" + std::string(CPPINTEROP_DIR) + "unittests/CppInterOp/APINotes";
   std::vector<const char*> interpreter_args = {
       "-fmodules", "-fimplicit-module-maps", "-fapinotes-modules",
@@ -883,13 +918,41 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_IsAllocator) {
   #include "TestHeader.h"
   )";
   Interp->process(code);
-  auto testAllocDecl = Cpp::GetNamed("testAlloc");
-  EXPECT_TRUE(Cpp::IsAllocator(Cpp::ConstFuncRef{testAllocDecl.data}));
 
-  auto testNotAllocDecl = Cpp::GetNamed("testNotAlloc");
-  EXPECT_FALSE(Cpp::IsAllocator(Cpp::ConstFuncRef{testNotAllocDecl.data}));
+  TESTIA(testAlloc, Cpp::AllocType::Malloc);
+  TESTIA(testNotAlloc, std::nullopt);
+
   Cpp::DeleteInterpreter();
 #endif
+#undef TESTIA
+  include_flag =
+      "-I" + std::string(CPPINTEROP_DIR) + "unittests/CppInterOp/APINotes";
+  Decls.clear();
+  code = R"(
+    void* mergeFunc() {
+      return malloc(sizeof(int));
+    }
+  )";
+  GetAllTopLevelDecls(code, Decls, true,
+                      {"-std=c++17", include_flag.c_str(), "-include",
+                       "stdlib.h", "-include", "TestAttributeMerge.h"});
+  EXPECT_EQ(Cpp::IsAllocator(Decls[0]), Cpp::AllocType::Malloc);
+
+  Decls.clear();
+  code = R"(
+    int* overloadFunc(){
+      return new int;
+    }
+
+    int* overloadFunc(int n){
+      return new int(n);
+    }
+  )";
+  GetAllTopLevelDecls(
+      code, Decls, true,
+      {"-std=c++17", include_flag.c_str(), "-include", "TestAttributeMerge.h"});
+  EXPECT_EQ(Cpp::IsAllocator(Decls[0]), Cpp::AllocType::New);
+  EXPECT_EQ(Cpp::IsAllocator(Decls[1]), Cpp::AllocType::New);
 }
 
 TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_IsDeallocator) {
@@ -1749,14 +1812,27 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_GetAllocType) {
       a = new int;
       return a;
     }
-    )";
-  TestFixture::CreateInterpreter({"-std=c++17"});
-  Interp->declare(code);
 
+    //Not analyzed, attribute is merged in header
+    void* func71_helper();
+
+    void* func71(){
+      return func71_helper();
+    }
+    )";
+  std::string include_flag =
+      "-I" + std::string(CPPINTEROP_DIR) + "unittests/CppInterOp/APINotes";
+#ifndef EMSCRIPTEN
+  TestFixture::CreateInterpreter(
+      {"-std=c++17", include_flag.c_str(), "-include", "TestAttributeMerge.h"});
+#else
+  TestFixture::CreateInterpreter({"-std=c++17"});
+#endif
+
+  Interp->declare(code);
 #define TESTAC(N, EXP)                                                         \
-  EXPECT_EQ(                                                                   \
-      Cpp::GetAllocType(Cpp::ConstFuncRef { Cpp::GetNamed("func" #N).data }),  \
-      Cpp::AllocType::EXP)
+  EXPECT_EQ(Cpp::GetAllocType(Cpp::FuncRef { Cpp::GetNamed("func" #N).data }), \
+            Cpp::AllocType::EXP)
 
   TESTAC(0, New);
   TESTAC(1, New);
@@ -1819,10 +1895,14 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_GetAllocType) {
   TESTAC(58, OperatorNew);
   TESTAC(59, Malloc);
   TESTAC(70, Unknown);
+#ifndef EMSCRIPTEN
+  TESTAC(71, Malloc);
+#endif
 #undef TESTAC
 
   Cpp::DeleteInterpreter();
 }
+
 TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_GetFunctionSignature) {
   std::vector<Decl*> Decls;
   std::string code = R"(

--- a/unittests/CppInterOp/FunctionReflectionTest.cpp
+++ b/unittests/CppInterOp/FunctionReflectionTest.cpp
@@ -844,7 +844,10 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_IsAllocator) {
   std::vector<Decl*> Decls;
   std::string code = R"(
     class Klass{
-      int val;
+      int val = 0;
+      int* __attribute__((annotate("cppAllocNone"))) getValAdress(){
+        return &val;
+      }
     };
     __attribute__((ownership_returns(malloc)))
     Klass* Allocator(){
@@ -860,18 +863,23 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_IsAllocator) {
     void __attribute__((ownership_takes(malloc, 1))) Deallocator(void* p);
     void* __attribute__((cf_returns_retained)) CFAllocFunc();
 
-    void __attribute__((annotate("cppAllocNone"))) NoneFunc();
-    void __attribute__((annotate("cppAllocNew"))) NewFunc();
-    void __attribute__((annotate("cppAllocNewArr"))) NewArrFunc();
-    void __attribute__((annotate("cppAllocMalloc"))) MallocFunc();
-    void __attribute__((annotate("cppAllocOperatorNew"))) OpNewFunc();
-    void __attribute__((annotate("cppAllocOperatorNewArr"))) OpNewArrFunc();
-    void __attribute__((annotate("unrelatedAttr"))) UnrelatedFunc();
-    __declspec(restrict) void* DeclspecRestrictFunc();
+    int* __attribute__((annotate("cppAllocNone"))) NoneFunc();
+    int* __attribute__((annotate("cppAllocNew"))) NewFunc();
+    int* __attribute__((annotate("cppAllocNewArr"))) NewArrFunc();
+    int* __attribute__((annotate("cppAllocMalloc"))) MallocFunc();
+    int* __attribute__((annotate("cppAllocOperatorNew"))) OpNewFunc();
+    int* __attribute__((annotate("cppAllocOperatorNewArr"))) OpNewArrFunc();
+    int* __attribute__((annotate("unrelatedAttr"))) UnrelatedFunc();
+    __declspec(restrict) int* DeclspecRestrictFunc();
+    template <typename T>
+    __attribute__((annotate("cppAllocNew"))) T* TemplatedFunc(){
+      return new T;
+    }
+    template <> int* TemplatedFunc();
+    template char* TemplatedFunc<char>();
   )";
-  TestFixture::CreateInterpreter(
-      {"-std=c++17", "-include", "stdlib.h", "-fdeclspec"});
-  Interp->declare(code);
+  GetAllTopLevelDecls(code, Decls, true,
+                      {"-std=c++17", "-include", "stdlib.h", "-fdeclspec"});
 #define TESTIA(N, EXP)                                                         \
   EXPECT_EQ(Cpp::IsAllocator(Cpp::ConstFuncRef { Cpp::GetNamed(#N).data }), EXP)
 
@@ -889,6 +897,20 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_IsAllocator) {
   TESTIA(OpNewArrFunc, Cpp::AllocType::OperatorNewArr);
   TESTIA(UnrelatedFunc, Cpp::AllocType::Unknown);
   TESTIA(DeclspecRestrictFunc, Cpp::AllocType::Unknown);
+
+  EXPECT_EQ(Cpp::IsAllocator(Cpp::ConstFuncRef{Decls[14]}),
+            Cpp::AllocType::New);
+  EXPECT_EQ(Cpp::IsAllocator(Cpp::ConstFuncRef{Decls[15]}),
+            Cpp::AllocType::New);
+  ASTContext& C = Interp->getCI()->getASTContext();
+  std::vector<Cpp::TemplateArgInfo> charArg = {C.CharTy.getAsOpaquePtr()};
+  EXPECT_EQ(Cpp::IsAllocator(Cpp::ConstFuncRef{
+                Cpp::InstantiateTemplate(Decls[14], charArg).data}),
+            Cpp::AllocType::New);
+
+  EXPECT_EQ(Cpp::IsAllocator(Cpp::ConstFuncRef{
+                Cpp::GetNamed("getValAdress", Cpp::GetNamed("Klass")).data}),
+            Cpp::AllocType::None);
 
   //! Fn coverage
   EXPECT_EQ(Cpp::IsAllocator(Cpp::ConstFuncRef{nullptr}),

--- a/unittests/CppInterOp/TracingTests.cpp
+++ b/unittests/CppInterOp/TracingTests.cpp
@@ -1142,7 +1142,7 @@ TEST_F(TracingTest, WriteToFileSuppressesSelfTrace) {
 #ifndef EMSCRIPTEN
 TEST_F(TracingTest, ReproducerCompilesViaInterpreter) {
   // Create an interpreter so we can exercise real API calls.
-  Cpp::CreateInterpreter({});
+  Cpp::CreateInterpreter({"-std=c++17"});
 
   // Verify tracing is active after interpreter creation.
   ASSERT_NE(TheTraceInfo, nullptr)
@@ -1192,7 +1192,7 @@ TEST_F(TracingTest, ReproducerCompilesViaInterpreter) {
   EXPECT_THAT(content, HasSubstr("Cpp::"));
 
   // Create a fresh interpreter and #include the reproducer file as-is.
-  Cpp::CreateInterpreter({});
+  Cpp::CreateInterpreter({"-std=c++17"});
   Cpp::AddIncludePath(CPPINTEROP_DIR "/include");
   // Generated .inc files live under the build tree.
   Cpp::AddIncludePath(CPPINTEROP_BINARY_DIR "/include");


### PR DESCRIPTION
IsAllocator now returns an AllocType value instead of bool, and it recognizes user added attrbiutes with specific keyword:
cppAlloc`AllocTypeEnum` 
For example
```cpp
[[clang::annotate("cppAllocMalloc")]] void* mergeFunc();
```
cppAllocMalloc attribute is added to mergeFunc with specific signature, and IsAllocator recognizes cppAllocMalloc  attribute as AllocType::Malloc. 

Also traverser now asks IsAllocator whether the callee is labeled with an attribute before recursively analyzing it
@Vipul-Cariappa @vgvassilev 
