### PR TITLE
Expose bit-field position and width in variable reflection

### DIFF
--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -28,7 +28,10 @@ infrastructure are described first.
 
 ## Introspection
 
--
+- Added bit-field reflection: `IsBitFieldVariable`, `GetVariableBitWidth` and
+  `GetVariableBitOffset` report whether a data member is a bit-field, its
+  declared width in bits, and its bit offset within the enclosing object, so
+  language bindings can read and write bit-fields without guessing the layout.
 
 ## Just-in-Time Compilation
 

--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -3438,6 +3438,32 @@ int GetVariableBitWidth(ConstDeclRef var) {
   return INTEROP_RETURN(static_cast<int>(FD->getBitWidthValue()));
 }
 
+intptr_t GetVariableBitOffset(ConstDeclRef var, ConstDeclRef parent) {
+  INTEROP_TRACE(var, parent);
+  const auto* D = unwrap<Decl>(var);
+  const auto* FD = llvm::dyn_cast_or_null<FieldDecl>(D);
+  if (!FD || !FD->isBitField())
+    return INTEROP_RETURN(-1);
+
+  // GetVariableOffset already accounts for anonymous struct/union nesting
+  // and base-class subobject offsets, in whole bytes. Every level of that
+  // accumulation except this innermost field is a record-typed member or a
+  // base, both of which are byte-aligned -- so only FD can contribute
+  // sub-byte bits, and adding them back is exact.
+  const intptr_t byte_offset = GetVariableOffset(var, parent);
+  ASTContext& C = FD->getASTContext();
+  // Call ordering is load-bearing: getFieldOffset() needs FD's record layout,
+  // and this call sits outside the compat::SynthesizingCodeRAII that
+  // GetVariableOffset establishes for itself. It is safe only because the
+  // GetVariableOffset above already ran and left the layout cached in
+  // ASTContext. Do not reorder these two lines, and do not reach
+  // getFieldOffset on any path that skips GetVariableOffset.
+  const uint64_t sub_byte_bits = C.getFieldOffset(FD) % 8;
+  return INTEROP_RETURN(
+      static_cast<intptr_t>(static_cast<int64_t>(byte_offset) * 8 +
+                            static_cast<int64_t>(sub_byte_bits)));
+}
+
 // Check if the Access Specifier of the variable matches the provided value.
 bool CheckVariableAccess(ConstDeclRef var, AccessSpecifier AS) {
   const auto* D = unwrap<Decl>(var);

--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -3421,6 +3421,23 @@ intptr_t GetVariableOffset(ConstDeclRef var, ConstDeclRef parent) {
   return INTEROP_RETURN(GetVariableOffset(getInterp(), D, RD));
 }
 
+bool IsBitFieldVariable(ConstDeclRef var) {
+  INTEROP_TRACE(var);
+  const auto* D = unwrap<Decl>(var);
+  if (const auto* FD = llvm::dyn_cast_or_null<FieldDecl>(D))
+    return INTEROP_RETURN(FD->isBitField());
+  return INTEROP_RETURN(false);
+}
+
+int GetVariableBitWidth(ConstDeclRef var) {
+  INTEROP_TRACE(var);
+  const auto* D = unwrap<Decl>(var);
+  const auto* FD = llvm::dyn_cast_or_null<FieldDecl>(D);
+  if (!FD || !FD->isBitField())
+    return INTEROP_RETURN(-1);
+  return INTEROP_RETURN(static_cast<int>(FD->getBitWidthValue()));
+}
+
 // Check if the Access Specifier of the variable matches the provided value.
 bool CheckVariableAccess(ConstDeclRef var, AccessSpecifier AS) {
   const auto* D = unwrap<Decl>(var);

--- a/lib/CppInterOp/CppInterOp.td
+++ b/lib/CppInterOp/CppInterOp.td
@@ -985,6 +985,25 @@ value stored in the variable.}];
   ];
 }
 
+def IsBitFieldVariable : CppInterOpAPI {
+  let Doc = "Checks if the provided variable is a bit-field.";
+
+  let ReturnType = "bool";
+  let Args = [
+    Arg<"ConstDeclRef", "var">
+  ];
+}
+
+def GetVariableBitWidth : CppInterOpAPI {
+  let Doc = [{Gets the declared bit width of a bit-field.
+Returns -1 if the variable is not a bit-field.}];
+
+  let ReturnType = "int";
+  let Args = [
+    Arg<"ConstDeclRef", "var">
+  ];
+}
+
 def IsPublicVariable : CppInterOpAPI {
   let Doc = "Checks if the provided variable is a 'Public' variable.";
 

--- a/lib/CppInterOp/CppInterOp.td
+++ b/lib/CppInterOp/CppInterOp.td
@@ -1004,6 +1004,26 @@ Returns -1 if the variable is not a bit-field.}];
   ];
 }
 
