### PR TITLE
Force definition completion in `IsAbstract` before returning false

### DIFF
--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -740,12 +740,14 @@ bool IsTypedefed(ConstDeclRef DRef) {
   return INTEROP_RETURN(llvm::isa_and_nonnull<clang::TypedefNameDecl>(D));
 }
 
-bool IsAbstract(ConstDeclRef DRef) {
+bool IsAbstract(DeclRef DRef) {
   INTEROP_TRACE(DRef);
   const auto* D = unwrap<clang::Decl>(DRef);
-  if (const auto* CXXRD = llvm::dyn_cast_or_null<clang::CXXRecordDecl>(D))
-    return INTEROP_RETURN(CXXRD->hasDefinition() &&
-                          CXXRD->getDefinition()->isAbstract());
+  if (llvm::isa_and_nonnull<clang::CXXRecordDecl>(D)) {
+    const auto* Def = llvm::dyn_cast_or_null<clang::CXXRecordDecl>(
+        unwrap<clang::Decl>(GetOrForceDefinition(DRef)));
+    return INTEROP_RETURN(Def && Def->isAbstract());
+  }
 
   return INTEROP_RETURN(false);
 }

--- a/lib/CppInterOp/CppInterOp.td
+++ b/lib/CppInterOp/CppInterOp.td
@@ -598,9 +598,13 @@ def Deallocate : CppInterOpAPI {
 }
 
 def IsAbstract : CppInterOpAPI {
+  let Doc = [{Checks if a class is abstract. Abstractness is a property of the
+class definition: if only a declaration is loaded, the definition is first
+forced into the AST (see GetOrForceDefinition).}];
+
   let ReturnType = "bool";
   let Args = [
-    Arg<"ConstDeclRef", "DRef">
+    Arg<"DeclRef", "DRef">
   ];
 }
 

--- a/unittests/CppInterOp/ScopeReflectionTest.cpp
+++ b/unittests/CppInterOp/ScopeReflectionTest.cpp
@@ -465,15 +465,29 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, ScopeReflection_IsAbstract) {
     }
 
     class FwdDeclared;
+
+    template <typename T>
+    struct AbsT {
+      virtual void f() = 0;
+    };
+    AbsT<int>* makeAbsT();
   )";
 
   GetAllTopLevelDecls(code, Decls);
   EXPECT_FALSE(Cpp::IsAbstract(Decls[0]));
   EXPECT_TRUE(Cpp::IsAbstract(Decls[1]));
   EXPECT_FALSE(Cpp::IsAbstract(Decls[2]));
-  // A class without a definition is not known to be abstract, and asking
-  // must not crash.
+  // A class with no definition anywhere answers false and must not crash.
   EXPECT_FALSE(Cpp::IsAbstract(Decls[3]));
+
+  // An uninstantiated specialization is completed on demand before answering.
+  // (hasDefinition() is the passive check: IsComplete itself would force.)
+  Cpp::TypeRef PtrTy = Cpp::GetFunctionReturnType(Decls[5]);
+  Cpp::DeclRef Spec = Cpp::GetScopeFromType(Cpp::GetPointeeType(PtrTy));
+  auto* SpecRD = Cpp::unwrap<clang::CXXRecordDecl>(Spec);
+  EXPECT_FALSE(SpecRD->hasDefinition());
+  EXPECT_TRUE(Cpp::IsAbstract(Spec));
+  EXPECT_TRUE(SpecRD->hasDefinition());
 }
 
 TYPED_TEST(CPPINTEROP_TEST_MODE, ScopeReflection_IsVariable) {


### PR DESCRIPTION
Follow-up to #1087 per review: abstractness is a property of the class definition, so answering false for a class whose definition is not loaded yet is ambiguous. Complete the definition through `GetOrForceDefinition` before answering; this drops the constness of the argument. A forward declaration with no definition anywhere still answers false.