### PR TITLE
Fix MSVC C4275 by exporting StatusError's members, not the class

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -480,6 +480,16 @@ include_directories(BEFORE SYSTEM
 #Removes flag due to issue with Google test download when LLVM_ENABLE_WERROR=On
 string(REPLACE "-Wcovered-switch-default" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
 
+# TEST-ONLY, drop before merge: fail the MSVC rows on C4275. LLVM passes
+# -wd4275 project-wide, so /WX alone cannot see the warning -- strip the
+# suppression and promote what is left to an error.
+if(MSVC)
+  string(REPLACE "-wd4275" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+  string(REPLACE "-wd4275" "" CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /we4275")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /we4275")
+endif()
+
 file(STRINGS "VERSION" CPPINTEROP_VERSION)
 string(REPLACE "." ";" VERSION_LIST "${CPPINTEROP_VERSION}")
 list(GET VERSION_LIST 0 CPPINTEROP_VERSION_MAJOR)

--- a/lib/CppInterOp/ErrorInternal.h
+++ b/lib/CppInterOp/ErrorInternal.h
@@ -66,16 +66,21 @@ struct alignas(16) ErrorSlice {
 // into a slice. Impl code returns llvm::Expected<T> with these on
 // the failure path; makeResult wraps them into Result<T>.
 
-class CPPINTEROP_API StatusError : public llvm::ErrorInfo<StatusError> {
+// Export the members, not the class: MSVC propagates a class-level
+// dllexport onto the llvm::ErrorInfo<> base, which LLVM does not export,
+// and warns C4275. ID and the out-of-line virtuals are exported here; the
+// vtable follows log() as key function, at the library's visibility.
+class StatusError : public llvm::ErrorInfo<StatusError> {
 public:
-  static char ID;
+  CPPINTEROP_API static char ID;
   Status Code;
   std::string Message;
 
   StatusError(Status C, std::string M) : Code(C), Message(std::move(M)) {}
 
-  void log(llvm::raw_ostream& OS) const override;
-  [[nodiscard]] std::error_code convertToErrorCode() const override;
+  CPPINTEROP_API void log(llvm::raw_ostream& OS) const override;
+  [[nodiscard]] CPPINTEROP_API std::error_code
+  convertToErrorCode() const override;
 };
 
 /// Allocate a fresh slice on the heap, refcount 0. Caller bumps the


### PR DESCRIPTION
A class-level `CPPINTEROP_API` makes `StatusError` dll-interface; MSVC propagates that onto the non-exported `llvm::ErrorInfo<>` base and warns C4275 in every TU including ErrorInternal.h. ROOT's Windows build sees it, ours doesn't as HandleLLVMOptions passes -wd4275.

Only ID and the two out-of-line virtuals cross the boundary, so annotate those instead. ELF symbols unchanged (identical symbol table, visibility included), CppInterOpTests still links and passes against the shared lib.

First commit promotes 4275 to an error to test if the win2025-msvc rows fail on it, will follow up with the fix.