+def GetVariableBitOffset : CppInterOpAPI {
+  let Doc = [{Gets the offset of a bit-field in bits, relative to the start
+of parent if parent is supplied, otherwise relative to the field's
+outermost non-anonymous enclosing record. Returns -1 if the variable is not
+a bit-field. A bit-field has no address of its own, so this is layout
+information for masked access, not something that can be turned into a
+pointer.
+
+Not supported for a bit-field inside a virtual base subobject: the
+underlying byte-offset computation only has a table of non-virtual base
+offsets, so a virtual base silently reads back an offset of 0 instead of
+the true one.}];
+
+  let ReturnType = "intptr_t";
+  let Args = [
+    Arg<"ConstDeclRef", "var">,
+    Arg<"ConstDeclRef", "parent", "nullptr">
+  ];
+}
+
 def IsPublicVariable : CppInterOpAPI {
   let Doc = "Checks if the provided variable is a 'Public' variable.";
 

--- a/unittests/CppInterOp/VariableReflectionTest.cpp
+++ b/unittests/CppInterOp/VariableReflectionTest.cpp
@@ -1038,3 +1038,128 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, VariableReflection_BitFieldBasics) {
   EXPECT_EQ(Cpp::GetVariableBitWidth(datamembers[2]), 4);
   EXPECT_EQ(Cpp::GetVariableBitWidth(datamembers[3]), -1);
 }
