### PR TITLE
[ci] Drop the obsolete Box.h staging shim in the ROOT job

### DIFF
--- a/.github/workflows/root.yml
+++ b/.github/workflows/root.yml
@@ -159,19 +159,6 @@ jobs:
         sed -i '/CPPINTEROP_ENABLE_TESTING.*Enable gtest in CppInterOp/s/ FORCE)/)/' \
           root/interpreter/CMakeLists.txt
 
-        # ROOT's interpreter/CMakeLists.txt hardcodes the list of headers
-        # it stages into ${CMAKE_BINARY_DIR}/etc/cppinterop/CppInterOp/.
-        # That list (search "set(cppinterop_src_files") names only the
-        # original three public headers and three generated .inc files.
-        # CppInterOp.h now also #includes <CppInterOp/Box.h>; without
-        # Box.h next to the staged CppInterOp.h, metacling fails to
-        # compile TCling.cxx with "CppInterOp/Box.h: No such file or
-        # directory". Inject the missing header so the staged set is
-        # complete -- the upstream fix lives in ROOT and is tracked
-        # there; this is a CI-only shim until that lands.
-        sed -i '\|CppInterOp/CppInterOp\.h$|a\  ${CMAKE_CURRENT_SOURCE_DIR}/CppInterOp/include/CppInterOp/Box.h' \
-          root/interpreter/CMakeLists.txt
-
     - name: Configure ROOT
       shell: bash
       run: |


### PR DESCRIPTION
The ROOT job sed-injects CppInterOp/Box.h into ROOT's cppinterop_src_files header-staging list, as ROOT did not yet stage the (then new) Box.h header.

Since that was addressed in the last upgrade and it is now automatically staged, drop the sed that was previously staging manually. This should fix the current failing CI failure as Box.h is no longer staged twice: 

```
[83](https://github.com/compiler-research/CppInterOp/actions/runs/30551262339/job/90900286147?pr=1076#step:12:184)
-- Enabled support for:  builtin_cling runtime_cxxmodules shared testsupport thisroot_scripts
-- Configuring done (5.0s)
CMake Error:
  Running

   '/usr/local/bin/ninja' '-C' '/home/runner/work/CppInterOp/CppInterOp/root-build' '-t' 'recompact'

  failed with:

   ninja: error: build.ninja:1625: etc/cppinterop/CppInterOp/Box.h is defined as an output multiple times


  ninja: error: etc/cppinterop/CppInterOp/Box.h is defined as an
  output multiple times
```