### PR TITLE
Branch support dealloc

### DIFF
--- a/include/CppInterOp/CppInterOpTypes.h
+++ b/include/CppInterOp/CppInterOpTypes.h
@@ -406,6 +406,7 @@ enum class InterpreterLanguageStandard : unsigned char {
   lang_unspecified
 };
 
+// Enum modelling memory allocation behaivour of functions
 enum class AllocType : unsigned char {
   None,
   New,
@@ -418,12 +419,20 @@ enum class AllocType : unsigned char {
   OperatorNewArr
 };
 
+// Enum modelling memory deallocation behaivour of functions
 enum class DeallocType : unsigned char {
   None,
   Delete,
   DeleteArr,
   Free,
-  Unknown, // Contradiction, delete x or delete[] x in same func
+  MaybeDelete,
+  MaybeDeleteArr,
+  MaybeFree,
+  OperatorDelete,
+  OperatorDeleteArr,
+  MaybeOperatorDelete,
+  MaybeOperatorDeleteArr,
+  Unknown, // Contradiction, delete x AND delete[] x in same func
   Opaque   // Could not analyze
 };
 

--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -2215,8 +2215,6 @@ struct DeallocationTraverser : RecursiveASTVisitor<DeallocationTraverser> {
   // if(ptr) delete ptr;  this pattern should return Delete not MaybeDelete, so
   // this function recognizes this pattern
   const clang::VarDecl* getNullCheckCond(const clang::Expr* E) {
-    if (!E)
-      return nullptr;
     E = E->IgnoreParens();
     const auto* ICE = dyn_cast<clang::ImplicitCastExpr>(E);
     if (!ICE)
@@ -2310,12 +2308,10 @@ struct DeallocationTraverser : RecursiveASTVisitor<DeallocationTraverser> {
   }
 
   void updateParam(unsigned index, DeallocType DT) {
+    // Probably dead code, but better to keep
     if (index >= valPerParam.size())
       return;
     auto curVal = valPerParam[index];
-    // Early return
-    if (curVal == DeallocType::Unknown)
-      return;
     // If DT did not effect index, or callee could not analyzed
     if (DT == DeallocType::None || DT == DeallocType::Opaque)
       return;

--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -1998,11 +1998,13 @@ static bool AnalyzeDeallocType(
                        std::optional<std::vector<DeallocType>>>& visitedFuncs);
 namespace {
 struct DeallocationTraverser : RecursiveASTVisitor<DeallocationTraverser> {
-  std::unordered_map<const clang::VarDecl*, const clang::ParmVarDecl*> aliasMap;
-  std::set<const clang::ParmVarDecl*> overwritenParms;
+  std::unordered_map<const clang::VarDecl*, std::set<const clang::ParmVarDecl*>>
+      aliasMap;
   std::vector<DeallocType>& valPerParam;
   std::unordered_map<const FunctionDecl*,
                      std::optional<std::vector<DeallocType>>>& visitedFuncs;
+  std::unordered_map<const clang::VarDecl*,
+                     std::set<const clang::ParmVarDecl*>>* undoLog = nullptr;
   DeallocationTraverser(
       std::vector<DeallocType>& v,
       std::unordered_map<const FunctionDecl*,
@@ -2027,14 +2029,110 @@ struct DeallocationTraverser : RecursiveASTVisitor<DeallocationTraverser> {
         continue;
       const clang::ParmVarDecl* PVD = resolveParam(CE->getArg(i));
       if (!PVD)
-        continue;
-      updateVPP(PVD->getFunctionScopeIndex(), recursiveVec[i]);
+  bool TraverseIfStmt(clang::IfStmt* IS) {
+    TraverseStmt(IS->getConditionVariableDeclStmt());
+    TraverseStmt(IS->getCond());
+    std::vector<DeallocType> outerVPP(valPerParam.size(), DeallocType::None);
+    std::swap(outerVPP, valPerParam);
+    auto* undoLogCopy = undoLog;
+    std::unordered_map<const clang::VarDecl*,
+                       std::set<const clang::ParmVarDecl*>>
+        undoLogThen;
+    undoLog = &undoLogThen;
+    const auto* guardedVD = getNullCheckCond(IS->getCond());
+    int guardedIndex = -1;
+    if (guardedVD) {
+      auto it = aliasMap.find(guardedVD);
+      // if(ptr) delete ptr; -> ptr is accepted as Delete only when ptr points
+      // to just ONE parameter and does not have any other possible aliases
+      if (it != aliasMap.end() && it->second.size() == 1 &&
+          *it->second.begin() != nullptr)
+        guardedIndex = (*it->second.begin())->getFunctionScopeIndex();
     }
+    TraverseStmt(IS->getThen());
+    std::vector<DeallocType> thenVPP(valPerParam.size(), DeallocType::None);
+    std::swap(thenVPP, valPerParam);
+    auto* elseBranch = IS->getElse();
+    // There is no else
+    if (!elseBranch) {
+      std::swap(valPerParam, outerVPP);
+      for (auto& [VD, setPVD] : undoLogThen) {
+        // Overwrite aliasMap with join of overwriten and previous value
+        aliasMap[VD].insert(setPVD.begin(), setPVD.end());
+        // If branch is nested, inform upper branch about your changes
+        if (undoLogCopy)
+          undoLogCopy->try_emplace(VD, setPVD);
+      }
+      for (unsigned i = 0; i < valPerParam.size(); i++) {
+        if (static_cast<int>(i) == guardedIndex) {
+          updateParam(i, thenVPP[i]);
+          continue;
+        }
+        updateParam(i, join(thenVPP[i], DeallocType::None));
+      }
+      undoLog = undoLogCopy;
+      return true;
+    }
+
+    // Save overwriten values in if branch to join
+    std::unordered_map<const clang::VarDecl*,
+                       std::set<const clang::ParmVarDecl*>>
+        valuesInIfBranch;
+    for (auto& [VD, setPVD] : undoLogThen)
+      valuesInIfBranch[VD] = aliasMap[VD];
+
+    // Take changes on aliasMap back before going to else branch
+    undoOnAliasMap();
+
+    std::unordered_map<const clang::VarDecl*,
+                       std::set<const clang::ParmVarDecl*>>
+        undoLogElse;
+    undoLog = &undoLogElse;
+    TraverseStmt(elseBranch);
+    // elseVPP is not needed actually, we can just swap outerVPP and valPerParam
+    // and then outerVPP will act as elseVPP, but to keep code readable i use
+    // it
+    std::vector<DeallocType> elseVPP(valPerParam.size(), DeallocType::None);
+    std::swap(valPerParam, elseVPP);
+    std::swap(outerVPP, valPerParam);
+    for (unsigned i = 0; i < valPerParam.size(); i++) {
+      if (static_cast<int>(i) == guardedIndex) {
+        updateParam(i, thenVPP[i]);
+        continue;
+      }
+      updateParam(i, join(elseVPP[i], thenVPP[i]));
+    }
+    for (auto& [VD, setPVD] : undoLogElse) {
+      auto it2 = valuesInIfBranch.find(VD);
+      // If var is just changed in else branch
+      if (it2 == valuesInIfBranch.end()) {
+        aliasMap[VD].insert(setPVD.begin(), setPVD.end());
+        continue;
+      }
+      // If var is changed in both
+      aliasMap[VD].insert(it2->second.begin(), it2->second.end());
+    }
+
+    for (auto& [VD, setPVD] : valuesInIfBranch)
+      // If var is changed in both, aliasMap carries changes from else, if it is
+      // just changed in then, aliasMap carries old values, so both situation
+      // yields to same
+      aliasMap[VD].insert(setPVD.begin(), setPVD.end());
+
+    // Inform upper branch about changes done for both inner if and else branch
+    if (undoLogCopy) {
+      for (auto& [VD, setPVD] : undoLogThen)
+        undoLogCopy->try_emplace(VD, setPVD);
+      for (auto& [VD, setPVD] : undoLogElse)
+        undoLogCopy->try_emplace(VD, setPVD);
+    }
+
+    undoLog = undoLogCopy;
+    return true;
   }
 
   bool VisitVarDecl(clang::VarDecl* VD) {
-    if (llvm::isa<clang::ParmVarDecl>(VD) ||
-        (!VD->getType()->isPointerType() && !VD->getType()->isRecordType()))
+    if (llvm::isa<clang::ParmVarDecl>(VD))
       return true;
     const clang::Expr* E = VD->getInit();
     updateMap(VD, E);
@@ -2051,60 +2149,144 @@ struct DeallocationTraverser : RecursiveASTVisitor<DeallocationTraverser> {
 
   bool VisitCXXDeleteExpr(clang::CXXDeleteExpr* CDE) {
     const clang::Expr* E = CDE->getArgument();
-    const auto* PVR = resolveParam(E);
-    if (!PVR)
-      return true;
+    auto setPVD = resolveAlias(E);
     if (CDE->isArrayForm()) {
-      updateVPP(PVR->getFunctionScopeIndex(), DeallocType::DeleteArr);
+      updateVPP(setPVD, DeallocType::DeleteArr);
       return true;
     }
-    updateVPP(PVR->getFunctionScopeIndex(), DeallocType::Delete);
+    updateVPP(setPVD, DeallocType::Delete);
     return true;
   }
 
   bool VisitCallExpr(clang::CallExpr* CE) {
-    // FIXME: for some operators, arg and parameter match may not match because
-    // of hidden __this__ parameter
-    if (llvm::isa<clang::CXXOperatorCallExpr>(CE))
-      return true;
     const clang::FunctionDecl* FD = CE->getDirectCallee();
+    // FIXME: function pointer call, it should behave as no-body functions, but
+    // it acts as identity
     if (!FD)
       return true;
+    unsigned offset = 0;
     if (FD->getBuiltinID() == Builtin::ID::BIfree) {
       handleFree(CE);
       return true;
     }
+    if (FD->getBuiltinID() == Builtin::ID::BI__builtin_operator_delete) {
+      handleOperatorDelete(CE);
+      return true;
+    }
+    if (llvm::isa<clang::CXXOperatorCallExpr>(CE)) {
+      if (const auto* CMD = dyn_cast<clang::CXXMethodDecl>(FD)) {
+        // implicit object member functions that which is not CXXMemberCall have
+        // `this` object at 0th arguments, but it does not effect parameters so
+        // this cause offset, same goes for static operator calls but it holds
+        // and temporaryExpr at 0th arg
+        if (CMD->isStatic() || CMD->isImplicitObjectMemberFunction())
+          offset = 1;
+      }
+    }
 
-    // FIXME: Recursive Case
+    // Detects operator new/new[]/delete/delete[]
+    if (FD->isReplaceableGlobalAllocationFunction()) {
+      switch (FD->getOverloadedOperator()) {
+      case OO_Delete:
+        handleOperatorDelete(CE);
+        return true;
+      case OO_Array_Delete:
+        handleOperatorDelete(CE, true);
+        return true;
+      default:
+        return true; // OO_New/OO_Array_New
+      }
+    }
     auto it = visitedFuncs.find(FD);
     if (it != visitedFuncs.end()) {
       // Function calls itself, or a cycle recursion
       if (it->second == std::nullopt)
         return true;
-      joinVectors(*(it->second), CE);
+      joinVectors(*(it->second), CE, offset);
       return true;
     }
     std::vector<DeallocType> calleeVec;
     visitedFuncs[FD] = std::nullopt;
     AnalyzeDeallocType(FD, calleeVec, visitedFuncs);
-    joinVectors(calleeVec, CE);
+    joinVectors(calleeVec, CE, offset);
     return true;
   }
 
-  const clang::ParmVarDecl* resolveParam(const clang::Expr* E) {
+  // if(ptr) delete ptr;  this pattern should return Delete not MaybeDelete, so
+  // this function recognizes this pattern
+  const clang::VarDecl* getNullCheckCond(const clang::Expr* E) {
+    if (!E)
+      return nullptr;
+    E = E->IgnoreParens();
+    const auto* ICE = dyn_cast<clang::ImplicitCastExpr>(E);
+    if (!ICE)
+      return nullptr;
+    if (ICE->getCastKind() != CastKind::CK_PointerToBoolean)
+      return nullptr;
+    // FIXME: Explicit casts are not handled:
+    // Ex: if((void*)ptr) delete ptr; ->is not recognized, for safety
+    E = E->IgnoreParenImpCasts();
+    if (const auto* DRE = dyn_cast<clang::DeclRefExpr>(E))
+      return dyn_cast<clang::VarDecl>(DRE->getDecl());
+    return nullptr;
+  }
+
+  void undoOnAliasMap() {
+    for (auto& [VD, setPVD] : *undoLog)
+      aliasMap[VD] = setPVD;
+  }
+
+  void handleOperatorDelete(clang::CallExpr* CE, bool isDeleteArr = false) {
+    const clang::Expr* paramExpr = CE->getArg(0);
+    auto setPVD = resolveAlias(paramExpr);
+    if (isDeleteArr) {
+      updateVPP(setPVD, DeallocType::OperatorDeleteArr);
+      return;
+    }
+    updateVPP(setPVD, DeallocType::OperatorDelete);
+  }
+  void handleFree(clang::CallExpr* CE) {
+    const clang::Expr* paramExpr = CE->getArg(0);
+    auto setPVD = resolveAlias(paramExpr);
+    updateVPP(setPVD, DeallocType::Free);
+  }
+
+  // recursiveVec is VPP of callee
+  void joinVectors(std::vector<DeallocType>& recursiveVec, clang::CallExpr* CE,
+                   unsigned offset) {
+    for (unsigned i = 0; i < recursiveVec.size() && i < CE->getNumArgs(); i++) {
+      auto setPVD = resolveAlias(CE->getArg(i + offset));
+      updateVPP(setPVD, recursiveVec[i]);
+    }
+  }
+
+  const clang::VarDecl* resolveExpr(const clang::Expr* E) {
+    if (!E)
+      return nullptr;
+    E = E->IgnoreParenCasts();
+    // delete *ptr; where ptr is std::optional<void*> or any other wrapper
+    if (const auto* COCE = dyn_cast<CXXOperatorCallExpr>(E)) {
+      if (COCE->getOperator() == OverloadedOperatorKind::OO_Star &&
+          !COCE->isInfixBinaryOp())
+        return resolveExpr(COCE->getArg(0));
+      return nullptr;
+    }
+    const auto* DRE = dyn_cast<clang::DeclRefExpr>(E);
+    if (!DRE)
+      return nullptr;
+    const auto* VD = dyn_cast<clang::VarDecl>(DRE->getDecl());
+    return VD;
+  }
+
+  std::set<const clang::ParmVarDecl*> resolveAlias(const clang::Expr* E) {
     const auto* VD = resolveExpr(E);
     if (!VD)
-      return nullptr;
-    if (const auto* PVD = dyn_cast<clang::ParmVarDecl>(VD)) {
-      if (overwritenParms.count(PVD))
-        return nullptr;
-      return PVD;
-    }
+      return std::set<const clang::ParmVarDecl*>{nullptr};
     auto it = aliasMap.find(VD);
-    if (it != aliasMap.end() && it->second != nullptr) {
+    if (it != aliasMap.end()) {
       return it->second;
     }
-    return nullptr;
+    return std::set<const clang::ParmVarDecl*>{nullptr};
   }
 
   void updateMap(const clang::VarDecl* VD, const clang::Expr* E) {
@@ -2112,66 +2294,105 @@ struct DeallocationTraverser : RecursiveASTVisitor<DeallocationTraverser> {
       return;
     if (!VD->getType()->isPointerType() && !VD->getType()->isRecordType())
       return;
-    if (const auto* PVD = dyn_cast<clang::ParmVarDecl>(VD)) {
-      overwritenParms.insert(PVD);
-      return;
-    }
-    const auto* rhsVD = resolveExpr(E);
-
-    if (!rhsVD) {
-      aliasMap[VD] = nullptr;
-      return;
-    }
-
-    if (const auto* rhsPVD = dyn_cast<clang::ParmVarDecl>(rhsVD)) {
-      if (overwritenParms.count(rhsPVD)) {
-        aliasMap[VD] = nullptr;
-        return;
-      }
-      aliasMap[VD] = rhsPVD;
-      // FIXME: does not handle situation where one param is assigned to
-      // another param
-      return;
-    }
-
-    auto it = aliasMap.find(rhsVD);
-    if (it != aliasMap.end()) {
-      aliasMap[VD] = it->second;
-      return;
-    }
-    aliasMap[VD] = nullptr;
+    if (undoLog)
+      undoLog->try_emplace(VD, aliasMap[VD]);
+    aliasMap[VD] = resolveAlias(E);
   }
 
-  void updateVPP(unsigned index, DeallocType DT) {
-    if (valPerParam[index] == DeallocType::Unknown)
+  void updateVPP(std::set<const clang::ParmVarDecl*>& setPVD, DeallocType DT) {
+    if (setPVD.size() != 1)
+      DT = toMaybe(DT);
+    for (auto* PVD : setPVD) {
+      if (PVD == nullptr)
+        continue;
+      updateParam(PVD->getFunctionScopeIndex(), DT);
+    }
+  }
+
+  void updateParam(unsigned index, DeallocType DT) {
+    if (index >= valPerParam.size())
       return;
-    // If new value from callee is Opaque, it is best to make parameter Unknown
-    // since we can not know what is going inside no-body functions
-    if ((valPerParam[index] != DeallocType::None && valPerParam[index] != DT) ||
-        DT == DeallocType::Opaque) {
+    auto curVal = valPerParam[index];
+    // Early return
+    if (curVal == DeallocType::Unknown)
+      return;
+    // If DT did not effect index, or callee could not analyzed
+    if (DT == DeallocType::None || DT == DeallocType::Opaque)
+      return;
+    // If the parameter has not been deallocated so far, there is no
+    // contradiction
+    if (curVal == DeallocType::None) {
+      valPerParam[index] = DT;
+      return;
+    }
+    // Totally different situations
+    if (absoluteKind(curVal) != absoluteKind(DT)) {
       valPerParam[index] = DeallocType::Unknown;
       return;
     }
-    valPerParam[index] = DT;
-  }
-
-  void handleFree(clang::CallExpr* CE) {
-    const clang::Expr* paramExpr = CE->getArg(0);
-    const auto* PVR = resolveParam(paramExpr);
-    if (!PVR)
+    // Maybe + Maybe = Maybe
+    if (isMaybe(curVal) && isMaybe(DT)) {
+      valPerParam[index] = DT;
       return;
-    updateVPP(PVR->getFunctionScopeIndex(), DeallocType::Free);
+    }
+    // Maybe + Absolute = Absolute
+    valPerParam[index] = absoluteKind(DT);
   }
 
-  const clang::VarDecl* resolveExpr(const clang::Expr* E) {
-    if (!E)
-      return nullptr;
-    E = E->IgnoreParenCasts();
-    const auto* DRE = dyn_cast<clang::DeclRefExpr>(E);
-    if (!DRE)
-      return nullptr;
-    const auto* VD = dyn_cast<clang::VarDecl>(DRE->getDecl());
-    return VD;
+  // Joining if-else branches
+  static DeallocType join(DeallocType a, DeallocType b) {
+    // Unknown devours
+    if (a == DeallocType::Unknown || b == DeallocType::Unknown)
+      return DeallocType::Unknown;
+    // None acts as identity
+    if (a == DeallocType::None)
+      return toMaybe(b);
+    if (b == DeallocType::None)
+      return toMaybe(a);
+    // Different deallocation types
+    if (absoluteKind(a) != absoluteKind(b))
+      return DeallocType::Unknown;
+    // If one is uncertain, their join is also uncertain
+    if (isMaybe(a) || isMaybe(b))
+      return toMaybe(a);
+    // Guaranteed a==b
+    return a;
+  }
+
+  static bool isMaybe(DeallocType DT) { return DT != absoluteKind(DT); }
+
+  static DeallocType absoluteKind(DeallocType DT) {
+    switch (DT) {
+    case DeallocType::MaybeDelete:
+      return DeallocType::Delete;
+    case DeallocType::MaybeDeleteArr:
+      return DeallocType::DeleteArr;
+    case DeallocType::MaybeFree:
+      return DeallocType::Free;
+    case DeallocType::MaybeOperatorDelete:
+      return DeallocType::OperatorDelete;
+    case DeallocType::MaybeOperatorDeleteArr:
+      return DeallocType::OperatorDeleteArr;
+    default:
+      return DT;
+    }
+  }
+
+  static DeallocType toMaybe(DeallocType DT) {
+    switch (DT) {
+    case DeallocType::Delete:
+      return DeallocType::MaybeDelete;
+    case DeallocType::DeleteArr:
+      return DeallocType::MaybeDeleteArr;
+    case DeallocType::Free:
+      return DeallocType::MaybeFree;
+    case DeallocType::OperatorDelete:
+      return DeallocType::MaybeOperatorDelete;
+    case DeallocType::OperatorDeleteArr:
+      return DeallocType::MaybeOperatorDeleteArr;
+    default:
+      return DT;
+    }
   }
 };
 } // namespace
@@ -2181,7 +2402,8 @@ static bool AnalyzeDeallocType(
     std::unordered_map<const FunctionDecl*,
                        std::optional<std::vector<DeallocType>>>& visitedFuncs) {
   const unsigned int numParam = FD->getNumParams();
-  const auto* S = FD->getBody();
+  const clang::FunctionDecl* realDef = nullptr;
+  const auto* S = FD->getBody(realDef);
   if (!S) {
     valPerParam.assign(numParam, DeallocType::Opaque);
     visitedFuncs[FD] = valPerParam;
@@ -2196,6 +2418,8 @@ static bool AnalyzeDeallocType(
   }
   valPerParam.assign(numParam, DeallocType::None);
   DeallocationTraverser Traverser(valPerParam, visitedFuncs);
+  for (auto* PVD : realDef->parameters())
+    Traverser.aliasMap[PVD] = std::set<const clang::ParmVarDecl*>{PVD};
   Traverser.TraverseStmt(const_cast<CompoundStmt*>(CmpStmt));
   visitedFuncs[FD] = valPerParam;
   return true;

--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -1992,10 +1992,6 @@ static bool AnalyzeDeallocType(
     const clang::FunctionDecl* FD, std::vector<DeallocType>& valPerParam,
     std::unordered_map<const FunctionDecl*,
                        std::optional<std::vector<DeallocType>>>& visitedFuncs);
-static bool AnalyzeDeallocType(
-    const clang::FunctionDecl* FD, std::vector<DeallocType>& valPerParam,
-    std::unordered_map<const FunctionDecl*,
-                       std::optional<std::vector<DeallocType>>>& visitedFuncs);
 namespace {
 struct DeallocationTraverser : RecursiveASTVisitor<DeallocationTraverser> {
   std::unordered_map<const clang::VarDecl*, std::set<const clang::ParmVarDecl*>>
@@ -2021,14 +2017,6 @@ struct DeallocationTraverser : RecursiveASTVisitor<DeallocationTraverser> {
     return RecursiveASTVisitor::TraverseDecl(D);
   }
 
-  // recursiveVec is VPP of callee
-  void joinVectors(std::vector<DeallocType>& recursiveVec,
-                   clang::CallExpr* CE) {
-    for (unsigned i = 0; i < recursiveVec.size() && i < CE->getNumArgs(); i++) {
-      if (recursiveVec[i] == DeallocType::None)
-        continue;
-      const clang::ParmVarDecl* PVD = resolveParam(CE->getArg(i));
-      if (!PVD)
   bool TraverseIfStmt(clang::IfStmt* IS) {
     TraverseStmt(IS->getConditionVariableDeclStmt());
     TraverseStmt(IS->getCond());
@@ -2312,9 +2300,15 @@ struct DeallocationTraverser : RecursiveASTVisitor<DeallocationTraverser> {
     if (index >= valPerParam.size())
       return;
     auto curVal = valPerParam[index];
-    // If DT did not effect index, or callee could not analyzed
-    if (DT == DeallocType::None || DT == DeallocType::Opaque)
+    // If DT did not effect index
+    if (DT == DeallocType::None)
       return;
+    // If new value from callee is Opaque, it is best to make parameter Unknown
+    // since we can not know what is going inside no-body functions
+    if (DT == DeallocType::Opaque) {
+      valPerParam[index] = DeallocType::Unknown;
+      return;
+    }
     // If the parameter has not been deallocated so far, there is no
     // contradiction
     if (curVal == DeallocType::None) {

--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -1992,6 +1992,10 @@ static bool AnalyzeDeallocType(
     const clang::FunctionDecl* FD, std::vector<DeallocType>& valPerParam,
     std::unordered_map<const FunctionDecl*,
                        std::optional<std::vector<DeallocType>>>& visitedFuncs);
+static bool AnalyzeDeallocType(
+    const clang::FunctionDecl* FD, std::vector<DeallocType>& valPerParam,
+    std::unordered_map<const FunctionDecl*,
+                       std::optional<std::vector<DeallocType>>>& visitedFuncs);
 namespace {
 struct DeallocationTraverser : RecursiveASTVisitor<DeallocationTraverser> {
   std::unordered_map<const clang::VarDecl*, const clang::ParmVarDecl*> aliasMap;

--- a/unittests/CppInterOp/FunctionReflectionTest.cpp
+++ b/unittests/CppInterOp/FunctionReflectionTest.cpp
@@ -1256,109 +1256,6 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_GetDeallocType) {
 
     void func41(int* ptr){ auto l = [&]{ delete ptr; }; }
 
-    void func24(int* p, int* q){ q = p; delete q; }
-
-    void func25(int* ptr){ func0(ptr); }
-
-    void func26(int* ptr1, int* ptr2){ func2(ptr1); func1(ptr2); }
-
-    void func27(int* ptr1, int* ptr2){ func0(ptr1); func6(ptr2); }
-
-    void func28(int* ptr1, int* ptr2){
-      int* tmp1 = ptr1;
-      func0(tmp1);
-      int* tmp2 = ptr2;
-      func23(tmp2);
-    }
-
-    void func29(int* ptr, int n){
-      if(n > 0)
-        func29(ptr, n-1);
-      delete ptr;
-    }
-
-    void func31(int* ptr, int n);
-    void func32(int* ptr, int n);
-    void func30(int* ptr, int n){
-      func31(ptr, n);
-    }
-
-    void func31(int* ptr, int n){
-      func32(ptr, n-1);
-    }
-
-    void func32(int* ptr, int n){
-      if(n > 0)
-        func30(ptr, n-1);
-      delete ptr;
-    }
-
-    // FIXME: Can not resolve parameter location in recursive call
-    // Probably impossible to solve statically
-    void func33(int* ptr1, int* ptr2, int n){
-      if(n > 0)
-        func33(ptr2, ptr1, n-1);
-      delete ptr1;
-    }
-
-    void func34(int* ptr1, int* ptr2){
-      delete ptr1;
-    }
-
-    void func35(int* ptr1, int* ptr2){
-      func34(ptr2, ptr1);
-    }
-
-    void func36(int* ptr1, int* ptr2){
-      func25(ptr1);
-      func0(ptr2);
-    }
-
-    void func37(int* ptr){
-      helper20(ptr);
-      delete ptr;
-    }
-
-    void func38(int* ptr){
-      delete ptr;
-      helper20(ptr);
-    }
-
-    void func39(int* ptr){
-      ptr = nullptr;
-      func0(ptr);
-    }
-
-    void func40(int* ptr, int n){
-      if(n > 0)
-        func0(ptr);
-      else
-        func2(ptr);
-    }
-
-    struct Klass {
-      void operator=(int* q){
-        delete q;
-      }
-    };
-    void func41(int* p, Klass& K){
-      K = p;
-    }
-
-    void func42(int* ptr){ auto l = [&]{ delete ptr; }; }
-
-    void func43(int* ptr){
-      ptr = nullptr;
-      int* x = ptr;
-      delete x;
-    }
-
-    void func44(int* ptr){ func8(ptr, true); }
-
-    void func45(int* ptr){
-      struct S { void g(int* q){ delete q; } };
-      delete ptr;
-    }
     void func42(int* ptr){
       ptr = nullptr;
       int* x = ptr;
@@ -1373,11 +1270,11 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_GetDeallocType) {
     }
 
     // This test's purpose is testing some lines, no specific purpose
-    int* globPtr = nullptr;
+    int* globPtr1 = nullptr;
     void func45(int* ptr){
       int a = 5;
       a = 6;
-      int* tmp = globPtr;
+      int* tmp = globPtr1;
       tmp = (int*)malloc(sizeof(int));
       free(tmp);
       delete ptr;
@@ -1743,14 +1640,14 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_GetDeallocType) {
     void func100(int* p){ Releaser r; r.release(p); }
 
     // This test is for covering some lines, not something meaningful
-    int* globPtr;
+    int* globPtr2;
     struct coverageStruct { int* operator*(int* q) { return q; } };
 
     void func101(int* p){
       void forCoverage(int*);
       int* tmp = (int*)::operator new(sizeof(int));
       ::operator delete(tmp);
-      delete globPtr;
+      delete globPtr2;
       coverageStruct s;
       delete (s * p);
     }
@@ -1786,33 +1683,32 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_GetDeallocType) {
   TESTGDT(16, true, DT::None);
   TESTGDT(17, true, DT::None);
   TESTGDT(18, true, DT::None, DT::None);
-  TESTGDT(19, true, DT::None);
-  TESTGDT(20, true, DT::None);
+  TESTGDT(19, true, DT::Unknown);
+  TESTGDT(20, true, DT::Delete);
   TESTGDT(21, true, DT::Delete);
   TESTGDT(22, true, DT::Delete);
-  TESTGDT(23, true, DT::Delete);
-  TESTGDT(24, true, DT::Delete, DT::None);
-  TESTGDT(25, true, DT::Delete);
-  TESTGDT(26, true, DT::Free, DT::DeleteArr);
-  TESTGDT(27, true, DT::Delete, DT::None);
-  TESTGDT(28, true, DT::Delete, DT::Delete);
+  TESTGDT(23, true, DT::Delete, DT::None);
+  TESTGDT(24, true, DT::Delete);
+  TESTGDT(25, true, DT::Free, DT::DeleteArr);
+  TESTGDT(26, true, DT::Delete, DT::None);
+  TESTGDT(27, true, DT::Delete, DT::Delete);
+  TESTGDT(28, true, DT::Delete, DT::None);
   TESTGDT(29, true, DT::Delete, DT::None);
   TESTGDT(30, true, DT::Delete, DT::None);
   TESTGDT(31, true, DT::Delete, DT::None);
-  TESTGDT(32, true, DT::Delete, DT::None);
-  TESTGDT(33, true, DT::Delete, DT::None, DT::None);
-  TESTGDT(34, true, DT::Delete, DT::None);
-  TESTGDT(35, true, DT::None, DT::Delete);
-  TESTGDT(36, true, DT::Delete, DT::Delete);
-  TESTGDT(37, true, DT::Delete);
-  TESTGDT(38, true, DT::Delete);
-  TESTGDT(39, true, DT::None);
-  TESTGDT(40, true, DT::Unknown, DT::None);
-  // K = p is a call to Klass::operator=, an implicit object member function
-  TESTGDT(41, true, DT::Delete, DT::None);
+  TESTGDT(32, true, DT::Delete, DT::None, DT::None);
+  TESTGDT(33, true, DT::Delete, DT::None);
+  TESTGDT(34, true, DT::None, DT::Delete);
+  TESTGDT(35, true, DT::Delete, DT::Delete);
+  TESTGDT(36, true, DT::Unknown);
+  TESTGDT(37, true, DT::Unknown);
+  TESTGDT(38, true, DT::None);
+  TESTGDT(39, true, DT::Unknown, DT::None);
+  TESTGDT(40, true, DT::Delete, DT::None);
+  TESTGDT(41, true, DT::None);
   TESTGDT(42, true, DT::None);
-  TESTGDT(43, true, DT::None);
-  TESTGDT(44, true, DT::Unknown);
+  TESTGDT(43, true, DT::Unknown);
+  TESTGDT(44, true, DT::Delete);
   TESTGDT(45, true, DT::Delete);
   TESTGDT(46, true, DT::MaybeDelete, DT::None);
   TESTGDT(47, true, DT::MaybeDelete, DT::MaybeDelete, DT::None);
@@ -1873,69 +1769,11 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_GetDeallocType) {
   TESTGDT(94, true, DT::None);
   TESTGDT(95, true, DT::Delete);
   TESTGDT(96, true, DT::None, DT::Delete);
-  TESTGDT(98, true, DT::DeleteArr);
   TESTGDT(97, true, DT::Delete);
+  TESTGDT(98, true, DT::DeleteArr);
   TESTGDT(99, true, DT::Delete);
   TESTGDT(100, true, DT::Delete);
   TESTGDT(101, true, DT::None);
-
-  TESTGDT(19, true, DT::Unknown);
-  TESTGDT(20, true, DT::Delete);
-  TESTGDT(21, true, DT::Delete);
-  TESTGDT(22, true, DT::Delete);
-  TESTGDT(23, true, DT::None, DT::None);
-  TESTGDT(24, true, DT::Delete);
-  TESTGDT(25, true, DT::Free, DT::DeleteArr);
-  TESTGDT(26, true, DT::Delete, DT::None);
-  TESTGDT(27, true, DT::Delete, DT::Delete);
-  TESTGDT(28, true, DT::Delete, DT::None);
-  TESTGDT(29, true, DT::Delete, DT::None);
-  TESTGDT(30, true, DT::Delete, DT::None);
-  TESTGDT(31, true, DT::Delete, DT::None);
-  TESTGDT(32, true, DT::Delete, DT::None, DT::None);
-  TESTGDT(33, true, DT::Delete, DT::None);
-  TESTGDT(34, true, DT::None, DT::Delete);
-  TESTGDT(35, true, DT::Delete, DT::Delete);
-  TESTGDT(36, true, DT::Unknown);
-  TESTGDT(37, true, DT::Unknown);
-  TESTGDT(38, true, DT::None);
-  TESTGDT(39, true, DT::Unknown, DT::None);
-  // FIXME: check top of VisitCallExpr function
-  TESTGDT(40, true, DT::None, DT::None);
-  TESTGDT(41, true, DT::None);
-  TESTGDT(42, true, DT::None);
-  TESTGDT(43, true, DT::Unknown);
-  TESTGDT(44, true, DT::Delete);
-  TESTGDT(45, true, DT::Delete);
-
-  TESTGDT(19, true, DT::Unknown);
-  TESTGDT(20, true, DT::Delete);
-  TESTGDT(21, true, DT::Delete);
-  TESTGDT(22, true, DT::Delete);
-  TESTGDT(23, true, DT::None, DT::None);
-  TESTGDT(24, true, DT::Delete);
-  TESTGDT(25, true, DT::Free, DT::DeleteArr);
-  TESTGDT(26, true, DT::Delete, DT::None);
-  TESTGDT(27, true, DT::Delete, DT::Delete);
-  TESTGDT(28, true, DT::Delete, DT::None);
-  TESTGDT(29, true, DT::Delete, DT::None);
-  TESTGDT(30, true, DT::Delete, DT::None);
-  TESTGDT(31, true, DT::Delete, DT::None);
-  TESTGDT(32, true, DT::Delete, DT::None, DT::None);
-  TESTGDT(33, true, DT::Delete, DT::None);
-  TESTGDT(34, true, DT::None, DT::Delete);
-  TESTGDT(35, true, DT::Delete, DT::Delete);
-  TESTGDT(36, true, DT::Unknown);
-  TESTGDT(37, true, DT::Unknown);
-  TESTGDT(38, true, DT::None);
-  TESTGDT(39, true, DT::Unknown, DT::None);
-  // FIXME: check top of VisitCallExpr function
-  TESTGDT(40, true, DT::None, DT::None);
-  TESTGDT(41, true, DT::None);
-  TESTGDT(42, true, DT::None);
-  TESTGDT(43, true, DT::Unknown);
-  TESTGDT(44, true, DT::Delete);
-  TESTGDT(45, true, DT::Delete);
 
 #undef TESTGDT
 

--- a/unittests/CppInterOp/FunctionReflectionTest.cpp
+++ b/unittests/CppInterOp/FunctionReflectionTest.cpp
@@ -1436,8 +1436,9 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_GetDeallocType) {
       if(n>5){
         if(n>8)
           delete p;
-        else
-          delete p;
+      }
+      else {
+        delete p;
       }
     }
 
@@ -1549,15 +1550,15 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_GetDeallocType) {
 
     void func63(int* p, int n){
       if(n>0)
-        delete p;
-      delete p;
+        ::operator delete[](p);
+      ::operator delete[](p);
     }
 
     void func64(int* p, int n){
       if(n>0)
-        delete p;
+        ::operator delete(p);
       if(n>5)
-        delete p;
+        ::operator delete(p);
     }
 
     void func65(int* p, int n){
@@ -1663,12 +1664,15 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_GetDeallocType) {
 
     void func80(int* p){ if(p != nullptr) delete p; }
 
-    void func81(int* p){
-      if(!p){
-
+    void func81(int* p, int* q, int n){
+      int* x = p;
+      if(n>0){
+        // Nothing changed
       }
-      else
-        delete p;
+      else {
+        x = q;
+      }
+      delete x;
     }
 
     void func82(int* p){ ::operator delete(p); }
@@ -1690,9 +1694,15 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_GetDeallocType) {
 
     void func89(std::optional<int*> p){ free(*p); }
 
-    void func90(std::optional<int*> p, int n){
-      if(n>0)
-        delete *p;
+    void func90(int* p, int* q, int n){
+      int* x = nullptr;
+      if(n>0){
+        if(n>5)
+          x = p;
+        else
+          x = q;
+      }
+      delete x;
     }
 
     void func91(std::optional<int*> p){ int* x = *p; delete x; }
@@ -1731,6 +1741,19 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_GetDeallocType) {
     struct Releaser { void release(int* p){ delete p; } };
     //No offset
     void func100(int* p){ Releaser r; r.release(p); }
+
+    // This test is for covering some lines, not something meaningful
+    int* globPtr;
+    struct coverageStruct { int* operator*(int* q) { return q; } };
+
+    void func101(int* p){
+      void forCoverage(int*);
+      int* tmp = (int*)::operator new(sizeof(int));
+      ::operator delete(tmp);
+      delete globPtr;
+      coverageStruct s;
+      delete (s * p);
+    }
   )";
   TestFixture::CreateInterpreter({"-std=c++17"});
   Interp->declare(code);
@@ -1808,8 +1831,8 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_GetDeallocType) {
   TESTGDT(60, true, DT::MaybeDeleteArr, DT::None);
   TESTGDT(61, true, DT::MaybeFree, DT::None);
   TESTGDT(62, true, DT::Delete, DT::None);
-  TESTGDT(63, true, DT::Delete, DT::None);
-  TESTGDT(64, true, DT::MaybeDelete, DT::None);
+  TESTGDT(63, true, DT::OperatorDeleteArr, DT::None);
+  TESTGDT(64, true, DT::MaybeOperatorDelete, DT::None);
   TESTGDT(65, true, DT::Unknown, DT::None);
   TESTGDT(66, true, DT::MaybeDelete, DT::None);
   TESTGDT(67, true, DT::MaybeDelete, DT::MaybeDelete, DT::None);
@@ -1825,9 +1848,9 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_GetDeallocType) {
   TESTGDT(77, true, DT::MaybeDelete, DT::None);
   TESTGDT(78, true, DT::None, DT::MaybeDelete);
   TESTGDT(79, true, DT::Unknown);
-  // FIXME: Unrecognized null checks
+  // FIXME: Unrecognized null check
   TESTGDT(80, true, DT::MaybeDelete);
-  TESTGDT(81, true, DT::MaybeDelete);
+  TESTGDT(81, true, DT::MaybeDelete, DT::MaybeDelete, DT::None);
   TESTGDT(82, true, DT::OperatorDelete);
   TESTGDT(83, true, DT::OperatorDeleteArr);
   // Placement delete is not a replaceable global deallocation function, it
@@ -1838,7 +1861,7 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_GetDeallocType) {
   TESTGDT(87, true, DT::Delete);
   TESTGDT(88, true, DT::DeleteArr);
   TESTGDT(89, true, DT::Free);
-  TESTGDT(90, true, DT::MaybeDelete, DT::None);
+  TESTGDT(90, true, DT::MaybeDelete, DT::MaybeDelete, DT::None);
   TESTGDT(91, true, DT::Delete);
   // FIXME: cond is CK_UserDefinedConversion not
   // CK_PointerToBoolean, so getNullCheckCond does not recognize it
@@ -1854,6 +1877,7 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_GetDeallocType) {
   TESTGDT(97, true, DT::Delete);
   TESTGDT(99, true, DT::Delete);
   TESTGDT(100, true, DT::Delete);
+  TESTGDT(101, true, DT::None);
 
   TESTGDT(19, true, DT::Unknown);
   TESTGDT(20, true, DT::Delete);

--- a/unittests/CppInterOp/FunctionReflectionTest.cpp
+++ b/unittests/CppInterOp/FunctionReflectionTest.cpp
@@ -1097,6 +1097,7 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_FunctionTypes) {
 TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_GetDeallocType) {
   std::string code = R"(
     #include <new>
+    #include <optional>
     #include <stdlib.h>
 
     void func0(int* p){ delete p; }
@@ -1381,8 +1382,357 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_GetDeallocType) {
       free(tmp);
       delete ptr;
     }
+
+    void func46(int* p, int n){
+      if(n>0)
+        delete p;
+    }
+
+    void func47(int* p, int* q, int n){
+      if(n>0){
+        delete p;
+      } else {
+        delete q;
+      }
+    }
+
+    void func48(int* p, int n){
+      if(n>9)
+        delete p;
+      else if(n>5)
+        free(p);
+      else if(n>2)
+        delete p;
+      else
+        delete p;
+    }
+
+    void func49(int* p, int n){
+      if(n>0){
+        delete p;
+        free(p);
+      }
+    }
+
+    void func50(int* p, int n){
+      if(int* tmp = p){
+        delete tmp;
+      }
+    }
+
+    void func51(int* p, int n){
+      if(n>9){
+
+      }
+      else if(n>5){
+        delete p;
+      }
+      else{
+        delete p;
+      }
+    }
+
+    void func52(int* p, int n){
+      if(n>5){
+        if(n>8)
+          delete p;
+        else
+          delete p;
+      }
+    }
+
+    void func53(int* p, int n){
+      if(n>20){
+        if(n>15){
+          if(n>10)
+            delete p;
+          else
+            delete p;
+        }
+        else {
+          delete p;
+        }
+      }
+      else {
+        delete p;
+      }
+    }
+
+    void func54(int* p, int* q, int n){
+      if(n>30){
+        delete q;
+        if(n>25){
+          if(n>22)
+            delete p;
+          else
+            delete p;
+        }
+        else {
+          delete p;
+        }
+      }
+      else if(n>20){
+        delete p;
+        if(n>15)
+          delete q;
+        else
+          free(q);
+      }
+      else {
+        delete p;
+        delete q;
+      }
+    }
+
+    void func55(int* p, int* q, int n){
+      free(p);
+      delete q;
+      if(n>30){
+        if(n>25){
+          free(p);
+          if(n>20)
+            q += 1;
+        }
+        else {
+          free(p);
+        }
+      }
+    }
+
+    void func56(int* p, int* q, int n){
+      int* x = p;
+      if(x = q){
+
+      }
+      delete x;
+    }
+
+    void func57(int* p, int n){
+      if(n>0){
+        delete p;
+        return;
+      }
+      free(p);
+    }
+
+    void func58(int* p, int n){
+      int* x = static_cast<int*>(0);
+      if(n>0)
+        x = p;
+      delete x;
+    }
+
+    void func59(int* p, int* q, int n){
+      int* x;
+      if(n>0)
+        x = p;
+      else
+        x = q;
+      delete x;
+    }
+
+    void func60(int* p, int n){
+      if(n>0)
+        delete[] p;
+    }
+
+    void func61(int* p, int n){
+      if(n>0)
+        free(p);
+    }
+
+    void func62(int* p, int n){
+      delete p;
+      if(n>0)
+        delete p;
+    }
+
+    void func63(int* p, int n){
+      if(n>0)
+        delete p;
+      delete p;
+    }
+
+    void func64(int* p, int n){
+      if(n>0)
+        delete p;
+      if(n>5)
+        delete p;
+    }
+
+    void func65(int* p, int n){
+      if(n>0)
+        delete p;
+      if(n>5)
+        free(p);
+    }
+
+    void func66(int* p, int n){ func46(p, n); }
+
+    void func67(int* p, int* q, int n){
+      int* x = nullptr;
+      if(n>0)
+        x = p;
+      else
+        x = q;
+      func0(x);
+    }
+
+    void func68(int* p, int* q, int n){
+      int* x = q;
+      if(n>0){
+        if(n>5)
+          x = p;
+      }
+      delete x;
+    }
+
+    bool helper69(int* p){ delete p; return true; }
+
+    void func69(int* p){
+      if(helper69(p)){
+
+      }
+    }
+
+    void func70(int* p){
+      if(p)
+        delete p;
+    }
+
+    void func71(int* p){
+      if(p)
+        delete p;
+      else
+        free(p);
+    }
+
+    void func72(int* p){
+      if(p){
+
+      }
+      else
+        delete p;
+    }
+
+    void func73(int* p, int* q){
+      if(q)
+        delete p;
+    }
+
+    void func74(int* p, int* q, int n){
+      int* x = nullptr;
+      if(n>0)
+        x = p;
+      else
+        x = q;
+      if(x)
+        delete x;
+    }
+
+    void func75(int* p){
+      if((void*)p)
+        delete p;
+    }
+
+    void func76(int* p){
+      int* x = p;
+      if(x)
+        delete x;
+    }
+
+    void func77(int* p, int n){
+      if(p){
+        if(n>0)
+          delete p;
+      }
+    }
+
+    void func78(int* p, int* q){
+      if(p){
+        p = q;
+        delete p;
+      }
+    }
+
+    void func79(int* p){
+      delete p;
+      if(p)
+        free(p);
+    }
+
+    void func80(int* p){ if(p != nullptr) delete p; }
+
+    void func81(int* p){
+      if(!p){
+
+      }
+      else
+        delete p;
+    }
+
+    void func82(int* p){ ::operator delete(p); }
+
+    void func83(int* p){ ::operator delete[](p); }
+
+    void func84(int* p, void* buf){ ::operator delete(p, buf); }
+
+    void func85(int* p){ __builtin_operator_delete(p); }
+
+    void func86(int* p, int n){
+      if(n>0)
+        ::operator delete(p);
+    }
+
+    void func87(std::optional<int*> p){ delete *p; }
+
+    void func88(std::optional<int*> p){ delete[] *p; }
+
+    void func89(std::optional<int*> p){ free(*p); }
+
+    void func90(std::optional<int*> p, int n){
+      if(n>0)
+        delete *p;
+    }
+
+    void func91(std::optional<int*> p){ int* x = *p; delete x; }
+
+    void func92(std::optional<int*> p){
+      if(p)
+        delete *p;
+    }
+
+    void func93(std::optional<int*> p){
+      std::optional<int*> tmp = p;
+      delete *tmp;
+    }
+
+    void func94(int** p){ delete *p; }
+
+    struct PtrDeleter {
+      void operator()(int* p) const { delete p; }
+      void operator[](int* p) const { delete[] p; }
+    };
+
+    void func95(int* p){ PtrDeleter deleter; deleter(p); }
+
+    void func96(PtrDeleter d, int* p){ d(p); }
+
+    //This is a member call, so there is no offset
+    void func97(int* p){ PtrDeleter d; d.operator()(p); }
+
+    void func98(int* p){ PtrDeleter d; d[p]; }
+
+    struct Deleter {};
+    void operator+(Deleter, int* p){ delete p; }
+    //No offset
+    void func99(int* p){ Deleter d; d + p; }
+
+    struct Releaser { void release(int* p){ delete p; } };
+    //No offset
+    void func100(int* p){ Releaser r; r.release(p); }
   )";
-  TestFixture::CreateInterpreter();
+  TestFixture::CreateInterpreter({"-std=c++17"});
   Interp->declare(code);
 
   using DT = Cpp::DeallocType;
@@ -1418,7 +1768,7 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_GetDeallocType) {
   TESTGDT(21, true, DT::Delete);
   TESTGDT(22, true, DT::Delete);
   TESTGDT(23, true, DT::Delete);
-  TESTGDT(24, true, DT::None, DT::None);
+  TESTGDT(24, true, DT::Delete, DT::None);
   TESTGDT(25, true, DT::Delete);
   TESTGDT(26, true, DT::Free, DT::DeleteArr);
   TESTGDT(27, true, DT::Delete, DT::None);
@@ -1435,11 +1785,103 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_GetDeallocType) {
   TESTGDT(38, true, DT::Delete);
   TESTGDT(39, true, DT::None);
   TESTGDT(40, true, DT::Unknown, DT::None);
-  // FIXME: check top of VisitCallExpr function
-  TESTGDT(41, true, DT::None, DT::None);
+  // K = p is a call to Klass::operator=, an implicit object member function
+  TESTGDT(41, true, DT::Delete, DT::None);
   TESTGDT(42, true, DT::None);
   TESTGDT(43, true, DT::None);
   TESTGDT(44, true, DT::Unknown);
+  TESTGDT(45, true, DT::Delete);
+  TESTGDT(46, true, DT::MaybeDelete, DT::None);
+  TESTGDT(47, true, DT::MaybeDelete, DT::MaybeDelete, DT::None);
+  TESTGDT(48, true, DT::Unknown, DT::None);
+  TESTGDT(49, true, DT::Unknown, DT::None);
+  TESTGDT(50, true, DT::Delete, DT::None);
+  TESTGDT(51, true, DT::MaybeDelete, DT::None);
+  TESTGDT(52, true, DT::MaybeDelete, DT::None);
+  TESTGDT(53, true, DT::Delete, DT::None);
+  TESTGDT(54, true, DT::Delete, DT::Unknown, DT::None);
+  TESTGDT(55, true, DT::Free, DT::Delete, DT::None);
+  TESTGDT(56, true, DT::None, DT::Delete, DT::None);
+  TESTGDT(57, true, DT::Unknown, DT::None);
+  TESTGDT(58, true, DT::MaybeDelete, DT::None);
+  TESTGDT(59, true, DT::MaybeDelete, DT::MaybeDelete, DT::None);
+  TESTGDT(60, true, DT::MaybeDeleteArr, DT::None);
+  TESTGDT(61, true, DT::MaybeFree, DT::None);
+  TESTGDT(62, true, DT::Delete, DT::None);
+  TESTGDT(63, true, DT::Delete, DT::None);
+  TESTGDT(64, true, DT::MaybeDelete, DT::None);
+  TESTGDT(65, true, DT::Unknown, DT::None);
+  TESTGDT(66, true, DT::MaybeDelete, DT::None);
+  TESTGDT(67, true, DT::MaybeDelete, DT::MaybeDelete, DT::None);
+  TESTGDT(68, true, DT::MaybeDelete, DT::MaybeDelete, DT::None);
+  TESTGDT(69, true, DT::Delete);
+  TESTGDT(70, true, DT::Delete);
+  TESTGDT(71, true, DT::Delete);
+  TESTGDT(72, true, DT::None);
+  TESTGDT(73, true, DT::MaybeDelete, DT::None);
+  TESTGDT(74, true, DT::MaybeDelete, DT::MaybeDelete, DT::None);
+  TESTGDT(75, true, DT::MaybeDelete);
+  TESTGDT(76, true, DT::Delete);
+  TESTGDT(77, true, DT::MaybeDelete, DT::None);
+  TESTGDT(78, true, DT::None, DT::MaybeDelete);
+  TESTGDT(79, true, DT::Unknown);
+  // FIXME: Unrecognized null checks
+  TESTGDT(80, true, DT::MaybeDelete);
+  TESTGDT(81, true, DT::MaybeDelete);
+  TESTGDT(82, true, DT::OperatorDelete);
+  TESTGDT(83, true, DT::OperatorDeleteArr);
+  // Placement delete is not a replaceable global deallocation function, it
+  // deallocates nothing
+  TESTGDT(84, true, DT::None, DT::None);
+  TESTGDT(85, true, DT::OperatorDelete);
+  TESTGDT(86, true, DT::MaybeOperatorDelete, DT::None);
+  TESTGDT(87, true, DT::Delete);
+  TESTGDT(88, true, DT::DeleteArr);
+  TESTGDT(89, true, DT::Free);
+  TESTGDT(90, true, DT::MaybeDelete, DT::None);
+  TESTGDT(91, true, DT::Delete);
+  // FIXME: cond is CK_UserDefinedConversion not
+  // CK_PointerToBoolean, so getNullCheckCond does not recognize it
+  TESTGDT(92, true, DT::MaybeDelete);
+  // FIXME: CopyConstructor assignments do not effect aliasMap
+  TESTGDT(93, true, DT::None);
+  // FIXME: double pointer, it was a must to distunguish unaryOperator and
+  // CXXCallOperatorExpr
+  TESTGDT(94, true, DT::None);
+  TESTGDT(95, true, DT::Delete);
+  TESTGDT(96, true, DT::None, DT::Delete);
+  TESTGDT(98, true, DT::DeleteArr);
+  TESTGDT(97, true, DT::Delete);
+  TESTGDT(99, true, DT::Delete);
+  TESTGDT(100, true, DT::Delete);
+
+  TESTGDT(19, true, DT::Unknown);
+  TESTGDT(20, true, DT::Delete);
+  TESTGDT(21, true, DT::Delete);
+  TESTGDT(22, true, DT::Delete);
+  TESTGDT(23, true, DT::None, DT::None);
+  TESTGDT(24, true, DT::Delete);
+  TESTGDT(25, true, DT::Free, DT::DeleteArr);
+  TESTGDT(26, true, DT::Delete, DT::None);
+  TESTGDT(27, true, DT::Delete, DT::Delete);
+  TESTGDT(28, true, DT::Delete, DT::None);
+  TESTGDT(29, true, DT::Delete, DT::None);
+  TESTGDT(30, true, DT::Delete, DT::None);
+  TESTGDT(31, true, DT::Delete, DT::None);
+  TESTGDT(32, true, DT::Delete, DT::None, DT::None);
+  TESTGDT(33, true, DT::Delete, DT::None);
+  TESTGDT(34, true, DT::None, DT::Delete);
+  TESTGDT(35, true, DT::Delete, DT::Delete);
+  TESTGDT(36, true, DT::Unknown);
+  TESTGDT(37, true, DT::Unknown);
+  TESTGDT(38, true, DT::None);
+  TESTGDT(39, true, DT::Unknown, DT::None);
+  // FIXME: check top of VisitCallExpr function
+  TESTGDT(40, true, DT::None, DT::None);
+  TESTGDT(41, true, DT::None);
+  TESTGDT(42, true, DT::None);
+  TESTGDT(43, true, DT::Unknown);
+  TESTGDT(44, true, DT::Delete);
   TESTGDT(45, true, DT::Delete);
 
   TESTGDT(19, true, DT::Unknown);

--- a/unittests/CppInterOp/FunctionReflectionTest.cpp
+++ b/unittests/CppInterOp/FunctionReflectionTest.cpp
@@ -1255,6 +1255,109 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_GetDeallocType) {
 
     void func41(int* ptr){ auto l = [&]{ delete ptr; }; }
 
+    void func24(int* p, int* q){ q = p; delete q; }
+
+    void func25(int* ptr){ func0(ptr); }
+
+    void func26(int* ptr1, int* ptr2){ func2(ptr1); func1(ptr2); }
+
+    void func27(int* ptr1, int* ptr2){ func0(ptr1); func6(ptr2); }
+
+    void func28(int* ptr1, int* ptr2){
+      int* tmp1 = ptr1;
+      func0(tmp1);
+      int* tmp2 = ptr2;
+      func23(tmp2);
+    }
+
+    void func29(int* ptr, int n){
+      if(n > 0)
+        func29(ptr, n-1);
+      delete ptr;
+    }
+
+    void func31(int* ptr, int n);
+    void func32(int* ptr, int n);
+    void func30(int* ptr, int n){
+      func31(ptr, n);
+    }
+
+    void func31(int* ptr, int n){
+      func32(ptr, n-1);
+    }
+
+    void func32(int* ptr, int n){
+      if(n > 0)
+        func30(ptr, n-1);
+      delete ptr;
+    }
+
+    // FIXME: Can not resolve parameter location in recursive call
+    // Probably impossible to solve statically
+    void func33(int* ptr1, int* ptr2, int n){
+      if(n > 0)
+        func33(ptr2, ptr1, n-1);
+      delete ptr1;
+    }
+
+    void func34(int* ptr1, int* ptr2){
+      delete ptr1;
+    }
+
+    void func35(int* ptr1, int* ptr2){
+      func34(ptr2, ptr1);
+    }
+
+    void func36(int* ptr1, int* ptr2){
+      func25(ptr1);
+      func0(ptr2);
+    }
+
+    void func37(int* ptr){
+      helper20(ptr);
+      delete ptr;
+    }
+
+    void func38(int* ptr){
+      delete ptr;
+      helper20(ptr);
+    }
+
+    void func39(int* ptr){
+      ptr = nullptr;
+      func0(ptr);
+    }
+
+    void func40(int* ptr, int n){
+      if(n > 0)
+        func0(ptr);
+      else
+        func2(ptr);
+    }
+
+    struct Klass {
+      void operator=(int* q){
+        delete q;
+      }
+    };
+    void func41(int* p, Klass& K){
+      K = p;
+    }
+
+    void func42(int* ptr){ auto l = [&]{ delete ptr; }; }
+
+    void func43(int* ptr){
+      ptr = nullptr;
+      int* x = ptr;
+      delete x;
+    }
+
+    void func44(int* ptr){ func8(ptr, true); }
+
+    void func45(int* ptr){
+      struct S { void g(int* q){ delete q; } };
+      delete ptr;
+    }
     void func42(int* ptr){
       ptr = nullptr;
       int* x = ptr;
@@ -1310,6 +1413,35 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_GetDeallocType) {
   TESTGDT(16, true, DT::None);
   TESTGDT(17, true, DT::None);
   TESTGDT(18, true, DT::None, DT::None);
+  TESTGDT(19, true, DT::None);
+  TESTGDT(20, true, DT::None);
+  TESTGDT(21, true, DT::Delete);
+  TESTGDT(22, true, DT::Delete);
+  TESTGDT(23, true, DT::Delete);
+  TESTGDT(24, true, DT::None, DT::None);
+  TESTGDT(25, true, DT::Delete);
+  TESTGDT(26, true, DT::Free, DT::DeleteArr);
+  TESTGDT(27, true, DT::Delete, DT::None);
+  TESTGDT(28, true, DT::Delete, DT::Delete);
+  TESTGDT(29, true, DT::Delete, DT::None);
+  TESTGDT(30, true, DT::Delete, DT::None);
+  TESTGDT(31, true, DT::Delete, DT::None);
+  TESTGDT(32, true, DT::Delete, DT::None);
+  TESTGDT(33, true, DT::Delete, DT::None, DT::None);
+  TESTGDT(34, true, DT::Delete, DT::None);
+  TESTGDT(35, true, DT::None, DT::Delete);
+  TESTGDT(36, true, DT::Delete, DT::Delete);
+  TESTGDT(37, true, DT::Delete);
+  TESTGDT(38, true, DT::Delete);
+  TESTGDT(39, true, DT::None);
+  TESTGDT(40, true, DT::Unknown, DT::None);
+  // FIXME: check top of VisitCallExpr function
+  TESTGDT(41, true, DT::None, DT::None);
+  TESTGDT(42, true, DT::None);
+  TESTGDT(43, true, DT::None);
+  TESTGDT(44, true, DT::Unknown);
+  TESTGDT(45, true, DT::Delete);
+
   TESTGDT(19, true, DT::Unknown);
   TESTGDT(20, true, DT::Delete);
   TESTGDT(21, true, DT::Delete);


### PR DESCRIPTION
Built upon #1052 

Changes:
1)
```cpp
 bool TraverseLambdaExpr(clang::LambdaExpr*) { return true; }

  // Do not analyze inside of TagDecls(structs/unions/class)
  bool TraverseDecl(clang::Decl* D) {
    if (llvm::isa_and_nonnull<clang::TagDecl>(D))
      return true;
    return RecursiveASTVisitor::TraverseDecl(D);
  }
``` 
 We do not want to analyze lambda functions and records, thats what these functions do.
  
  2) 
  ```cpp
  bool TraverseIfStmt(clang::IfStmt* IS)
 ```
  This function works pretty same as the one in AllocationTraverser, but it also keeps track of valPerParam for each branch beside aliasMap, also dead codes are eliminated. Also the aliasMap was an VarDecl, ParmVarDecl map, but currently it is changed to VarDecl, set ParmVarDecl because it can have potential(possible) aliases due to if-else branches.
  
3)
  ```cpp
  if (llvm::isa<clang::CXXOperatorCallExpr>(CE)) {
      if (const auto* CMD = dyn_cast<clang::CXXMethodDecl>(FD))
```
There was a parametrer offset problem for implicit object member functions and static operators
      
4)
```cpp
    const clang::VarDecl* getNullCheckCond(const clang::Expr* E)
```
 this func catches situations like : if( ptr) so that this if branch is handled as absolute
    
 5)
```cpp
    static DeallocType absoluteKind(DeallocType DT)
    static DeallocType toMaybe(DeallocType DT)
 ``` 
We distinguished absolute deallocation and maybe deallocation instead of just keeping it unknown, this functions are helper for joining mechanism.
    
And there are lots of tests
    
@vgvassilev @Vipul-Cariappa 