+
+TYPED_TEST(CPPINTEROP_TEST_MODE, VariableReflection_BitFieldOffset) {
+  std::vector<Decl*> Decls;
+  std::string code = R"(
+    struct Simple {
+      unsigned int a : 1;
+      unsigned int b : 2;
+      unsigned int c : 4;
+      unsigned int d : 1;
+      unsigned int e : 8;
+    };
+    struct WithLead {
+      char pad;
+      unsigned int x : 3;
+      unsigned int y : 5;
+    };
+    struct Base { unsigned int bb : 6; };
+    struct A1 { char c; };
+    struct MI : A1, Base {};
+    struct Anon {
+      char pad;
+      struct { unsigned int u : 3; unsigned int v : 5; };
+    };
+    struct DeepAnon {
+      char pad;
+      union { struct { unsigned u : 3; unsigned v : 5; }; unsigned long long w; };
+    };
+  )";
+  GetAllTopLevelDecls(code, Decls);
+
+  std::vector<Cpp::DeclRef> simple;
+  Cpp::GetDatamembers(Decls[0], simple);
+  EXPECT_EQ(Cpp::GetVariableBitOffset(simple[0]), 0);
+  EXPECT_EQ(Cpp::GetVariableBitOffset(simple[1]), 1);
+  EXPECT_EQ(Cpp::GetVariableBitOffset(simple[2]), 3);
+  EXPECT_EQ(Cpp::GetVariableBitOffset(simple[3]), 7);
+  EXPECT_EQ(Cpp::GetVariableBitOffset(simple[4]), 8);
+
+  std::vector<Cpp::DeclRef> lead;
+  Cpp::GetDatamembers(Decls[1], lead);
+  // not a bitfield -> -1
+  EXPECT_EQ(Cpp::GetVariableBitOffset(lead[0]), -1);
+
+  // Multiple inheritance: Base::bb reached through MI. MI's first base (A1,
+  // 1 byte) is followed by Base, which still needs 4-byte alignment for its
+  // bit-field, so Base lands at a non-zero, non-trivial byte offset within
+  // MI -- unlike `struct Derived : Base` alone, whose base offset is 0 and
+  // so can't distinguish a working base-class DFS from one that never runs
+  // (GetDatamembers does not walk base classes, so Base::bb has to be
+  // looked up directly on Base and passed through with parent = MI).
+  std::vector<Cpp::DeclRef> base_members;
+  Cpp::GetDatamembers(Decls[2], base_members);
+  ASSERT_FALSE(base_members.empty());
+  EXPECT_EQ(Cpp::GetVariableBitOffset(base_members[0], Decls[4]), 32);
+
+  // anonymous struct member: offset must include the 8 bits of `pad` plus
+  // the padding needed to reach 4-byte alignment for the anonymous struct.
+  std::vector<Cpp::DeclRef> anon;
+  Cpp::GetDatamembers(Decls[5], anon);
+  ASSERT_EQ(anon.size(), 3U); // pad, u, v
+  EXPECT_EQ(Cpp::GetVariableBitOffset(anon[1], Decls[5]), 32);
+  EXPECT_EQ(Cpp::GetVariableBitOffset(anon[2], Decls[5]), 35);
+
+  // Two-level anonymous nesting: an anonymous struct inside an anonymous
+  // union, itself inside a named struct.
+  std::vector<Cpp::DeclRef> deep_anon;
+  Cpp::GetDatamembers(Decls[6], deep_anon);
+  ASSERT_EQ(deep_anon.size(), 4U); // pad, u, v, w
+  EXPECT_EQ(Cpp::GetVariableBitOffset(deep_anon[1], Decls[6]), 64);
+  EXPECT_EQ(Cpp::GetVariableBitOffset(deep_anon[2], Decls[6]), 67);
+
+  // Invariant the downstream cppjit reader actually depends on: the byte
+  // part of the bit offset always agrees with GetVariableOffset, on every
+  // ABI -- this holds even where the exact bit value below is ABI-specific
+  // (WithLead), so check it for every bit-field across every fixture here.
+  auto check_invariant = [](Cpp::DeclRef m, Cpp::DeclRef p) {
+    if (Cpp::IsBitFieldVariable(m)) {
+      EXPECT_EQ(Cpp::GetVariableBitOffset(m, p) / 8,
+                Cpp::GetVariableOffset(m, p));
+    }
+  };
+  for (auto m : simple)
+    check_invariant(m, nullptr);
+  for (auto m : lead)
+    check_invariant(m, nullptr);
+  check_invariant(base_members[0], Decls[4]);
+  for (auto m : anon)
+    check_invariant(m, Decls[5]);
+  for (auto m : deep_anon)
+    check_invariant(m, Decls[6]);
+
+  // The ABI-specific WithLead bit offsets live in
+  // VariableReflection_BitFieldOffsetItaniumABI below, so that its Windows
+  // skip can be an early one like every other skip in this file.
+}
+
+// Split out of VariableReflection_BitFieldOffset purely so the skip can come
+// first: these offsets depend on the ABI's rule for a bit-field that follows a
+// non-bit-field member. The Itanium ABI packs it into the padding after `pad`
+// (offsets 8 and 11); the MS ABI starts a fresh allocation unit instead
+// (32 and 35). A tail GTEST_SKIP() in the parent test would be silently
+// disabled by anyone appending an assertion after it.
+TYPED_TEST(CPPINTEROP_TEST_MODE, VariableReflection_BitFieldOffsetItaniumABI) {
+#ifdef _WIN32
+  GTEST_SKIP() << "WithLead bit-offsets assume the Itanium ABI's rule for a "
+                  "bit-field following a non-bit-field; the MS ABI starts a "
+                  "fresh allocation unit instead.";
+#endif
+
+  std::vector<Decl*> Decls;
+  std::string code = R"(
+    struct WithLead {
+      char pad;
+      unsigned int x : 3;
+      unsigned int y : 5;
+    };
+  )";
+  GetAllTopLevelDecls(code, Decls);
+
+  std::vector<Cpp::DeclRef> lead;
+  Cpp::GetDatamembers(Decls[0], lead);
+  ASSERT_EQ(lead.size(), 3U); // pad, x, y
+  EXPECT_EQ(Cpp::GetVariableBitOffset(lead[1]), 8);
+  EXPECT_EQ(Cpp::GetVariableBitOffset(lead[2]), 11);
+}

--- a/unittests/CppInterOp/VariableReflectionTest.cpp
+++ b/unittests/CppInterOp/VariableReflectionTest.cpp
@@ -1011,3 +1011,30 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, VariableReflection_GetPointerType) {
   EXPECT_EQ(Cpp::GetPointerType(Cpp::GetVariableType(Decls[5])),
             Cpp::GetVariableType(Decls[6]));
 }
