### PR TITLE
Support lean embedder installs with components and unversioned output

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ option(CPPINTEROP_BUILD_TABLEGEN_ONLY "Only build cppinterop-tblgen (for cross-c
 # add_llvm_library(... BUILDTREE_ONLY)
 option(CPPINTEROP_INSTALL "Generate install rules for CppInterOp" ON)
 
-#=Set OFF to ship the shared library as a single unversioned file, matching
+# OFF to ship the shared library as a single unversioned file, matching
 # the Darwin layout: archives that cannot carry symlinks (Python wheels)
 # would otherwise materialize the SOVERSION namelink as a second full copy.
 option(CPPINTEROP_SHARED_LIBRARY_VERSIONING

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,12 @@ option(CPPINTEROP_BUILD_TABLEGEN_ONLY "Only build cppinterop-tblgen (for cross-c
 #=Set OFF to suppress install() rules and route clangCppInterOp through
 # add_llvm_library(... BUILDTREE_ONLY)
 option(CPPINTEROP_INSTALL "Generate install rules for CppInterOp" ON)
+
+#=Set OFF to ship the shared library as a single unversioned file, matching
+# the Darwin layout: archives that cannot carry symlinks (Python wheels)
+# would otherwise materialize the SOVERSION namelink as a second full copy.
+option(CPPINTEROP_SHARED_LIBRARY_VERSIONING
+  "Attach the LLVM SOVERSION and namelink to shared clangCppInterOp" ON)
 if(EMSCRIPTEN)
   set(CPPINTEROP_EXTRA_WASM_FLAGS "-fwasm-exceptions" CACHE STRING "Extra flags for wasm")
 endif()
@@ -504,6 +510,7 @@ if(CPPINTEROP_INSTALL)
 
   install(DIRECTORY include/
     DESTINATION include
+    COMPONENT cppinterop-headers
     FILES_MATCHING
     PATTERN "*.def"
     PATTERN "*.h"
@@ -513,12 +520,14 @@ if(CPPINTEROP_INSTALL)
 
   install(DIRECTORY tools/
     DESTINATION include/CppInterOp/tools
+    COMPONENT cppinterop-headers
     FILES_MATCHING
     PATTERN "*.h"
   )
 
   install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/include/
     DESTINATION include
+    COMPONENT cppinterop-headers
     FILES_MATCHING
     PATTERN "CMakeFiles" EXCLUDE
     PATTERN "*.inc"
@@ -617,6 +626,17 @@ if(NOT EMSCRIPTEN AND NOT CPPINTEROP_TABLEGEN_EXE)
   add_subdirectory(utils/TableGen)
 endif()
 add_subdirectory(lib)
+
+if(CPPINTEROP_INSTALL)
+  # Installing the headers needs to depend on generating the tablegen'd
+  # public headers.
+  add_custom_target(cppinterop-headers DEPENDS CppInterOpTableGen)
+  if(NOT LLVM_ENABLE_IDE)
+    add_llvm_install_targets(install-cppinterop-headers
+                             DEPENDS cppinterop-headers
+                             COMPONENT cppinterop-headers)
+  endif()
+endif()
 if (CPPINTEROP_ENABLE_TESTING)
   add_subdirectory(unittests)
 endif(CPPINTEROP_ENABLE_TESTING)

--- a/lib/CppInterOp/CMakeLists.txt
+++ b/lib/CppInterOp/CMakeLists.txt
@@ -225,6 +225,13 @@ add_llvm_library(clangCppInterOp
   ${link_libs}
 )
 
+# llvm_add_library() stamps LLVM's VERSION/SOVERSION on shared libraries on
+# ELF platforms; unsetting them ships one unversioned file, as on Darwin.
+if(NOT CPPINTEROP_SHARED_LIBRARY_VERSIONING)
+  set_property(TARGET clangCppInterOp PROPERTY VERSION)
+  set_property(TARGET clangCppInterOp PROPERTY SOVERSION)
+endif()
+
 if(EMSCRIPTEN)
   if(BUILD_SHARED_LIBS)
   # FIXME: When dynamically linking the Emscripten shared library to the


### PR DESCRIPTION
Label the header install rules `COMPONENT cppinterop-headers` and add an `install-cppinterop-headers` target, so embedders can drive a minimal install (library plus headers) through the same LLVM component machinery that already provides `install-clangCppInterOp(-stripped)`. Add `CPPINTEROP_SHARED_LIBRARY_VERSIONING` (default ON) to optionally ship the shared library as a single unversioned file, matching the Darwin layout: archives that cannot carry symlinks, such as in the case of Python wheels, otherwise materialize the SOVERSION namelink as a second full copy of the library.
