### PR TITLE
Search base classes in GetNamed for class scopes

### DIFF
--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -1257,6 +1257,34 @@ DeclRef GetNamed(const std::string& name, ConstDeclRef parent /*= nullptr*/) {
   if (ND && ND != (clang::NamedDecl*)-1)
     return INTEROP_RETURN(ND->getCanonicalDecl());
 
+  // Redeclaration-style lookup stops at the class itself; [class.qual]
+  // member lookup also searches the bases. Retry accordingly.
+  // FIXME: GetNamed should only return decls that are named and reachable
+  // within the provided decl context — the same contract question as the
+  // LookupUnqualified FIXME above: expose distinct lookup routes so callers
+  // pick the semantics they want, instead of GetNamed approximating both.
+  if (!ND && Within) {
+    if (auto* RD = llvm::dyn_cast<clang::CXXRecordDecl>(Within)) {
+      auto* Def = llvm::dyn_cast_or_null<clang::CXXRecordDecl>(
+          unwrap<clang::Decl>(GetOrForceDefinition(DeclRef(RD))));
+      if (!Def)
+        return INTEROP_RETURN(nullptr);
+      auto& S = getSema();
+      clang::DeclarationName DName = &S.Context.Idents.get(name);
+      clang::LookupResult R(S, DName, clang::SourceLocation(),
+                            clang::Sema::LookupOrdinaryName,
+                            RedeclarationKind::NotForRedeclaration);
+      R.suppressDiagnostics();
+      S.LookupQualifiedName(R, Def);
+      if (R.empty())
+        return INTEROP_RETURN(nullptr);
+      R.resolveKind();
+      if (!R.isSingleResult())
+        return INTEROP_RETURN(nullptr);
+      return INTEROP_RETURN(R.getFoundDecl()->getCanonicalDecl());
+    }
+  }
+
   // Slow path: only when qualified lookup missed AND `Within` is a
   // namespace whose enclosing chain carries at least one using-directive
   // (the only reason qualified-vs-unqualified disagree at namespace

--- a/unittests/CppInterOp/ScopeReflectionTest.cpp
+++ b/unittests/CppInterOp/ScopeReflectionTest.cpp
@@ -770,6 +770,62 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, ScopeReflection_GetNamed) {
   EXPECT_EQ(Cpp::GetQualifiedName(std_string_npos_var), "std::basic_string<char>::npos");
 }
 
+// GetNamed on a class scope must find inherited members per [class.qual].
+TYPED_TEST(CPPINTEROP_TEST_MODE, ScopeReflection_GetNamedSearchesBaseClasses) {
+  std::string code = R"(struct GNBase {
+                          typedef int value_type;
+                          int ivalue;
+                        };
+                        struct GNDerived : GNBase {};
+                        struct GNGrandChild : GNDerived {};
+
+                        struct GNLeft  { typedef int T; };
+                        struct GNRight { typedef float T; };
+                        struct GNBoth : GNLeft, GNRight {};
+                        struct GNFwd;
+
+                        template <typename T> struct GNTBase { typedef T type; };
+                        template <typename T> struct GNT : GNTBase<T> {};
+                        GNT<int> gnt_provider();
+                       )";
+
+  std::vector<const char*> interpreter_args = {"-include", "new"};
+  TestFixture::CreateInterpreter(interpreter_args);
+  Interp->declare(code);
+
+  Cpp::DeclRef base = Cpp::GetNamed("GNBase", nullptr);
+  Cpp::DeclRef derived = Cpp::GetNamed("GNDerived", nullptr);
+  ASSERT_TRUE(base);
+  ASSERT_TRUE(derived);
+
+  Cpp::DeclRef vt = Cpp::GetNamed("value_type", derived);
+  ASSERT_TRUE(vt);
+  EXPECT_EQ(Cpp::GetQualifiedName(vt), "GNBase::value_type");
+  EXPECT_EQ(vt, Cpp::GetNamed("value_type", base));
+  EXPECT_EQ(Cpp::GetQualifiedName(Cpp::GetNamed("ivalue", derived)),
+            "GNBase::ivalue");
+
+  EXPECT_EQ(Cpp::GetNamed("value_type", Cpp::GetNamed("GNGrandChild", nullptr)),
+            vt);
+
+  // An ambiguous inherited name stays unresolved.
+  EXPECT_FALSE(Cpp::GetNamed("T", Cpp::GetNamed("GNBoth", nullptr)));
+
+  // A name absent from the class and all of its bases stays unresolved.
+  EXPECT_FALSE(Cpp::GetNamed("no_such_member", derived));
+
+  // A class with no definition reachable anywhere cannot be searched.
+  EXPECT_FALSE(Cpp::GetNamed("value_type", Cpp::GetNamed("GNFwd", nullptr)));
+
+  // A member of an uninstantiated specialization: complete it, then search.
+  Cpp::DeclRef gnt = Cpp::GetScopeFromType(Cpp::GetFunctionReturnType(
+      Cpp::FuncRef{Cpp::GetNamed("gnt_provider").data}));
+  ASSERT_TRUE(gnt);
+  Cpp::DeclRef gnt_type = Cpp::GetNamed("type", gnt);
+  ASSERT_TRUE(gnt_type);
+  EXPECT_EQ(Cpp::GetName(gnt_type), "type");
+}
+
 TYPED_TEST(CPPINTEROP_TEST_MODE, ScopeReflection_GetNamedWithUsing) {
   // Each subcase covers one form of [namespace.udecl] / [namespace.udir].
   // GetNamed must look through the alias and return the original decl,


### PR DESCRIPTION
`Lookup::Named` performs a redeclaration-style lookup (`RedeclarationKind::ForVisibleRedeclaration`), for whihc `Sema::LookupQualifiedName` stops at the queried context since a redeclaration must live in the same scope. A lookup of an existing member name per [class.qual] also searches the base classes. `GetNamed` therefore missed any member inherited from a base, e.g. the `type` member typedef of `std::tuple_element`, implemented by older libstdc++ (gcc8/alma8) with recursive inheritance with `type` declared in a base of looked-up specialization. Newer libstdc++ declares it directly in the specialization, hiding the problem. `cling::LookupHelper` performs full C++ member lookup (qualifier is built by parsing the C++ name and building a `Sema::BuildCXXNestedNameSpecifier`) and was not affected.

Retry the lookup with RedeclarationKind::NotForRedeclaration when the scope is a class and the direct lookup found nothing, accepting only an unambiguous result. Fixes test20_tuple_element of cppyy-test-cpp11features on alma8.