### PR TITLE
Fix crash in `IsAbstract` for classes without a definition

### DIFF
--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -744,7 +744,8 @@ bool IsAbstract(ConstDeclRef DRef) {
   INTEROP_TRACE(DRef);
   const auto* D = unwrap<clang::Decl>(DRef);
   if (const auto* CXXRD = llvm::dyn_cast_or_null<clang::CXXRecordDecl>(D))
-    return INTEROP_RETURN(CXXRD->isAbstract());
+    return INTEROP_RETURN(CXXRD->hasDefinition() &&
+                          CXXRD->getDefinition()->isAbstract());
 
   return INTEROP_RETURN(false);
 }

--- a/unittests/CppInterOp/ScopeReflectionTest.cpp
+++ b/unittests/CppInterOp/ScopeReflectionTest.cpp
@@ -463,12 +463,17 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, ScopeReflection_IsAbstract) {
     int sum(int a, int b) {
       return a+b;
     }
+
+    class FwdDeclared;
   )";
 
   GetAllTopLevelDecls(code, Decls);
   EXPECT_FALSE(Cpp::IsAbstract(Decls[0]));
   EXPECT_TRUE(Cpp::IsAbstract(Decls[1]));
   EXPECT_FALSE(Cpp::IsAbstract(Decls[2]));
+  // A class without a definition is not known to be abstract, and asking
+  // must not crash.
+  EXPECT_FALSE(Cpp::IsAbstract(Decls[3]));
 }
 
 TYPED_TEST(CPPINTEROP_TEST_MODE, ScopeReflection_IsVariable) {


### PR DESCRIPTION
`CXXRecordDecl::isAbstract()` reads the definition data, which a forward-declared class does not have, so asking whether an incomplete class is abstract crashed. Answer false instead (not known to be abstract), reading through the definition when there is one.