### PR TITLE
Guard `GetSizeOfType` against a null type

### DIFF
--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -887,6 +887,8 @@ size_t GetEnumConstantValue(ConstDeclRef DRef) {
 
 size_t GetSizeOfType(ConstTypeRef TyRef) {
   INTEROP_TRACE(TyRef);
+  if (!TyRef)
+    return INTEROP_RETURN(0);
   QualType QT = QualType::getFromOpaquePtr(TyRef.data);
   if (const TagType* TT = QT->getAs<TagType>())
     return INTEROP_RETURN(SizeOf(TT->getDecl()));

--- a/unittests/CppInterOp/TypeReflectionTest.cpp
+++ b/unittests/CppInterOp/TypeReflectionTest.cpp
@@ -81,6 +81,8 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, TypeReflection_GetSizeOfType) {
   EXPECT_EQ(Cpp::GetSizeOfType(Cpp::GetTypeFromScope(Decls[5])), 0);
   EXPECT_EQ(Cpp::GetSizeOfType(Cpp::GetVariableType(Decls[6])),
             sizeof(intptr_t));
+  // A null type must not crash and has no size.
+  EXPECT_EQ(Cpp::GetSizeOfType(nullptr), 0);
 }
 
 TYPED_TEST(CPPINTEROP_TEST_MODE, TypeReflection_GetCanonicalType) {


### PR DESCRIPTION
QualType::getFromOpaquePtr(nullptr) produces a null QualType, and the subsequent getAs<TagType>() dereferences it. Return size 0 instead, so callers can detect that the size is unavailable