### PR TITLE
Fix JitCall codegen for move-only by-value arguments

### DIFF
--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -3992,6 +3992,30 @@ void collect_type_info(const FunctionDecl* FD, QualType& QT,
   get_type_as_string(QT, type_name, C, Policy);
 }
 
+bool IsCopyConstructorDeleted(QualType QT) {
+  CXXRecordDecl* RD = QT->getAsCXXRecordDecl();
+  if (!RD) {
+    // For types that are not C++ records (such as PODs), we assume that they
+    // are copyable, ie their copy constructor is not deleted.
+    return false;
+  }
+
+  RD = unwrap<CXXRecordDecl>(GetOrForceDefinition(DeclRef(RD)));
+  if (!RD)
+    return false;
+
+  if (RD->hasSimpleCopyConstructor())
+    return false;
+
+  for (auto* Ctor : RD->ctors())
+    if (Ctor->isCopyConstructor())
+      return Ctor->isDeleted();
+
+  // The return value is somewhat arbitrary: we did not see a deleted copy
+  // ctor. The user will be told if the generated code doesn't compile.
+  return false;
+}
+
 void make_narg_ctor(const FunctionDecl* FD, const unsigned N,
                     std::ostringstream& typedefbuf, std::ostringstream& callbuf,
                     const std::string& class_name, int indent_level,
@@ -4036,7 +4060,18 @@ void make_narg_ctor(const FunctionDecl* FD, const unsigned N,
       } else if (isPointer) {
         callbuf << "*(" << type_name.c_str() << "**)args[" << i << "]";
       } else {
+        // By-value construction: Figure out if the type can be
+        // copy-constructed. This is tricky and cannot be done in a fully
+        // reliable way, also because std::vector<T> always defines a copy
+        // constructor, even if the type T is only moveable. As a heuristic, we
+        // only check if the copy constructor is deleted, or would be if
+        // implicit.
+        bool Move = IsCopyConstructorDeleted(QT);
+        if (Move)
+          callbuf << "static_cast<" << type_name << "&&>(";
         callbuf << "*(" << type_name.c_str() << "*)args[" << i << "]";
+        if (Move)
+          callbuf << ")";
       }
     }
     callbuf << ")";
@@ -4216,17 +4251,11 @@ void make_narg_call(const FunctionDecl* FD, const std::string& return_type,
               << type_name.c_str() << "*)args[" << i << "]";
     } else if (isPointer) {
       callbuf << "*(" << type_name.c_str() << "**)args[" << i << "]";
-    } else if (rtdecl &&
-               (rtdecl->hasTrivialCopyConstructor() &&
-                !rtdecl->hasSimpleCopyConstructor()) &&
-               rtdecl->hasMoveConstructor()) {
+    } else if (rtdecl && IsCopyConstructorDeleted(QT)) {
       // By-value construction; this may either copy or move, but there is no
       // information here in terms of intent. Thus, simply assume that the
       // intent is to move if there is no viable copy constructor (ie. if the
-      // code would otherwise fail to even compile). There does not appear to be
-      // a simple way of determining whether a viable copy constructor exists,
-      // so check for the most common case: the trivial one, but not uniquely
-      // available, while there is a move constructor.
+      // code would otherwise fail to even compile).
 
       // Move construction as needed for classes (note that this is
       // implicit). Emit `std::move`'s expansion directly rather than the

--- a/unittests/CppInterOp/FunctionReflectionTest.cpp
+++ b/unittests/CppInterOp/FunctionReflectionTest.cpp
@@ -4999,3 +4999,57 @@ TYPED_TEST(CPPINTEROP_TEST_MODE,
                       /*interpreter_args=*/{"-std=c++23", "-include", "new"});
   EXPECT_EQ(JitCallIntNullary("BlogTransform", "drive"), 42);
 }
+
+// A by-value parameter of a move-only type must be moved into the call: the
+// wrapper otherwise fails to compile against the deleted copy constructor.
+// MoveOnly's deleted copy constructor is also non-trivial (Payload's is
+// user-provided), so triviality bits cannot classify it.
+TYPED_TEST(CPPINTEROP_TEST_MODE, FunctionReflection_MoveOnlyByValueArgs) {
+#ifdef EMSCRIPTEN
+  GTEST_SKIP() << "Test fails for Emscripten builds";
+#endif
+  if (TypeParam::isOutOfProcess)
+    GTEST_SKIP() << "Test fails for OOP JIT builds";
+
+  std::vector<Decl*> Decls;
+  std::vector<Decl*> SubDecls;
+  std::string code = R"(
+    struct Payload {
+      Payload() = default;
+      Payload(const Payload&) {}
+    };
+    struct MoveOnly {
+      Payload p;
+      MoveOnly(const MoveOnly&) = delete;
+      MoveOnly(MoveOnly&&) = default;
+    };
+    int take(MoveOnly m) { return 1; }
+    struct Taker {
+      Taker(MoveOnly m) {}
+    };
+    struct Fwd;
+    int take_fwd(Fwd f);
+  )";
+
+  GetAllTopLevelDecls(code, Decls, /*filter_implicitGenerated=*/false,
+                      /*interpreter_args=*/{"-include", "new"});
+  ASSERT_EQ(Decls.size(), 6);
+
+  // Function argument path (make_narg_call).
+  EXPECT_EQ(Cpp::MakeFunctionCallable(Decls[2]).getKind(),
+            Cpp::JitCall::kGenericCall);
+
+  // Constructor argument path (make_narg_ctor).
+  GetAllSubDecls(Decls[3], SubDecls);
+  ASSERT_TRUE(Cpp::IsConstructor(SubDecls[1]));
+  EXPECT_EQ(Cpp::MakeFunctionCallable(SubDecls[1]).getKind(),
+            Cpp::JitCall::kConstructorCall);
+
+  // A parameter type with no reachable definition is assumed copyable; the
+  // wrapper compile reports the incomplete type (captured: on Windows the
+  // MSVC-format diagnostic would fail MSBuild's output scan).
+  testing::internal::CaptureStderr();
+  EXPECT_EQ(Cpp::MakeFunctionCallable(Decls[5]).getKind(),
+            Cpp::JitCall::kUnknown);
+  EXPECT_FALSE(testing::internal::GetCapturedStderr().empty());
+}


### PR DESCRIPTION
Based on TClingCallFunc. make_narg_ctor never moved by-value arguments, and make_narg_call used a heuristic with triviality bits which is not comparable across standard libraries. Check the actual copy constructor at both sites, as TClingCallFunc does, completing the parameter type through GetOrForceDefinition first; a type with no reachable definition is assumed copyable and the wrapper compile reports otherwise.

Supersedes #971 (also addresses the review comments) as this PR is a superset of that one:
MSVC's std::unique_ptr has a non-trivial deleted copy constructor, so check assumes "don't move", passes lvalues, and fails compilation on Windows (RNTupleWriter::Append(std::unique_ptr<RNTupleModel>)). #971 alone would not have fixed it.

Fixes failures in the ROOT migration.