### PR TITLE
Ownership Representation

### DIFF
--- a/include/CppInterOp/CppInterOpTypes.h
+++ b/include/CppInterOp/CppInterOpTypes.h
@@ -342,6 +342,11 @@ enum QualKind : unsigned char {
   All = Const | Volatile | Restrict
 };
 
+inline QualKind operator|(QualKind a, QualKind b) {
+  return static_cast<QualKind>(static_cast<unsigned char>(a) |
+                               static_cast<unsigned char>(b));
+}
+
 /// Enum modelling programming languages.
 enum class InterpreterLanguage : unsigned char {
   Unknown,
@@ -427,9 +432,18 @@ enum class DeallocType : unsigned char {
   Opaque   // Could not analyze
 };
 
-inline QualKind operator|(QualKind a, QualKind b) {
-  return static_cast<QualKind>(static_cast<unsigned char>(a) |
-                               static_cast<unsigned char>(b));
+enum class OwnershipBehaviour : unsigned char {
+  Unknown = 0, // If function does not have any ownership attribute, it is
+               // assumed to be Unknown, not None
+  OwnershipReturns = 1 << 0,
+  OwnershipHolds = 1 << 1,
+  OwnershipTakes = 1 << 2
+};
+
+inline OwnershipBehaviour operator|(OwnershipBehaviour A,
+                                    OwnershipBehaviour B) {
+  return static_cast<OwnershipBehaviour>(static_cast<unsigned char>(A) |
+                                         static_cast<unsigned char>(B));
 }
 
 enum class ValueKind : std::uint8_t {

--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -1767,6 +1767,82 @@ TypeRef GetFunctionReturnType(ConstFuncRef func) {
   return INTEROP_RETURN(nullptr);
 }
 
+bool IsFunctionProtoType(ConstTypeRef TyRef) {
+  INTEROP_TRACE(TyRef);
+  QualType QT = QualType::getFromOpaquePtr(TyRef.data);
+  const auto* T = QT.getTypePtr();
+  return INTEROP_RETURN(llvm::isa_and_nonnull<clang::FunctionProtoType>(T));
+}
+
+OwnershipBehaviour GetOwnershipBehaviour(ConstFuncRef Fn) {
+  INTEROP_TRACE(Fn);
+  if (!Fn)
+    return INTEROP_RETURN(OwnershipBehaviour::Unknown);
+  const auto* D = UnwrapUsingShadowToFunction(unwrap<clang::Decl>(Fn));
+  if (const auto* FTD = dyn_cast<FunctionTemplateDecl>(D))
+    D = FTD->getTemplatedDecl();
+  const auto* FD = dyn_cast<FunctionDecl>(D);
+  if (!FD)
+    return INTEROP_RETURN(OwnershipBehaviour::Unknown);
+
+  OwnershipBehaviour result = OwnershipBehaviour::Unknown; // 0b000
+  for (const auto* FDA : FD->specific_attrs<OwnershipAttr>()) {
+    switch (FDA->getOwnKind()) {
+    case OwnershipAttr::Returns:
+      result = result | OwnershipBehaviour::OwnershipReturns;
+      break;
+    case OwnershipAttr::Takes:
+      result = result | OwnershipBehaviour::OwnershipTakes;
+      break;
+    case OwnershipAttr::Holds:
+      result = result | OwnershipBehaviour::OwnershipHolds;
+      break;
+    }
+  }
+  return INTEROP_RETURN(result);
+}
+
+uint64_t GetDeallocationIndexes(ConstFuncRef Fn) {
+  INTEROP_TRACE(Fn);
+  if (!Fn)
+    return INTEROP_RETURN(uint64_t{0});
+  const auto* D = UnwrapUsingShadowToFunction(unwrap<clang::Decl>(Fn));
+  if (const auto* FTD = dyn_cast<FunctionTemplateDecl>(D))
+    D = FTD->getTemplatedDecl();
+  const auto* FD = dyn_cast<FunctionDecl>(D);
+  if (!FD)
+    return INTEROP_RETURN(uint64_t{0});
+  uint64_t result = 0;
+  for (const auto* attr : FD->specific_attrs<OwnershipAttr>()) {
+    if (attr->getOwnKind() == OwnershipAttr::Returns)
+      continue;
+    for (const auto& Idx : attr->args()) {
+      unsigned index = Idx.getASTIndex();
+      if (index < 64)
+        result |= (uint64_t{1} << index);
+    }
+  }
+  return INTEROP_RETURN(result);
+}
+
+int GetAllocationSizeParamIndex(ConstFuncRef Fn) {
+  INTEROP_TRACE(Fn);
+  if (!Fn)
+    return INTEROP_RETURN(-1);
+  const auto* D = UnwrapUsingShadowToFunction(unwrap<clang::Decl>(Fn));
+  if (const auto* FTD = dyn_cast<FunctionTemplateDecl>(D))
+    D = FTD->getTemplatedDecl();
+  const auto* FD = dyn_cast<FunctionDecl>(D);
+  if (!FD)
+    return INTEROP_RETURN(-1);
+  for (const auto* attr : FD->specific_attrs<OwnershipAttr>()) {
+    if (attr->getOwnKind() != OwnershipAttr::Returns || attr->args().empty())
+      continue;
+    return INTEROP_RETURN(static_cast<int>(attr->args_begin()->getASTIndex()));
+  }
+  return INTEROP_RETURN(-1);
+}
+
 bool IsAllocator(ConstFuncRef Fn) {
   INTEROP_TRACE(Fn);
   if (!Fn)
@@ -1809,13 +1885,6 @@ bool IsDeallocator(ConstFuncRef Fn) {
   }
 
   return INTEROP_RETURN(false);
-}
-
-bool IsFunctionProtoType(ConstTypeRef TyRef) {
-  INTEROP_TRACE(TyRef);
-  QualType QT = QualType::getFromOpaquePtr(TyRef.data);
-  const auto* T = QT.getTypePtr();
-  return INTEROP_RETURN(llvm::isa_and_nonnull<clang::FunctionProtoType>(T));
 }
 
 static std::optional<AllocType>

--- a/lib/CppInterOp/CppInterOp.td
+++ b/lib/CppInterOp/CppInterOp.td
@@ -783,6 +783,39 @@ def IsFunctionProtoType : CppInterOpAPI {
   ];
 }
 
+def GetOwnershipBehaviour : CppInterOpAPI {
+  let Doc = [{Returns the ownership behaviour the function declares, as a
+bitmask of OwnershipBehaviour flags read off its ownership_returns,
+ownership_takes and ownership_holds attributes.}];
+
+  let ReturnType = "OwnershipBehaviour";
+  let Args = [
+    Arg<"ConstFuncRef", "func">
+  ];
+}
+
+def GetDeallocationIndexes : CppInterOpAPI {
+  let Doc = [{Returns a bitmask of the parameters whose ownership the function
+takes or holds, as annotated by ownership_takes/ownership_holds: The mask is meaningful only when
+GetOwnershipBehaviour reports OwnershipTakes or OwnershipHolds.}];
+
+  let ReturnType = "uint64_t";
+  let Args = [
+    Arg<"ConstFuncRef", "func">
+  ];
+}
+
+def GetAllocationSizeParamIndex : CppInterOpAPI {
+  let Doc = [{Returns the 0-based index of the parameter carrying the allocation
+size for a function annotated with ownership_returns, or -1 if the function is
+not so annotated or the size argument was omitted.}];
+
+  let ReturnType = "int";
+  let Args = [
+    Arg<"ConstFuncRef", "func">
+  ];
+}
+
 def GetAllocType: CppInterOpAPI {
   let Doc = "Analyzes function's body to detect memory allocation behaviour";
 

--- a/lib/CppInterOp/CppInterOpAPI.td
+++ b/lib/CppInterOp/CppInterOpAPI.td
@@ -142,6 +142,9 @@ def CMap_InterpLangStd  : CTypeMap<"InterpreterLanguageStandard", "unsigned char
 def CMap_ValueKind      : CTypeMap<"ValueKind", "unsigned char",
     /*ArgConv=*/"",
     /*RetConv=*/"static_cast<unsigned char>($result)">;
+def CMap_OwnershipBehaviour : CTypeMap<"OwnershipBehaviour", "unsigned char",
+    /*ArgConv=*/"",
+    /*RetConv=*/"static_cast<unsigned char>($result)">;
 def CMap_Signedness     : CTypeMap<"Signedness*", "unsigned*",
     /*ArgConv=*/"reinterpret_cast<Cpp::Signedness*>($name)">;
 

--- a/unittests/CppInterOp/FunctionReflectionTest.cpp
+++ b/unittests/CppInterOp/FunctionReflectionTest.cpp
@@ -1093,6 +1093,82 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_FunctionTypes) {
 
   EXPECT_TRUE(Cpp::IsSameType(typ1, typ2));
 }
+TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_OwnershipAttributes) {
+  std::vector<Decl*> Decls;
+  std::string code = R"(
+    class Klass {
+      int val;
+    };
+
+    __attribute__((ownership_returns(malloc)))
+    void* alloc_no_size(unsigned long sz);
+
+    __attribute__((ownership_returns(malloc, 1)))
+    void* alloc_sized(unsigned long sz);
+
+    __attribute__((ownership_returns(malloc, 2)))
+    void* alloc_sized2(void* hint, unsigned long sz);
+
+    __attribute__((ownership_takes(malloc, 1)))
+    void dealloc(void* p);
+
+    __attribute__((ownership_holds(malloc, 1, 2)))
+    void hold_two(void* p, void* q);
+
+    __attribute__((ownership_returns(malloc)))
+    __attribute__((ownership_takes(malloc, 1)))
+    void* realloc_like(void* p, unsigned long sz);
+
+    void plain(void* p);
+
+    template <typename T>
+    __attribute__((ownership_returns(malloc, 2)))
+    __attribute__((ownership_takes(malloc, 1)))
+    T* templated_alloc(void* p, unsigned long sz);
+    )";
+  GetAllTopLevelDecls(code, Decls, true);
+
+  Cpp::ConstFuncRef Klass{Decls[0]};
+  Cpp::ConstFuncRef AllocNoSize{Decls[1]};
+  Cpp::ConstFuncRef AllocSized{Decls[2]};
+  Cpp::ConstFuncRef AllocSized2{Decls[3]};
+  Cpp::ConstFuncRef Dealloc{Decls[4]};
+  Cpp::ConstFuncRef HoldTwo{Decls[5]};
+  Cpp::ConstFuncRef ReallocLike{Decls[6]};
+  Cpp::ConstFuncRef Plain{Decls[7]};
+  Cpp::ConstFuncRef TemplatedAlloc{Decls[8]};
+
+  using OB = Cpp::OwnershipBehaviour;
+  EXPECT_EQ(Cpp::GetOwnershipBehaviour(AllocNoSize), OB::OwnershipReturns);
+  EXPECT_EQ(Cpp::GetOwnershipBehaviour(Dealloc), OB::OwnershipTakes);
+  EXPECT_EQ(Cpp::GetOwnershipBehaviour(HoldTwo), OB::OwnershipHolds);
+  EXPECT_EQ(Cpp::GetOwnershipBehaviour(ReallocLike),
+            OB::OwnershipReturns | OB::OwnershipTakes);
+  EXPECT_EQ(Cpp::GetOwnershipBehaviour(Plain), OB::Unknown);
+  EXPECT_EQ(Cpp::GetOwnershipBehaviour(Klass), OB::Unknown);
+  EXPECT_EQ(Cpp::GetOwnershipBehaviour({nullptr}), OB::Unknown);
+
+  EXPECT_EQ(Cpp::GetOwnershipBehaviour(TemplatedAlloc),
+            OB::OwnershipReturns | OB::OwnershipTakes);
+  EXPECT_EQ(Cpp::GetDeallocationIndexes(TemplatedAlloc), uint64_t{0b1});
+  EXPECT_EQ(Cpp::GetAllocationSizeParamIndex(TemplatedAlloc), 1);
+
+  EXPECT_EQ(Cpp::GetDeallocationIndexes(Dealloc), uint64_t{0b1});
+  EXPECT_EQ(Cpp::GetDeallocationIndexes(HoldTwo), uint64_t{0b11});
+  EXPECT_EQ(Cpp::GetDeallocationIndexes(ReallocLike), uint64_t{0b1});
+  EXPECT_EQ(Cpp::GetDeallocationIndexes(AllocNoSize), uint64_t{0});
+  EXPECT_EQ(Cpp::GetDeallocationIndexes(Plain), uint64_t{0});
+  EXPECT_EQ(Cpp::GetDeallocationIndexes(Klass), uint64_t{0});
+  EXPECT_EQ(Cpp::GetDeallocationIndexes({nullptr}), uint64_t{0});
+
+  EXPECT_EQ(Cpp::GetAllocationSizeParamIndex(AllocSized), 0);
+  EXPECT_EQ(Cpp::GetAllocationSizeParamIndex(AllocSized2), 1);
+  EXPECT_EQ(Cpp::GetAllocationSizeParamIndex(AllocNoSize), -1);
+  EXPECT_EQ(Cpp::GetAllocationSizeParamIndex(Dealloc), -1);
+  EXPECT_EQ(Cpp::GetAllocationSizeParamIndex(Plain), -1);
+  EXPECT_EQ(Cpp::GetAllocationSizeParamIndex(Klass), -1);
+  EXPECT_EQ(Cpp::GetAllocationSizeParamIndex({nullptr}), -1);
+}
 
 TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_GetDeallocType) {
   std::string code = R"(


### PR DESCRIPTION
Besides Alloc-DeallocType, a new added for representing functions ownership returns-takes behaviour based on ownership_... attributes, also added API for getting index of deallocated parameters for functions take ownership, and if it is specified another API is available to get which parameter decides the size of allocation for functions return ownership. Also some replacements that are not important.

@Vipul-Cariappa 