### PR TITLE
[ci] Setup cling from root-project/cling

### DIFF
--- a/.github/actions/Build_and_Test_CppInterOp/action.yml
+++ b/.github/actions/Build_and_Test_CppInterOp/action.yml
@@ -127,6 +127,8 @@ runs:
             # unbalanced across the boundary and trips false use-after-poison.
             # Real use-after-free detection is unaffected.
             export ASAN_OPTIONS=allow_user_poisoning=0
+            # cling teardown leaks, see etc/lsan-cling.supp.
+            export LSAN_OPTIONS=suppressions=${GITHUB_WORKSPACE}/etc/lsan-cling.supp
           fi
           cmake --build . --target check-cppinterop --parallel ${{ env.ncpus }}
           # Verify the source-side `LLVM_VERSION_MAJOR > 21 &&

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -121,11 +121,6 @@ jobs:
         flavor:          ${{ matrix.flavor }}
         flavor-version:  ${{ matrix.cling-patches && format('{0}-llvm{1}', matrix.cling-patches, matrix.clang-runtime) || matrix.flavor-version }}
         cling-sanitizer: ${{ matrix.sanitizer }}
-        # TEST ONLY (revert before merge): build cling from the fork branch
-        # carrying the LLVM-22 fixes, to validate them in CI before they land
-        # in root-project/cling. Only consulted when flavor=cling.
-        cling-repo: 'https://github.com/aaronj0/cling.git'
-        cling-ref:  'llvm22-fixes'
 
     - name: Setup code coverage
       if: ${{ success() && (matrix.coverage == true) }}

--- a/.github/workflows/root.yml
+++ b/.github/workflows/root.yml
@@ -70,11 +70,6 @@ jobs:
         arch: x86_64
         flavor: cling
         flavor-version: ROOT-llvm${{ matrix.clang-runtime }}
-        # TEST ONLY (revert before merge): build cling from the fork branch
-        # carrying the LLVM-22 fixes, to validate them in CI before they land
-        # in root-project/cling. Only consulted when flavor=cling.
-        cling-repo: 'https://github.com/aaronj0/cling.git'
-        cling-ref:  'llvm22-fixes'
 
     - name: Verify cached LLVM/Clang layout
       shell: bash

--- a/etc/lsan-cling.supp
+++ b/etc/lsan-cling.supp
@@ -1,0 +1,14 @@
+# Two cling interpreter-teardown leaks, fixed in root-project/root#23045;
+# suppress until the fixes reach root-project/cling. Applied only to the
+# cling+Address row; the clang-repl asan row runs unsuppressed.
+#
+# 1. deallocate() retains code via FinalizedAlloc::release(), orphaning
+#    each allocation's DeallocActions vector (eh-frame deregistration,
+#    new with LLVM 22).
+# 2. ShutDown() leaks the frontend through the DisableFree path and hides
+#    the pointers with llvm::BuryPointer, which only holds 16 pointers;
+#    destroying a few interpreters per process overflows it.
+#
+# The allocation stacks are often 2 frames deep (the fast unwinder stops
+# at JIT frames), hence the module-level match.
+leak:libclangCppInterOp


### PR DESCRIPTION
#1076 temporarily redirected the cling rows to a fork branch (aaronj0/cling@llvm22-fixes) to validate the LLVM 22 fixes in CI before they landed upstream.