+
+TYPED_TEST(CPPINTEROP_TEST_MODE, VariableReflection_BitFieldBasics) {
+  std::vector<Decl*> Decls;
+  std::string code = R"(
+    struct S {
+      unsigned int a : 1;
+      unsigned int b : 2;
+      unsigned int c : 4;
+      int plain;
+    };
+  )";
+  GetAllTopLevelDecls(code, Decls);
+
+  std::vector<Cpp::DeclRef> datamembers;
+  Cpp::GetDatamembers(Decls[0], datamembers);
+  ASSERT_EQ(datamembers.size(), 4U);
+
+  EXPECT_TRUE(Cpp::IsBitFieldVariable(datamembers[0]));
+  EXPECT_TRUE(Cpp::IsBitFieldVariable(datamembers[1]));
+  EXPECT_TRUE(Cpp::IsBitFieldVariable(datamembers[2]));
+  EXPECT_FALSE(Cpp::IsBitFieldVariable(datamembers[3]));
+
+  EXPECT_EQ(Cpp::GetVariableBitWidth(datamembers[0]), 1);
+  EXPECT_EQ(Cpp::GetVariableBitWidth(datamembers[1]), 2);
+  EXPECT_EQ(Cpp::GetVariableBitWidth(datamembers[2]), 4);
+  EXPECT_EQ(Cpp::GetVariableBitWidth(datamembers[3]), -1);
+}


### PR DESCRIPTION
A bit-field data member is indistinguishable from an ordinary one through the reflection API: nothing reports whether a variable is a bit-field or how many bits it declares, and `GetVariableOffset` converts the field offset with `toCharUnitsFromBits`, which truncates to whole bytes and discards the sub-byte position. A binding layer is therefore forced to treat a bit-field as a whole-width member and read or write the entire storage unit containing it — returning the neighbouring fields on a read and clobbering them on a write.

`IsBitFieldVariable` and `GetVariableBitWidth` expose `FieldDecl::isBitField()` and `getBitWidthValue()`. Both return a `false` / `-1` sentinel for a non-bit-field or a non-`FieldDecl`, so any variable can be queried without first checking its kind.

`GetVariableBitOffset` recovers the discarded position without duplicating the record-layout walk:

```
bit_offset = 8 * GetVariableOffset(var, parent) + getFieldOffset(FD) % 8
```

This is exact. `GetVariableOffset` already accumulates anonymous struct/union nesting and non-virtual base-class offsets, and every level of that accumulation apart from the innermost field is a record-typed member or a base subobject, both of which are byte-aligned; only the innermost `FieldDecl` can sit at a sub-byte offset. The residue is in fact frame-independent: `getFieldOffset` is relative to `FD->getParent()` while the accumulated byte offset is relative to `parent`, but the two frames differ by a sum of exact multiples of 8 bits, and residues mod 8 are invariant under adding those.

Delegating rather than walking the layout a second time also makes `floor(GetVariableBitOffset(v, p) / 8)` equal `GetVariableOffset(v, p)` **by construction**, so a caller's byte offset and its shift can never disagree. An independent walk would not have that property, and a disagreement between the two is precisely the silent corruption these APIs exist to prevent — so the delegation is deliberate rather than an economy.

A field in a virtual base subobject is not supported, and the limitation is documented on the API. The byte offset ultimately comes from `ASTRecordLayout::getBaseClassOffset`, which consults `BaseOffsets` — non-virtual bases only — so an assertions-off build reads a default-inserted `CharUnits(0)` and also pollutes the cached layout. That is pre-existing in `GetVariableOffset` (the byte offset is wrong for the same field today) and is left alone here to keep this change atomic; it deserves its own issue and fix, presumably via `getVBaseClassOffset`.

Tested in `VariableReflectionTest` for the true and false cases, declared widths, offsets both at and away from a byte boundary, a bit-field reached through multiple inheritance (where the base offset is non-zero, so the base-class traversal genuinely runs), and two-level anonymous struct-in-union nesting. The suite also asserts the `floor(bit_offset / 8) == GetVariableOffset` invariant over every bit-field in every fixture, which is ABI-independent and therefore the strongest available check. The few ABI-dependent absolute offsets live in a separate `VariableReflection_BitFieldOffsetItaniumABI` test, skipped early on Windows, because the MS ABI starts a fresh allocation unit for a bit-field that follows a non-bit-field.

This is the CppJIT-side equivalent of wlav/cppyy#57. The fixes for that issue against the cppyy stack were wlav/CPyCppyy#69, wlav/cppyy#332 and wlav/cppyy-backend#39; rather than merge them, the issue's maintainer directed the work upstream to compiler-research, noting a new backend would need a different placement. The four-hop cling chain those PRs added (`TClingDataMemberInfo` → `TCling` → `TDataMember` → `Cppyy::` → C API) collapses into the three APIs here.

The downstream consumer is compiler-research/cppjit#73, which uses these three APIs to fix Python-level bit-field reads and writes; it cannot build until this lands and its `CPPINTEROP_GIT_TAG` is bumped.
