### PR TITLE
Record support for GetAllocType

### DIFF
--- a/include/CppInterOp/CppInterOpTypes.h
+++ b/include/CppInterOp/CppInterOpTypes.h
@@ -411,11 +411,11 @@ enum class AllocType : unsigned char {
   New,
   NewArr,
   Malloc,
-  Unknown,
   CustomAlloc,
-  Null,
   OperatorNew,
-  OperatorNewArr
+  OperatorNewArr,
+  Null,
+  Unknown
 };
 
 enum class DeallocType : unsigned char {

--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -1730,8 +1730,8 @@ struct AllocationTraverser : RecursiveASTVisitor<AllocationTraverser> {
     return RecursiveASTVisitor::TraverseDecl(D);
   }
 
-  std::optional<AllocType> join(std::optional<AllocType> a,
-                                std::optional<AllocType> b) {
+  static std::optional<AllocType> join(std::optional<AllocType> a,
+                                       std::optional<AllocType> b) {
     if (a == AllocType::Null)
       return b;
 
@@ -1840,7 +1840,7 @@ struct AllocationTraverser : RecursiveASTVisitor<AllocationTraverser> {
       varMap[VD] = handleExpr(RHS);
       return true;
     }
-    if (BO->isCompoundAssignmentOp()) {
+    if (VD->getType()->isPointerType() && BO->isCompoundAssignmentOp()) {
       if (undoLog)
         undoLog->try_emplace(VD, varMap[VD]);
       varMap[VD] = AllocType::Unknown;
@@ -1913,6 +1913,20 @@ struct AllocationTraverser : RecursiveASTVisitor<AllocationTraverser> {
     return AllocType::New;
   }
 
+  static bool isNullOpt(const clang::CXXConstructExpr* CCE) {
+    // Expected: std/cpp::optional constructor
+    const clang::CXXConstructorDecl* CCD = CCE->getConstructor();
+    // optional(nullopt_t) noexcept; -> one arg
+    if (CCD->getNumParams() != 1)
+      return false;
+    clang::QualType ParamTy =
+        CCD->getParamDecl(0)->getType().getNonReferenceType();
+    // FIXME: Copy constructor of optional is not handled
+    if (const auto* CRD = ParamTy->getAsCXXRecordDecl())
+      return CRD->getName() == "nullopt_t";
+    return false;
+  }
+
   std::optional<AllocType> handleExpr(const clang::Expr* expr) {
     const clang::Expr* finExpr = expr->IgnoreParenCasts();
     // Case: return new __type__
@@ -1934,17 +1948,39 @@ struct AllocationTraverser : RecursiveASTVisitor<AllocationTraverser> {
     }
 
     // Case: malloc or another func call
-    if (const auto* CE = dyn_cast<CallExpr>(finExpr))
+    if (const auto* CE = dyn_cast<CallExpr>(finExpr)) {
+      // Case: std::optional<int*> ptr = new int; return *ptr;
+      if (const auto* COCE = dyn_cast<clang::CXXOperatorCallExpr>(CE)) {
+        if (COCE->getOperator() == OverloadedOperatorKind::OO_Star &&
+            !COCE->isInfixBinaryOp())
+          return handleExpr(COCE->getArg(0));
+      }
       return handleCall(CE);
-
-    // Case: NULL, nullptr or (int*)(__integerLiteral__)
-    const clang::Expr* parExpr = expr->IgnoreParens();
-    while (const auto* CE = dyn_cast<CastExpr>(parExpr)) {
-      if (CE->getCastKind() == CK_NullToPointer)
-        return AllocType::Null;
-      parExpr = CE->getSubExpr();
     }
 
+    // Case: NULL, nullptr or (int*)(__integerLiteral__)
+    if (finExpr->isNullPointerConstant(getASTContext(),
+                                       Expr::NPC_ValueDependentIsNotNull) !=
+        Expr::NPCK_NotNull)
+      return AllocType::Null;
+
+    // Case: constructor cast
+    if (const auto* CCE = dyn_cast<clang::CXXConstructExpr>(finExpr)) {
+      // std::nullopt or cpp::nullopt
+      if (isNullOpt(CCE))
+        return AllocType::Null;
+      const clang::Expr* stripped = expr->IgnoreParens();
+      // ExprWithCleanups -> ImplicitCastExpr -> CXXConstructExpr pattern
+      if (const auto* EWC = dyn_cast<clang::ExprWithCleanups>(stripped))
+        stripped = EWC->getSubExpr();
+      // We do not want to analyze explicit conversions
+      const auto* ICE = dyn_cast<clang::ImplicitCastExpr>(stripped);
+      bool isImplicitConv =
+          ICE && ICE->getCastKind() == CK_ConstructorConversion;
+      // ImplicitCastExpr -> CXXConstructExpr pattern
+      if (isImplicitConv)
+        return handleExpr(CCE->getArg(0));
+    }
     return AllocType::None;
   }
 };
@@ -1954,8 +1990,8 @@ static std::optional<AllocType>
 AnalyzeAllocType(const clang::FunctionDecl* Fn,
                  std::unordered_map<const clang::FunctionDecl*,
                                     std::optional<AllocType>>& visitedFuncs) {
-  const clang::QualType QT = Fn->getReturnType();
-  if (!QT->isPointerType())
+  QualType QT = Fn->getReturnType();
+  if (!QT->isPointerType() && !QT->isRecordType())
     return AllocType::None;
   const Stmt* fnBody = Fn->getBody();
   if (!fnBody)

--- a/unittests/CppInterOp/FunctionReflectionTest.cpp
+++ b/unittests/CppInterOp/FunctionReflectionTest.cpp
@@ -1357,6 +1357,7 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_GetAllocType) {
   std::string code = R"(
     #include <new>
     #include <stdlib.h>
+    #include <optional>
 
     int* func0(int n){ return new int(n); }
 
@@ -1802,32 +1803,22 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_GetAllocType) {
       return b;
     }
 
-    // This test is for testing some lines, does not neccesarily mean something;
-    // But, it also shows how BindingDecls are not handled
-    struct Tuple {
-      int* ptr1;
-      int* ptr2;
-    };
-    int* func70(){
-      int arr[5];
-      arr[0] = 5;
-      arr[1] = 6;
-      int* ptr = (int*)::operator new(sizeof(int));
-      ::operator delete(ptr);
-      Tuple T;
-      T.ptr1 = &arr[0];
-      T.ptr2 = &arr[1];
-      auto [a, b] = T;
-      a = new int;
-      return a;
+    // FIXME: ptr = new int; -> calls optional::operator= which is -CXXOperatorCallExpr, not handled yet
+    std::optional<int*> func70(int n){
+      std::optional<int*> ptr;
+      if(n>0)
+        return ptr;
+      ptr = new int;
+      return ptr;
     }
+
     // This test is for testing some lines, does not neccesarily mean something;
     // But, it also shows how BindingDecls are not handled
     struct Tuple {
       int* ptr1;
       int* ptr2;
     };
-    int* func70(){
+    int* func71(){
       int arr[5];
       arr[0] = 5;
       arr[1] = 6;
@@ -1920,7 +1911,8 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_GetAllocType) {
   TESTAC(68, Unknown);
   TESTAC(69, None);
   TESTAC(70, None);
-  TESTAC(70, Unknown);
+  TESTAC(71, Unknown);
+
 #undef TESTAC
 
   Cpp::DeleteInterpreter();

--- a/unittests/CppInterOp/FunctionReflectionTest.cpp
+++ b/unittests/CppInterOp/FunctionReflectionTest.cpp
@@ -1730,6 +1730,97 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_GetAllocType) {
     void* func58(){ return __builtin_operator_new(64); }
     void* func59(){int* m = (int*)0; return malloc(sizeof(int));}
 
+    template <typename T>
+    std::optional<T*> func60_helper(){
+      T* ptr = new T;
+      return ptr;
+    }
+
+    std::optional<int*> func60(){
+      return func60_helper<int>();
+    }
+
+    std::optional<int*> func61(int n){
+      if(n>0)
+        return std::nullopt;
+      return new int;
+    }
+
+    struct Empty { Empty() {} };
+    Empty func62() {
+      Empty e;
+      return e;
+    }
+
+    struct Wrapper { int a, b; Wrapper(int x, int y) : a(x), b(y) {} };
+    Wrapper func63() {
+      int a = 1, b = 2;
+      return Wrapper(a, b);
+    }
+
+    Wrapper func64() {
+      int a = 1, b = 2;
+      return {a, b};
+    }
+
+    int* func65(){
+      auto ptr = func61(10);
+      if(ptr)
+        return *ptr;
+      return nullptr;
+    }
+
+    struct Box {
+    int* p;
+    Box(int* p) : p(p) {}
+    Box operator*(const Box& o) const { return Box(nullptr); }
+    };
+    Box func66() {
+      Box a(new int);
+      Box b(nullptr);
+      return a * b;
+    }
+
+    std::optional<int*> func67(){
+      return nullptr;
+    }
+
+    int* func68(){
+      int tmp = 10;
+      int* m = (int*)tmp;
+      for(int i = 0; i < 10; m+=1){
+        return m;
+      }
+      return m;
+    }
+
+    std::optional<int*> func69() {
+      std::optional<int*> a = new int;
+      //FIXME: Copy constructor is called, which takes one arg but is not nullopt constructor
+      //so it returns none, look at isNullOpt(const clang::CXXConstructExpr* CCE) function
+      std::optional<int*> b = a;
+      return b;
+    }
+
+    // This test is for testing some lines, does not neccesarily mean something;
+    // But, it also shows how BindingDecls are not handled
+    struct Tuple {
+      int* ptr1;
+      int* ptr2;
+    };
+    int* func70(){
+      int arr[5];
+      arr[0] = 5;
+      arr[1] = 6;
+      int* ptr = (int*)::operator new(sizeof(int));
+      ::operator delete(ptr);
+      Tuple T;
+      T.ptr1 = &arr[0];
+      T.ptr2 = &arr[1];
+      auto [a, b] = T;
+      a = new int;
+      return a;
+    }
     // This test is for testing some lines, does not neccesarily mean something;
     // But, it also shows how BindingDecls are not handled
     struct Tuple {
@@ -1818,6 +1909,17 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_GetAllocType) {
   TESTAC(57, None);
   TESTAC(58, OperatorNew);
   TESTAC(59, Malloc);
+  TESTAC(60, New);
+  TESTAC(61, New);
+  TESTAC(62, None);
+  TESTAC(63, None);
+  TESTAC(64, None);
+  TESTAC(65, New);
+  TESTAC(66, None);
+  TESTAC(67, Null);
+  TESTAC(68, Unknown);
+  TESTAC(69, None);
+  TESTAC(70, None);
   TESTAC(70, Unknown);
 #undef TESTAC
 


### PR DESCRIPTION
Built upon #1065 

Restrict the pointer-arithmetic Unknown-downgrade in VisitBinaryOperator to
  pointer-typed variables only, so unrelated scalar compound-assignments no
  longer poison tracked results.
```cpp
if (VD->getType()->isPointerType() && BO->isCompoundAssignmentOp()) {
      if (undoLog)
        undoLog->try_emplace(VD, varMap[VD]);
      varMap[VD] = AllocType::Unknown;
```


  Allow AnalyzeAllocType to also traverse record-typed (class/struct) return
  values, not just raw pointers, so wrapper types like std::optional<T*> get
  analyzed instead of short-circuiting to None.

  In handleExpr:
  - Unwrap unary operator* calls (e.g.  on an optional) to
    recurse into the wrapped value instead of falling back to a call analysis.
```cpp
if (const auto* CE = dyn_cast<CallExpr>(finExpr)) {
      // Case: std::optional<int*> ptr = new int; return *ptr;
      if (const auto* COCE = dyn_cast<clang::CXXOperatorCallExpr>(CE)) {
        if (COCE->getOperator() == OverloadedOperatorKind::OO_Star &&
            !COCE->isInfixBinaryOp())
          return handleExpr(COCE->getArg(0));
      }
```


  - Detect nullptr/NULL literals via isNullPointerConstant API, which I were not aware of 
  ```cpp
      // Case: NULL, nullptr or (int*)(__integerLiteral__)
    if (finExpr->isNullPointerConstant(getASTContext(),
                                       Expr::NPC_ValueDependentIsNotNull) !=
        Expr::NPCK_NotNull)
      return AllocType::Null;
 ```
 
 
 
  - Recognize implicit converting-constructor calls (ExprWithCleanups ->
    ImplicitCastExpr(CK_ConstructorConversion) -> CXXConstructExpr) and
    recurse into the constructor's argument, so New/Malloc/etc. tags
    propagate through implicit wrapping (e.g. ).
    ```cpp
    // Case: constructor cast
    if (const auto* CCE = dyn_cast<clang::CXXConstructExpr>(finExpr)) {
      // std::nullopt or cpp::nullopt
      ```
  - Add isNullOpt() to recognize std::nullopt/cpp::nullopt construction as
    AllocType::Null.
   
   ```cpp
   static bool isNullOpt(const clang::CXXConstructExpr* CCE)
   ```

  Known limitation (documented via FIXME + test): optional's copy/move
  constructor is not a converting constructor, so copying an optional loses
  its tracked AllocType and reports None.