### PR TITLE
Use the defining declaration's type for unbounded arrays

### DIFF
--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -2976,6 +2976,16 @@ TypeRef GetVariableType(ConstDeclRef var) {
   if (const auto* DD = llvm::dyn_cast_or_null<DeclaratorDecl>(D)) {
     QualType QT = DD->getType();
 
+    // For an array of unknown bound (e.g. `extern std::string arr[];`),
+    // prefer the defining declaration's complete type, which carries the
+    // actual dimension.
+    if (QT->isIncompleteArrayType()) {
+      if (const auto* VD = llvm::dyn_cast<VarDecl>(DD)) {
+        if (const VarDecl* Def = VD->getDefinition())
+          QT = Def->getType();
+      }
+    }
+
     // Check if the TyRef is a typedef TyRef
     if (QT->isTypedefNameType()) {
       return INTEROP_RETURN(QT.getAsOpaquePtr());

--- a/unittests/CppInterOp/VariableReflectionTest.cpp
+++ b/unittests/CppInterOp/VariableReflectionTest.cpp
@@ -235,6 +235,8 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, VariableReflection_GetVariableType) {
     E<int> *f;
     int g[4];
     auto fn = []() { return 1; };
+    extern int uarr[];
+    int uarr[7];
     )";
 
   GetAllTopLevelDecls(code, Decls);
@@ -249,6 +251,14 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, VariableReflection_GetVariableType) {
 
   EXPECT_FALSE(Cpp::IsLambdaClass(Cpp::GetVariableType(Decls[8])));
   EXPECT_TRUE(Cpp::IsLambdaClass(Cpp::GetVariableType(Decls[9])));
+
+  std::vector<Decl*> UArrDecls;
+  for (Decl* D : Decls)
+    if (Cpp::GetName(D) == "uarr")
+      UArrDecls.push_back(D);
+  ASSERT_EQ(UArrDecls.size(), 2);
+  EXPECT_EQ(Cpp::GetTypeAsString(Cpp::GetVariableType(UArrDecls[0])), "int[7]");
+  EXPECT_EQ(Cpp::GetTypeAsString(Cpp::GetVariableType(UArrDecls[1])), "int[7]");
 }
 
 #define CODE                                                                   \


### PR DESCRIPTION
`GetVariableType` returns the declared type of the passed decl. In the case opf `extern std::string arr[];`, we get back an incomplete array since it has no dimension (`len()` fails) and no element stride (every index read the first element). Prefer the defining declaration's complete type for arrays of unknown bound.

Fixes the test04_array_of_strings case of cppyy-test-stltypes.