### PR TITLE
GoogleTest to latest release version (v1.18.0)

### DIFF
--- a/cmake/modules/GoogleTest.cmake
+++ b/cmake/modules/GoogleTest.cmake
@@ -84,7 +84,7 @@ ExternalProject_Add(
   googletest
   GIT_REPOSITORY https://github.com/google/googletest.git
   GIT_SHALLOW FALSE
-  GIT_TAG fa8438ae6b70c57010177de47a9f13d7041a6328
+  GIT_TAG v1.18.0
   UPDATE_COMMAND ""
   ${_gtest_configure}
   BUILD_COMMAND ${build_cmd}


### PR DESCRIPTION
Googletest released a new version 2 weeks ago, so this PR updates Googletest to this new version (and CppInterOp is no longer on some random commit between v1.17.0 and v1.18.0).