### PR TITLE
Cycle through ambiguous lookups in `ExistsFunctionTemplate`

### DIFF
--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -2358,8 +2358,24 @@ bool ExistsFunctionTemplate(const std::string& name, ConstDeclRef parent) {
     return INTEROP_RETURN(IsTemplatedFunction(ND) ||
                           IsTemplateInstantiationOrSpecialization(ND));
 
-  // FIXME: Cycle through the Decls and check if there is a templated function
-  return INTEROP_RETURN(true);
+  // The name is ambiguous, i.e. an overload set: cycle through the found
+  // decls and check if any of them is a templated function. Blindly
+  // returning true here would present any function with two or more
+  // non-template overloads as a template.
+  auto& S = getSema();
+  auto& Ctx = getASTContext();
+  clang::LookupResult R(S, &Ctx.Idents.get(name), SourceLocation(),
+                        Sema::LookupOrdinaryName,
+                        RedeclarationKind::ForVisibleRedeclaration);
+  CppInternal::utils::Lookup::Named(&S, R, Within);
+  for (const NamedDecl* Found : R) {
+    const Decl* D = Found;
+    if (const auto* USD = llvm::dyn_cast<UsingShadowDecl>(Found))
+      D = USD->getTargetDecl();
+    if (IsTemplatedFunction(D) || IsTemplateInstantiationOrSpecialization(D))
+      return INTEROP_RETURN(true);
+  }
+  return INTEROP_RETURN(false);
 }
 
 // Looks up all constructors in the current DeclContext

--- a/unittests/CppInterOp/FunctionReflectionTest.cpp
+++ b/unittests/CppInterOp/FunctionReflectionTest.cpp
@@ -1908,12 +1908,34 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_ExistsFunctionTemplate) {
     };
 
     void f(char ch) {}
+
+    void g(int) {}
+    void g(double) {}
+
+    template<typename T>
+    void h(T a) {}
+    void h(int) {}
+
+    namespace NS {
+      template<typename T>
+      void k(T a) {}
+    }
+    using NS::k;
+    void k(int) {}
     )";
 
   GetAllTopLevelDecls(code, Decls);
   EXPECT_TRUE(Cpp::ExistsFunctionTemplate("f", nullptr));
   EXPECT_TRUE(Cpp::ExistsFunctionTemplate("f", Decls[1]));
   EXPECT_FALSE(Cpp::ExistsFunctionTemplate("f", Decls[2]));
+  // An ambiguous name (overload set) is not a template just because the
+  // lookup found more than one decl: only report true if a templated
+  // function is among the results.
+  EXPECT_FALSE(Cpp::ExistsFunctionTemplate("g", nullptr));
+  EXPECT_TRUE(Cpp::ExistsFunctionTemplate("h", nullptr));
+  // The template may enter the overload set through a using-declaration:
+  // the using-shadow must be unwrapped to its target.
+  EXPECT_TRUE(Cpp::ExistsFunctionTemplate("k", nullptr));
 }
 
 TYPED_TEST(CPPINTEROP_TEST_MODE,


### PR DESCRIPTION
Addresses the FIXME in `ExistsFunctionTemplate`, with an included test:

When the name lookup was ambiguous (an overload set), the existing code path blindly returned true, so any function with two or more non-template overloads was presented as a function template. In cppyy this wrapped plain overloaded functions in a TemplateProxy, whose error aggregation does not preserve the C++-exception priority of CPPOverload (e.g. a `std::runtime_error` thrown by an overload surfaced as a generic "Template method resolution failed" TypeError).

The fix was already documented in the FIXME comment: cycle through the found decls (following using declarations) and check whether any is actually a templated function.

Fixes the test49_overloads_with_runtime_errors case of cppyy-test-regression