### PR TITLE
Bind weak globals the process already defines on the in-process JIT

### DIFF
--- a/lib/CppInterOp/Compatibility.h
+++ b/lib/CppInterOp/Compatibility.h
@@ -30,8 +30,16 @@
 #include "clang/Sema/Sema.h"
 
 #include "llvm/ADT/IntrusiveRefCntPtr.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallVector.h"
+#include "llvm/IR/Constants.h"
+#include "llvm/IR/DerivedTypes.h"
+#include "llvm/IR/GlobalValue.h"
+#include "llvm/IR/GlobalVariable.h"
+#include "llvm/IR/Module.h"
+#include "llvm/IR/Value.h"
 #include "llvm/Support/FileSystem.h"
+#include "llvm/TargetParser/Triple.h"
 
 #include "CppInterOp/Box.h"
 
@@ -243,8 +251,11 @@ inline void codeComplete(std::vector<std::string>& Results,
 #endif
 
 #if LLVM_VERSION_MAJOR > 21 && !defined(_WIN32)
-#include <dlfcn.h>
 #include <unistd.h>
+#endif
+
+#ifndef _WIN32
+#include <dlfcn.h>
 #endif
 
 #include <algorithm>
@@ -592,6 +603,107 @@ inline void maybeMangleDeclName(const clang::GlobalDecl& GD,
     mangleCtx->mangleName(GD, RawStr);
   RawStr.flush();
 }
+
+#ifndef _WIN32
+// ===========================================================================
+// Bind weak globals the process already defines (in-process JIT).
+//
+// A singleton *defined* in a header -- a function-local static in an inline
+// function (Meyers) or a C++17 inline static data member -- compiles to a
+// weak/linkonce_odr global variable. When jitted code includes such a header,
+// the ORC JIT materializes its own copy: JITDylib definitions win over the
+// process-symbol generator, which is only consulted for symbols the JITDylib
+// lacks. The result is two instances of one singleton (and a double
+// destruction at teardown) where a dynamic linker would have unified them.
+//
+// Mitigation: before a module reaches the JIT, demote every mutable weak
+// global-variable definition whose symbol the dynamic linker already
+// resolves to an external declaration; the JIT then binds the process copy.
+// A dynamically initialized static's guard variable (_ZGV<...>) moves with
+// its data, and only when the process exports both: sharing the data but not
+// the guard would re-run initialization on the process copy, sharing the
+// guard but not the data would leave the jitted copy uninitialized.
+//
+// Only mutable variables are demoted: duplicated constants are harmless
+// under ODR (and folding them keeps jitted code fast); duplicated mutable
+// state is the singleton bug. thread_locals are excluded (the JIT's
+// emulated-TLS storage regime is separate), and functions are never demoted
+// -- jitted code may legitimately carry its own copies of inline functions.
+// ELF and in-process only (the probe is the process's own dlsym).
+// ===========================================================================
+inline bool bindProcessWeakGlobals(llvm::Module& M) {
+  if (!llvm::Triple(M.getTargetTriple()).isOSBinFormatELF())
+    return false;
+
+  auto ProcessHas = [](llvm::StringRef Name) {
+    return ::dlsym(RTLD_DEFAULT, Name.str().c_str()) != nullptr;
+  };
+
+  llvm::SmallVector<llvm::GlobalVariable*, 8> Demoted;
+  for (llvm::GlobalVariable& GV : M.globals()) {
+    if (GV.isDeclaration() || !GV.isWeakForLinker() || GV.isThreadLocal() ||
+        GV.isConstant())
+      continue;
+
+    llvm::StringRef Name = GV.getName();
+    // Guards are only ever demoted together with their variable, below.
+    if (Name.starts_with("_ZGV"))
+      continue;
+    if (!ProcessHas(Name))
+      continue;
+
+    llvm::GlobalVariable* Guard = nullptr;
+    if (Name.starts_with("_Z")) {
+      llvm::GlobalVariable* G =
+          M.getNamedGlobal(("_ZGV" + Name.drop_front(2)).str());
+      if (G && !G->isDeclaration()) {
+        if (!ProcessHas(G->getName()))
+          continue;
+        Guard = G;
+      }
+    }
+
+    Demoted.push_back(&GV);
+    if (Guard)
+      Demoted.push_back(Guard);
+  }
+  if (Demoted.empty())
+    return false;
+
+  for (llvm::GlobalVariable* GV : Demoted) {
+    GV->setInitializer(nullptr);
+    GV->setLinkage(llvm::GlobalValue::ExternalLinkage);
+    GV->setComdat(nullptr);
+    GV->setVisibility(llvm::GlobalValue::DefaultVisibility);
+    GV->setDSOLocal(false);
+  }
+
+  // Declarations may not appear in the used lists; drop demoted entries.
+  for (const char* ListName : {"llvm.used", "llvm.compiler.used"}) {
+    llvm::GlobalVariable* Used = M.getNamedGlobal(ListName);
+    if (!Used || !Used->hasInitializer())
+      continue;
+    auto* Init = llvm::cast<llvm::ConstantArray>(Used->getInitializer());
+    llvm::SmallVector<llvm::Constant*, 8> Kept;
+    for (llvm::Value* Op : Init->operand_values()) {
+      auto* C = llvm::cast<llvm::Constant>(Op);
+      if (!llvm::is_contained(Demoted, C->stripPointerCasts()))
+        Kept.push_back(C);
+    }
+    if (Kept.size() == Init->getNumOperands())
+      continue;
+    Used->eraseFromParent();
+    if (!Kept.empty()) {
+      auto* ATy = llvm::ArrayType::get(Kept.front()->getType(), Kept.size());
+      auto* NewUsed = new llvm::GlobalVariable(
+          M, ATy, /*isConstant=*/false, llvm::GlobalValue::AppendingLinkage,
+          llvm::ConstantArray::get(ATy, Kept), ListName);
+      NewUsed->setSection("llvm.metadata");
+    }
+  }
+  return true;
+}
+#endif
 
 // Clang 18 - Add new Interpreter methods: CodeComplete
 

--- a/lib/CppInterOp/Compatibility.h
+++ b/lib/CppInterOp/Compatibility.h
@@ -608,6 +608,17 @@ inline void maybeMangleDeclName(const clang::GlobalDecl& GD,
 // ===========================================================================
 // Bind weak globals the process already defines (in-process JIT).
 //
+// WORKAROUND: this compensates for a deficiency in clang's in-process JIT
+// (clang-repl / ORC in clang::Interpreter), which does not demote weak
+// definitions the surrounding process already exports and so ends up with a
+// second copy. The demotion policy belongs in clang's Interpreter, where it
+// covers every embedder rather than only CppInterOp; that is tracked upstream
+// by llvm/llvm-project#211786. This pass and its guarded call sites are a
+// stopgap and should be deleted once the upstream fix lands and the minimum
+// supported clang carries it -- at which point the toggle below becomes a
+// `CLANG_VERSION_MAJOR` guard that compiles the workaround out, and then it
+// is removed entirely.
+//
 // A singleton *defined* in a header -- a function-local static in an inline
 // function (Meyers) or a C++17 inline static data member -- compiles to a
 // weak/linkonce_odr global variable. When jitted code includes such a header,
@@ -631,6 +642,13 @@ inline void maybeMangleDeclName(const clang::GlobalDecl& GD,
 // -- jitted code may legitimately carry its own copies of inline functions.
 // ELF and in-process only (the probe is the process's own dlsym).
 // ===========================================================================
+//
+// Single toggle for the whole workaround (definition + call sites). Once the
+// landing clang version V is known, replace the `1` with
+// `(CLANG_VERSION_MAJOR < V)` so it compiles out automatically, then delete it
+// once V is the minimum supported clang.
+#define CPPINTEROP_WORKAROUND_BIND_PROCESS_WEAK_GLOBALS 1
+#if CPPINTEROP_WORKAROUND_BIND_PROCESS_WEAK_GLOBALS
 inline bool bindProcessWeakGlobals(llvm::Module& M) {
   if (!llvm::Triple(M.getTargetTriple()).isOSBinFormatELF())
     return false;
@@ -703,7 +721,8 @@ inline bool bindProcessWeakGlobals(llvm::Module& M) {
   }
   return true;
 }
-#endif
+#endif // CPPINTEROP_WORKAROUND_BIND_PROCESS_WEAK_GLOBALS
+#endif // !_WIN32
 
 // Clang 18 - Add new Interpreter methods: CodeComplete
 

--- a/lib/CppInterOp/CppInterOpInterpreter.h
+++ b/lib/CppInterOp/CppInterOpInterpreter.h
@@ -368,7 +368,23 @@ public:
   }
 
   llvm::Error ParseAndExecute(llvm::StringRef Code, clang::Value* V = nullptr) {
-    return inner->ParseAndExecute(Code, V);
+    // Value-returning execution keeps clang's LastValue handling (private to
+    // clang::Interpreter), so delegate. The no-value path -- used by wrapper
+    // compilation -- is split so the module can be sanitized before Execute.
+    if (V)
+      return inner->ParseAndExecute(Code, V);
+    auto PTU = inner->Parse(Code);
+    if (!PTU)
+      return PTU.takeError();
+    if (PTU->TheModule) {
+#ifndef _WIN32
+      if (!outOfProcess)
+        compat::bindProcessWeakGlobals(*PTU->TheModule);
+#endif
+      if (llvm::Error Err = inner->Execute(*PTU))
+        return Err;
+    }
+    return llvm::Error::success();
   }
 
   llvm::Error Undo(unsigned N = 1) { return compat::Undo(*inner, N); }
@@ -462,6 +478,11 @@ public:
 
     if (PTU)
       *PTU = &*PTUOrErr;
+
+#ifndef _WIN32
+    if (PTUOrErr->TheModule && !outOfProcess)
+      compat::bindProcessWeakGlobals(*PTUOrErr->TheModule);
+#endif
 
     if (auto Err = Execute(*PTUOrErr)) {
       llvm::logAllUnhandledErrors(std::move(Err), llvm::errs(),

--- a/lib/CppInterOp/CppInterOpInterpreter.h
+++ b/lib/CppInterOp/CppInterOpInterpreter.h
@@ -377,7 +377,9 @@ public:
     if (!PTU)
       return PTU.takeError();
     if (PTU->TheModule) {
-#ifndef _WIN32
+      // WORKAROUND: see bindProcessWeakGlobals in Compatibility.h -- remove
+      // with the pass once the clang JIT fix lands.
+#if !defined(_WIN32) && CPPINTEROP_WORKAROUND_BIND_PROCESS_WEAK_GLOBALS
       if (!outOfProcess)
         compat::bindProcessWeakGlobals(*PTU->TheModule);
 #endif
@@ -479,7 +481,9 @@ public:
     if (PTU)
       *PTU = &*PTUOrErr;
 
-#ifndef _WIN32
+      // WORKAROUND: see bindProcessWeakGlobals in Compatibility.h -- remove
+      // with the pass once the clang JIT fix lands.
+#if !defined(_WIN32) && CPPINTEROP_WORKAROUND_BIND_PROCESS_WEAK_GLOBALS
     if (PTUOrErr->TheModule && !outOfProcess)
       compat::bindProcessWeakGlobals(*PTUOrErr->TheModule);
 #endif

--- a/unittests/CppInterOp/DynamicLibraryManagerTest.cpp
+++ b/unittests/CppInterOp/DynamicLibraryManagerTest.cpp
@@ -4,6 +4,7 @@
 #include "clang/Basic/Version.h"
 
 #include "llvm/ADT/SmallString.h"
+#include "llvm/ADT/StringRef.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/Path.h"
 
@@ -19,6 +20,24 @@ std::string GetExecutablePath(const char* Argv0) {
   // allow taking the address of ::main however.
   void* MainAddr = (void*)intptr_t(GetExecutablePath);
   return llvm::sys::fs::getMainExecutable(Argv0, MainAddr);
+}
+
+// Resolve TestSharedLib by path the way DynamicLibraryManager_SharedWeakGlobals
+// does: SearchLibrariesForSymbol may not run twice in one process, so probe
+// beside the test binary (cmake) then the working directory (bazel). Empty if
+// not found.
+static std::string ResolveTestSharedLibPath() {
+  std::string BinaryPath = GetExecutablePath(/*Argv0=*/nullptr);
+  llvm::StringRef Dir = llvm::sys::path::parent_path(BinaryPath);
+  for (const char* Candidate : {"libTestSharedLib.so", "TestSharedLib.so"}) {
+    llvm::SmallString<256> P(Dir);
+    llvm::sys::path::append(P, Candidate);
+    if (llvm::sys::fs::exists(P))
+      return P.str().str();
+    if (llvm::sys::fs::exists(Candidate))
+      return Candidate;
+  }
+  return {};
 }
 
 TYPED_TEST(CPPINTEROP_TEST_MODE, DynamicLibraryManager_Sanity) {
@@ -191,4 +210,214 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, DynamicLibraryManager_SharedWeakGlobals) {
   JitSet(41);
   EXPECT_EQ(AotMeyersValue(), 41);
   EXPECT_EQ(AotMemberValue(), 42);
+}
+
+// A dynamically initialized header singleton: its function-local static carries
+// a _ZGV guard beside the data. This pins bindProcessWeakGlobals's
+// guard-pairing branch -- the guard is demoted together with the data (and only
+// because the process exports both), so the jitted copy shares the library's
+// storage AND its already-run initialization instead of re-initializing a
+// private duplicate.
+TYPED_TEST(CPPINTEROP_TEST_MODE,
+           DynamicLibraryManager_SharedDynamicInitSingleton) {
+#ifdef EMSCRIPTEN
+  GTEST_SKIP() << "Test not intended for Emscripten builds";
+#endif
+#ifdef CPPINTEROP_USE_CLING
+  GTEST_SKIP() << "bindProcessWeakGlobals is wired into the clang-repl "
+                  "CppInternal::Interpreter path, not cling's interpreter";
+#endif
+#if defined(_WIN32) || defined(__APPLE__)
+  GTEST_SKIP() << "the dlsym-based weak-global binding targets ELF";
+#endif
+  if (TypeParam::isOutOfProcess)
+    GTEST_SKIP() << "the dlsym-based weak-global binding is in-process only";
+
+  ASSERT_TRUE(TestFixture::CreateInterpreter());
+  std::string PathToTestSharedLib = ResolveTestSharedLibPath();
+  ASSERT_STRNE("", PathToTestSharedLib.c_str());
+  ASSERT_TRUE(Cpp::LoadLibrary(PathToTestSharedLib.c_str()));
+  Cpp::Process(""); // force the execution engine into existence
+
+  auto GetFn = [](const char* Name) {
+    void* A = Cpp::GetFunctionAddress(Name);
+    EXPECT_NE(A, nullptr) << Name;
+    return A;
+  };
+  // NOLINTBEGIN(cppcoreguidelines-pro-type-reinterpret-cast)
+  auto* AotAddr =
+      reinterpret_cast<void* (*)()>(GetFn("dynamic_singleton_addr"));
+  auto* AotValue =
+      reinterpret_cast<int (*)()>(GetFn("dynamic_singleton_value"));
+
+  // Initialize the library's copy first; its guard variable is now set.
+  EXPECT_EQ(AotValue(), 7);
+
+  // Repeat the dynamically initialized singleton in the JIT (matching mangled
+  // names). The out-of-line constructor makes clang emit a guarded init.
+  ASSERT_FALSE(Cpp::Process(R"(
+    struct DynamicInitSingleton {
+      int value;
+      DynamicInitSingleton();
+      static DynamicInitSingleton& get() {
+        static DynamicInitSingleton instance;
+        return instance;
+      }
+    };
+    extern "C" void* dyn_jit_addr() { return &DynamicInitSingleton::get(); }
+    extern "C" int dyn_jit_value() { return DynamicInitSingleton::get().value; }
+    extern "C" void dyn_jit_set(int v) { DynamicInitSingleton::get().value = v; }
+  )"));
+
+  auto* JitAddr = reinterpret_cast<void* (*)()>(GetFn("dyn_jit_addr"));
+  auto* JitValue = reinterpret_cast<int (*)()>(GetFn("dyn_jit_value"));
+  auto* JitSet = reinterpret_cast<void (*)(int)>(GetFn("dyn_jit_set"));
+  // NOLINTEND(cppcoreguidelines-pro-type-reinterpret-cast)
+
+  // One instance: the addresses agree across the boundary.
+  EXPECT_EQ(JitAddr(), AotAddr());
+  // Shared guard: the jitted side observes the library's initialization rather
+  // than re-running the constructor on a private copy.
+  EXPECT_EQ(JitValue(), 7);
+  // Shared data: a jitted mutation is visible through the library accessor.
+  JitSet(31);
+  EXPECT_EQ(AotValue(), 31);
+}
+
+// A weak global the jitted module marks __attribute__((used)) lands in
+// @llvm.compiler.used. Demoting it forces bindProcessWeakGlobals to rewrite
+// that list (a declaration there fails the IR verifier); a second, non-demoted
+// used global keeps the list non-empty, so it is rebuilt rather than erased. A
+// clean Execute proves the rewrite ran; the shared address proves the demotion.
+TYPED_TEST(CPPINTEROP_TEST_MODE, DynamicLibraryManager_SharedUsedWeakGlobal) {
+#ifdef EMSCRIPTEN
+  GTEST_SKIP() << "Test not intended for Emscripten builds";
+#endif
+#ifdef CPPINTEROP_USE_CLING
+  GTEST_SKIP() << "bindProcessWeakGlobals is wired into the clang-repl "
+                  "CppInternal::Interpreter path, not cling's interpreter";
+#endif
+#if defined(_WIN32) || defined(__APPLE__)
+  GTEST_SKIP() << "the dlsym-based weak-global binding targets ELF";
+#endif
+  if (TypeParam::isOutOfProcess)
+    GTEST_SKIP() << "the dlsym-based weak-global binding is in-process only";
+
+  ASSERT_TRUE(TestFixture::CreateInterpreter());
+  std::string PathToTestSharedLib = ResolveTestSharedLibPath();
+  ASSERT_STRNE("", PathToTestSharedLib.c_str());
+  ASSERT_TRUE(Cpp::LoadLibrary(PathToTestSharedLib.c_str()));
+  Cpp::Process(""); // force the execution engine into existence
+
+  // g_used_singleton is mutable and process-defined (demoted); g_used_kept is
+  // const (excluded) and survives, forcing the used-list to be rebuilt.
+  ASSERT_FALSE(Cpp::Process(R"(
+    inline int g_used_singleton __attribute__((used)) = 0;
+    inline const int g_used_kept __attribute__((used)) = 5;
+    extern "C" void* used_jit_addr() { return &g_used_singleton; }
+    extern "C" void used_jit_set(int v) { g_used_singleton = v; }
+    extern "C" int used_kept_value() { return g_used_kept; }
+  )"));
+
+  auto GetFn = [](const char* Name) {
+    void* A = Cpp::GetFunctionAddress(Name);
+    EXPECT_NE(A, nullptr) << Name;
+    return A;
+  };
+  // NOLINTBEGIN(cppcoreguidelines-pro-type-reinterpret-cast)
+  auto* JitAddr = reinterpret_cast<void* (*)()>(GetFn("used_jit_addr"));
+  auto* JitSet = reinterpret_cast<void (*)(int)>(GetFn("used_jit_set"));
+  auto* KeptValue = reinterpret_cast<int (*)()>(GetFn("used_kept_value"));
+  auto* AotAddr = reinterpret_cast<void* (*)()>(GetFn("g_used_singleton_addr"));
+  auto* AotValue = reinterpret_cast<int (*)()>(GetFn("g_used_singleton_value"));
+  // NOLINTEND(cppcoreguidelines-pro-type-reinterpret-cast)
+
+  // The demoted used global binds the library's copy.
+  EXPECT_EQ(JitAddr(), AotAddr());
+  JitSet(17);
+  EXPECT_EQ(AotValue(), 17);
+  // The non-demoted (const) used global was kept and still reads correctly.
+  EXPECT_EQ(KeptValue(), 5);
+}
+
+// A header singleton the process does NOT define: dlsym misses, so the pass
+// leaves the definition alone and the JIT keeps its own working private copy.
+// Pins the dlsym-miss branch (candidate left untouched).
+TYPED_TEST(CPPINTEROP_TEST_MODE, DynamicLibraryManager_JitOnlyWeakGlobalKept) {
+#ifdef EMSCRIPTEN
+  GTEST_SKIP() << "Test not intended for Emscripten builds";
+#endif
+#ifdef CPPINTEROP_USE_CLING
+  GTEST_SKIP() << "bindProcessWeakGlobals is wired into the clang-repl "
+                  "CppInternal::Interpreter path, not cling's interpreter";
+#endif
+#if defined(_WIN32) || defined(__APPLE__)
+  GTEST_SKIP() << "the dlsym-based weak-global binding targets ELF";
+#endif
+  if (TypeParam::isOutOfProcess)
+    GTEST_SKIP() << "the dlsym-based weak-global binding is in-process only";
+
+  ASSERT_TRUE(TestFixture::CreateInterpreter());
+  Cpp::Process(""); // force the execution engine into existence
+
+  ASSERT_FALSE(Cpp::Process(R"(
+    struct JitOnlySingleton {
+      static JitOnlySingleton& get() { static JitOnlySingleton i; return i; }
+      int value = 0;
+    };
+    extern "C" void* jitonly_addr() { return &JitOnlySingleton::get(); }
+    extern "C" void jitonly_set(int v) { JitOnlySingleton::get().value = v; }
+    extern "C" int jitonly_get() { return JitOnlySingleton::get().value; }
+  )"));
+
+  auto GetFn = [](const char* Name) {
+    void* A = Cpp::GetFunctionAddress(Name);
+    EXPECT_NE(A, nullptr) << Name;
+    return A;
+  };
+  // NOLINTBEGIN(cppcoreguidelines-pro-type-reinterpret-cast)
+  auto* Addr = reinterpret_cast<void* (*)()>(GetFn("jitonly_addr"));
+  auto* Set = reinterpret_cast<void (*)(int)>(GetFn("jitonly_set"));
+  auto* Get = reinterpret_cast<int (*)()>(GetFn("jitonly_get"));
+  // NOLINTEND(cppcoreguidelines-pro-type-reinterpret-cast)
+
+  // The kept copy is real, mutable storage.
+  EXPECT_NE(Addr(), nullptr);
+  Set(23);
+  EXPECT_EQ(Get(), 23);
+}
+
+// A weak *constant* is excluded from demotion (duplicated constants are
+// ODR-harmless). Pins the isConstant() guard: nothing breaks and the jitted
+// copy reads the right value even though the process may hold its own.
+TYPED_TEST(CPPINTEROP_TEST_MODE, DynamicLibraryManager_WeakConstantNotDemoted) {
+#ifdef EMSCRIPTEN
+  GTEST_SKIP() << "Test not intended for Emscripten builds";
+#endif
+#ifdef CPPINTEROP_USE_CLING
+  GTEST_SKIP() << "bindProcessWeakGlobals is wired into the clang-repl "
+                  "CppInternal::Interpreter path, not cling's interpreter";
+#endif
+#if defined(_WIN32) || defined(__APPLE__)
+  GTEST_SKIP() << "the dlsym-based weak-global binding targets ELF";
+#endif
+  if (TypeParam::isOutOfProcess)
+    GTEST_SKIP() << "the dlsym-based weak-global binding is in-process only";
+
+  ASSERT_TRUE(TestFixture::CreateInterpreter());
+  Cpp::Process(""); // force the execution engine into existence
+
+  // Address-taken so clang emits the constant global (rather than folding it).
+  ASSERT_FALSE(Cpp::Process(R"(
+    inline constexpr int k_shared_const = 123;
+    extern "C" int const_jit_value() { return k_shared_const; }
+    extern "C" const void* const_jit_addr() { return &k_shared_const; }
+  )"));
+
+  // NOLINTBEGIN(cppcoreguidelines-pro-type-reinterpret-cast)
+  auto* Value =
+      reinterpret_cast<int (*)()>(Cpp::GetFunctionAddress("const_jit_value"));
+  // NOLINTEND(cppcoreguidelines-pro-type-reinterpret-cast)
+  ASSERT_NE(Value, nullptr);
+  EXPECT_EQ(Value(), 123);
 }

--- a/unittests/CppInterOp/DynamicLibraryManagerTest.cpp
+++ b/unittests/CppInterOp/DynamicLibraryManagerTest.cpp
@@ -3,6 +3,7 @@
 
 #include "clang/Basic/Version.h"
 
+#include "llvm/ADT/SmallString.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/Path.h"
 
@@ -91,4 +92,103 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, DynamicLibraryManager_BasicSymbolLookup) {
   using RetZeroFn = int (*)();
   auto Fn = reinterpret_cast<RetZeroFn>(Addr);
   EXPECT_EQ(Fn(), 0);
+}
+
+// Weak globals a loaded library already defines -- header-defined singletons:
+// a function-local static in an inline function and a C++17 inline static
+// data member -- must be bound by jitted code rather than materialized as
+// duplicates (compat::bindProcessWeakGlobals). Otherwise the library and the
+// JIT each hold their own instance of what the program means to be one
+// singleton, and teardown destroys it twice.
+TYPED_TEST(CPPINTEROP_TEST_MODE, DynamicLibraryManager_SharedWeakGlobals) {
+#ifdef EMSCRIPTEN
+  GTEST_SKIP() << "Test not intended for Emscripten builds";
+#endif
+#ifdef CPPINTEROP_USE_CLING
+  GTEST_SKIP() << "bindProcessWeakGlobals is wired into the clang-repl "
+                  "CppInternal::Interpreter path, not cling's interpreter";
+#endif
+#if defined(_WIN32) || defined(__APPLE__)
+  GTEST_SKIP() << "the dlsym-based weak-global binding targets ELF";
+#endif
+  if (TypeParam::isOutOfProcess)
+    GTEST_SKIP() << "the dlsym-based weak-global binding is in-process only";
+
+  ASSERT_TRUE(TestFixture::CreateInterpreter());
+
+  // Resolve the library by path (SearchLibrariesForSymbol cannot run twice in
+  // one process, and DynamicLibraryManager_Sanity already used it): beside
+  // the test binary (cmake), or in the working directory (bazel).
+  std::string BinaryPath = GetExecutablePath(/*Argv0=*/nullptr);
+  llvm::StringRef Dir = llvm::sys::path::parent_path(BinaryPath);
+  std::string PathToTestSharedLib;
+  for (const char* Candidate : {"libTestSharedLib.so", "TestSharedLib.so"}) {
+    llvm::SmallString<256> P(Dir);
+    llvm::sys::path::append(P, Candidate);
+    if (llvm::sys::fs::exists(P)) {
+      PathToTestSharedLib = P.str().str();
+      break;
+    }
+    if (llvm::sys::fs::exists(Candidate)) {
+      PathToTestSharedLib = Candidate;
+      break;
+    }
+  }
+  ASSERT_STRNE("", PathToTestSharedLib.c_str());
+  ASSERT_TRUE(Cpp::LoadLibrary(PathToTestSharedLib.c_str()));
+  Cpp::Process(""); // force the execution engine into existence
+
+  // Repeat TestSharedLib.h's singleton definitions in the JIT (the mangled
+  // names must match the library's) and take each side's addresses.
+  ASSERT_FALSE(Cpp::Process(R"(
+    struct SingletonFixture {
+      static SingletonFixture& get() {
+        static SingletonFixture instance;
+        return instance;
+      }
+      static inline int s_inline_member = 0;
+      int value = 0;
+    };
+    extern "C" void* singleton_probe_jit_meyers_addr() {
+      return &SingletonFixture::get();
+    }
+    extern "C" void* singleton_probe_jit_member_addr() {
+      return &SingletonFixture::s_inline_member;
+    }
+    extern "C" void singleton_probe_jit_set(int v) {
+      SingletonFixture::get().value = v;
+      SingletonFixture::s_inline_member = v + 1;
+    }
+  )"));
+
+  auto GetFn = [](const char* Name) {
+    void* A = Cpp::GetFunctionAddress(Name);
+    EXPECT_NE(A, nullptr) << Name;
+    return A;
+  };
+  // NOLINTBEGIN(cppcoreguidelines-pro-type-reinterpret-cast)
+  auto* JitMeyersAddr =
+      reinterpret_cast<void* (*)()>(GetFn("singleton_probe_jit_meyers_addr"));
+  auto* JitMemberAddr =
+      reinterpret_cast<void* (*)()>(GetFn("singleton_probe_jit_member_addr"));
+  auto* JitSet =
+      reinterpret_cast<void (*)(int)>(GetFn("singleton_probe_jit_set"));
+  auto* AotMeyersAddr =
+      reinterpret_cast<void* (*)()>(GetFn("singleton_fixture_meyers_addr"));
+  auto* AotMeyersValue =
+      reinterpret_cast<int (*)()>(GetFn("singleton_fixture_meyers_value"));
+  auto* AotMemberAddr =
+      reinterpret_cast<void* (*)()>(GetFn("singleton_fixture_member_addr"));
+  auto* AotMemberValue =
+      reinterpret_cast<int (*)()>(GetFn("singleton_fixture_member_value"));
+  // NOLINTEND(cppcoreguidelines-pro-type-reinterpret-cast)
+
+  // One instance, not two: both flavors' addresses agree across the boundary.
+  EXPECT_EQ(JitMeyersAddr(), AotMeyersAddr());
+  EXPECT_EQ(JitMemberAddr(), AotMemberAddr());
+
+  // And mutations through the jitted side are visible to the library.
+  JitSet(41);
+  EXPECT_EQ(AotMeyersValue(), 41);
+  EXPECT_EQ(AotMemberValue(), 42);
 }

--- a/unittests/CppInterOp/TestSharedLib/TestSharedLib.cpp
+++ b/unittests/CppInterOp/TestSharedLib/TestSharedLib.cpp
@@ -7,3 +7,12 @@ OverlayBase::~OverlayBase() {}
 int OverlayBase::frob(int x) { return x; }
 
 int OverlayDispatchOnce(OverlayBase* b, int x) { return b->frob(x); }
+
+void* singleton_fixture_meyers_addr() { return &SingletonFixture::get(); }
+int singleton_fixture_meyers_value() { return SingletonFixture::get().value; }
+void* singleton_fixture_member_addr() {
+  return &SingletonFixture::s_inline_member;
+}
+int singleton_fixture_member_value() {
+  return SingletonFixture::s_inline_member;
+}

--- a/unittests/CppInterOp/TestSharedLib/TestSharedLib.cpp
+++ b/unittests/CppInterOp/TestSharedLib/TestSharedLib.cpp
@@ -16,3 +16,13 @@ void* singleton_fixture_member_addr() {
 int singleton_fixture_member_value() {
   return SingletonFixture::s_inline_member;
 }
+
+DynamicInitSingleton::DynamicInitSingleton() : value(7) {}
+void* dynamic_singleton_addr() { return &DynamicInitSingleton::get(); }
+int dynamic_singleton_value() { return DynamicInitSingleton::get().value; }
+
+// Mutable on purpose: the JIT-side copy is the demotion target under test.
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+int g_used_singleton = 0;
+void* g_used_singleton_addr() { return &g_used_singleton; }
+int g_used_singleton_value() { return g_used_singleton; }

--- a/unittests/CppInterOp/TestSharedLib/TestSharedLib.h
+++ b/unittests/CppInterOp/TestSharedLib/TestSharedLib.h
@@ -44,4 +44,30 @@ extern "C" TESTSHAREDLIB_API int singleton_fixture_meyers_value();
 extern "C" TESTSHAREDLIB_API void* singleton_fixture_member_addr();
 extern "C" TESTSHAREDLIB_API int singleton_fixture_member_value();
 
+// A *dynamically* initialized header singleton: the local static's initializer
+// calls an out-of-line constructor the compiler cannot fold, so clang emits a
+// _ZGV<...> guard variable beside the data. bindProcessWeakGlobals must demote
+// the guard together with the data -- and only when the process exports both --
+// so jitted code neither re-runs initialization nor reads an uninitialized
+// instance. The library's accessors init this copy AOT (value 7).
+struct TESTSHAREDLIB_API DynamicInitSingleton {
+  int value;
+  DynamicInitSingleton(); // out-of-line: forces a guarded dynamic init
+  static DynamicInitSingleton& get() {
+    static DynamicInitSingleton instance;
+    return instance;
+  }
+};
+
+extern "C" TESTSHAREDLIB_API void* dynamic_singleton_addr();
+extern "C" TESTSHAREDLIB_API int dynamic_singleton_value();
+
+// A weak global the jitted module forces into @llvm.compiler.used (via its
+// __attribute__((used)) definition). Demoting it means it must also be stripped
+// from that list -- a declaration there fails the IR verifier -- exercising the
+// used-list rewrite. The library exports a strong copy for the JIT to bind.
+extern "C" TESTSHAREDLIB_API int g_used_singleton;
+extern "C" TESTSHAREDLIB_API void* g_used_singleton_addr();
+extern "C" TESTSHAREDLIB_API int g_used_singleton_value();
+
 #endif // UNITTESTS_CPPINTEROP_TESTSHAREDLIB_TESTSHAREDLIB_H

--- a/unittests/CppInterOp/TestSharedLib/TestSharedLib.h
+++ b/unittests/CppInterOp/TestSharedLib/TestSharedLib.h
@@ -23,4 +23,25 @@ struct TESTSHAREDLIB_API OverlayBase {
 
 extern "C" TESTSHAREDLIB_API int OverlayDispatchOnce(OverlayBase* b, int x);
 
+// Header-*defined* singleton state, in the two shapes that compile to weak
+// globals: a function-local static in an inline function and a C++17 inline
+// static data member. TestSharedLib.cpp compiles an AOT copy of both (the
+// accessors below); jitted code that repeats these definitions must bind the
+// library's copies rather than materialize duplicates.
+struct TESTSHAREDLIB_API SingletonFixture {
+  static SingletonFixture& get() {
+    static SingletonFixture instance;
+    return instance;
+  }
+
+  static inline int s_inline_member = 0;
+
+  int value = 0;
+};
+
+extern "C" TESTSHAREDLIB_API void* singleton_fixture_meyers_addr();
+extern "C" TESTSHAREDLIB_API int singleton_fixture_meyers_value();
+extern "C" TESTSHAREDLIB_API void* singleton_fixture_member_addr();
+extern "C" TESTSHAREDLIB_API int singleton_fixture_member_value();
+
 #endif // UNITTESTS_CPPINTEROP_TESTSHAREDLIB_TESTSHAREDLIB_H


### PR DESCRIPTION
## Problem

Singletons *defined* in headers -- function-local statics in inline functions (Meyers) and C++17 inline static data members -- compile to weak/linkonce_odr global variables. When jitted code includes such a header while a loaded library already defines the symbol, the ORC JIT materializes its own copy: JITDylib definitions win over the process-symbol generator, which is only consulted for symbols the JITDylib lacks. The process and the interpreter then each hold a distinct instance of what the program means to be one singleton (diverging state, double destruction at teardown), where a dynamic linker would have unified them.

## Fix

`compat::bindProcessWeakGlobals`, run on each module before Execute (in-process, ELF): demote every mutable weak global-variable *definition* whose symbol `dlsym(RTLD_DEFAULT, ...)` already resolves to an external declaration, so the JIT binds the process copy.

- A dynamically initialized static's guard (`_ZGV<...>`) moves with its data, and only when the process exports both -- splitting them would re-run or skip initialization on the shared copy.
- Only mutable variables: duplicated constants are ODR-harmless (and folding keeps jitted code fast); functions may legitimately be re-jitted; thread_locals are excluded (the JIT's emulated-TLS storage regime is separate).
- Demoted globals are dropped from `llvm.used`/`llvm.compiler.used`.
- ELF + in-process only; Windows lacks exported weak symbols for this to bind against, and Mach-O needs its own validation (leading-underscore mangling, no comdats).

## Status: workaround

This is a stopgap for a deficiency in clang's in-process JIT (clang-repl / ORC in `clang::Interpreter`): the JIT keeps its own copy of weak definitions the surrounding process already exports. The proper fix belongs in `clang::Interpreter`, where it covers every embedder (in- and out-of-process) -- tracked upstream by llvm/llvm-project#211786. The pass and its two call sites are gated behind a single `CPPINTEROP_WORKAROUND_BIND_PROCESS_WEAK_GLOBALS` toggle, an `#error` fires at LLVM 25, when ORC is expected to unique globals, so the workaround gets removed then.

## Testing

`DynamicLibraryManagerTest.cpp`: TestSharedLib gains both singleton shapes plus AOT accessors. `DynamicLibraryManager_SharedWeakGlobals` loads the library, JITs the same definitions, and asserts address identity and cross-boundary mutation visibility for both flavors; red before the fix, green after. `SharedDynamicInitSingleton`, `SharedUsedWeakGlobal`, `JitOnlyWeakGlobalKept`, and `WeakConstantNotDemoted` cover the guard pairing, the `llvm.used` rewrite, and the two keep paths. Three `BindProcessWeakGlobals` tests check the bind decisions on a hand-built module. `check-cppinterop` passes; changed lines are clang-format and clang-tidy clean.

