### PR TITLE
Add an optional reason out-parameter to LoadLibrary

### DIFF
--- a/include/CppInterOp/CXCppInterOp.h
+++ b/include/CppInterOp/CXCppInterOp.h
@@ -63,6 +63,10 @@ CPPINTEROP_API intptr_t cppinterop_Evaluate(const char* code, bool* HadError);
 CPPINTEROP_API CppInterOpArray
 cppinterop_GetClassTemplatedMethods(const char* name, CppConstDeclRef parent);
 
+/// C-ABI bridge for \c Cpp::LoadLibrary. The optional \c std::string*
+/// reason argument is C++-only, so the generated wrapper is suppressed.
+CPPINTEROP_API bool cppinterop_LoadLibrary(const char* lib_stem, bool lookup);
+
 #ifdef __cplusplus
 } // extern "C"
 #pragma clang diagnostic pop

--- a/lib/CppInterOp/CXCppInterOp.cpp
+++ b/lib/CppInterOp/CXCppInterOp.cpp
@@ -61,6 +61,11 @@ CPPINTEROP_API intptr_t cppinterop_Evaluate(const char* code, bool* HadError) {
   return Cpp::Evaluate(code, HadError);
 }
 
+// The std::string* reason argument of Cpp::LoadLibrary is C++-only.
+CPPINTEROP_API bool cppinterop_LoadLibrary(const char* lib_stem, bool lookup) {
+  return Cpp::LoadLibrary(lib_stem, lookup);
+}
+
 // GetClassTemplatedMethods returns bool AND fills a vector out-param.
 // The C wrapper drops the bool (caller checks arr.size > 0 instead).
 CPPINTEROP_API Cpp::CppInterOpArray

--- a/lib/CppInterOp/CppInterOp.cpp
+++ b/lib/CppInterOp/CppInterOp.cpp
@@ -5746,10 +5746,26 @@ std::string LookupLibrary(const char* lib_name) {
       getInterp().getDynamicLibraryManager()->lookupLibrary(lib_name));
 }
 
-bool LoadLibrary(const char* lib_stem, bool lookup) {
-  INTEROP_TRACE(lib_stem, lookup);
+bool LoadLibrary(const char* lib_stem, bool lookup, std::string* error) {
+  INTEROP_TRACE(lib_stem, lookup, error);
+  if (error)
+    error->clear();
+#ifdef CPPINTEROP_USE_CLING
+  // cling::Interpreter::loadLibrary has no reason channel; report what the
+  // lookup alone can tell.
   compat::Interpreter::CompilationResult res =
       getInterp().loadLibrary(lib_stem, lookup);
+  if (res != compat::Interpreter::kSuccess && error) {
+    bool NotFound =
+        lookup &&
+        getInterp().getDynamicLibraryManager()->lookupLibrary(lib_stem).empty();
+    *error = std::string(lib_stem) +
+             (NotFound ? ": library not found" : ": failed to load");
+  }
+#else
+  compat::Interpreter::CompilationResult res =
+      getInterp().loadLibrary(lib_stem, lookup, error);
+#endif
 
   return INTEROP_RETURN(res == compat::Interpreter::kSuccess);
 }

--- a/lib/CppInterOp/CppInterOp.td
+++ b/lib/CppInterOp/CppInterOp.td
@@ -245,12 +245,20 @@ GetResourceDir() function.}];
 def LoadLibrary : CppInterOpAPI {
   let Doc = [{Finds \c lib_stem considering the list of search paths and loads it by
 calling dlopen.
+\param[out] error - if non-null, receives the reason a load failed (the
+           dlerror() text, or a not-found note when lookup fails). When it
+           is set the reason is not also written to stderr. The Cling
+           backend only reports a generic note.
 \returns true on success.}];
 
+  // std::string* cannot cross the C ABI; CXCppInterOp.cpp keeps the
+  // two-argument cppinterop_LoadLibrary wrapper by hand.
+  let NoCWrapper = true;
   let ReturnType = "bool";
   let Args = [
     Arg<"const char*", "lib_stem">,
-    Arg<"bool", "lookup", "true">
+    Arg<"bool", "lookup", "true">,
+    Arg<"std::string*", "error", "nullptr">
   ];
 }
 

--- a/lib/CppInterOp/CppInterOpInterpreter.h
+++ b/lib/CppInterOp/CppInterOpInterpreter.h
@@ -586,16 +586,22 @@ public:
                                          incpaths, withSystem, withFlags);
   }
 
-  CompilationResult loadLibrary(const std::string& filename, bool lookup) {
+  CompilationResult loadLibrary(const std::string& filename, bool lookup,
+                                std::string* error = nullptr) {
     llvm::Triple triple(getCompilerInstance()->getTargetOpts().Triple);
     if (triple.isWasm()) {
+      // LCOV_EXCL_START -- no coverage lane runs the wasm path.
       // On WASM, dlopen-style canonical lookup has no effect.
       if (auto Err = inner->LoadDynamicLibrary(filename.c_str())) {
-        llvm::logAllUnhandledErrors(std::move(Err), llvm::errs(),
-                                    "loadLibrary: ");
+        std::string Msg = llvm::toString(std::move(Err));
+        if (error)
+          *error = std::move(Msg);
+        else
+          llvm::errs() << "loadLibrary: " << Msg << '\n';
         return kFailure;
       }
       return kSuccess;
+      // LCOV_EXCL_STOP
     }
 
     DynamicLibraryManager* DLM = getDynamicLibraryManager();
@@ -604,9 +610,14 @@ public:
       canonicalLib = DLM->lookupLibrary(filename);
 
     const std::string& library = lookup ? canonicalLib : filename;
-    if (!library.empty()) {
-      switch (
-          DLM->loadLibrary(library, /*permanent*/ false, /*resolved*/ true)) {
+    if (library.empty()) {
+      if (error)
+        *error = filename + ": library not found";
+      return kMoreInputExpected;
+    }
+    {
+      switch (DLM->loadLibrary(library, /*permanent*/ false, /*resolved*/ true,
+                               error)) {
       case DynamicLibraryManager::kLoadLibSuccess: // Intentional fall through
       case DynamicLibraryManager::kLoadLibAlreadyLoaded:
         return kSuccess;
@@ -618,7 +629,6 @@ public:
         return kFailure;
       }
     }
-    return kMoreInputExpected;
   }
 
   std::string toString(const char* type, void* obj) {

--- a/lib/CppInterOp/DynamicLibraryManager.cpp
+++ b/lib/CppInterOp/DynamicLibraryManager.cpp
@@ -24,6 +24,7 @@
 #endif
 
 #include <fstream>
+#include <iostream>
 #include <sys/stat.h>
 #include <system_error>
 
@@ -369,6 +370,9 @@ DynamicLibraryManager::loadLibrary(StringRef libStem, bool permanent,
     // We emit callback to LibraryLoadingFailed when we get error with error
     // message.
     // TODO: Implement callbacks
+
+    if (!errMsg.empty())
+      std::cerr << errMsg << '\n';
 
     LLVM_DEBUG(dbgs() << "DynamicLibraryManager::loadLibrary(): " << errMsg);
 

--- a/lib/CppInterOp/DynamicLibraryManager.cpp
+++ b/lib/CppInterOp/DynamicLibraryManager.cpp
@@ -344,7 +344,7 @@ std::string DynamicLibraryManager::lookupLibrary(
 
 DynamicLibraryManager::LoadLibResult
 DynamicLibraryManager::loadLibrary(StringRef libStem, bool permanent,
-                                   bool resolved) {
+                                   bool resolved, std::string* errMsg) {
 #define DEBUG_TYPE "Dyld::loadLibrary:"
   LLVM_DEBUG(dbgs() << "Dyld::loadLibrary: " << libStem.str() << ", "
                     << (permanent ? "permanent" : "not-permanent") << ", "
@@ -364,17 +364,19 @@ DynamicLibraryManager::loadLibrary(StringRef libStem, bool permanent,
 
   // TODO: !permanent case
 
-  std::string errMsg;
-  DyLibHandle dyLibHandle = platform::DLOpen(canonicalLoadedLib, &errMsg);
+  std::string loadErr;
+  DyLibHandle dyLibHandle = platform::DLOpen(canonicalLoadedLib, &loadErr);
   if (!dyLibHandle) {
     // We emit callback to LibraryLoadingFailed when we get error with error
     // message.
     // TODO: Implement callbacks
 
-    if (!errMsg.empty())
-      std::cerr << errMsg << '\n';
+    if (errMsg)
+      *errMsg = loadErr;
+    else if (!loadErr.empty())
+      std::cerr << loadErr << '\n';
 
-    LLVM_DEBUG(dbgs() << "DynamicLibraryManager::loadLibrary(): " << errMsg);
+    LLVM_DEBUG(dbgs() << "DynamicLibraryManager::loadLibrary(): " << loadErr);
 
     return kLoadLibLoadError;
   }

--- a/lib/CppInterOp/DynamicLibraryManager.h
+++ b/lib/CppInterOp/DynamicLibraryManager.h
@@ -163,13 +163,16 @@ public:
   ///\param [in] permanent - If false, the file can be unloaded later.
   ///\param [in] resolved - Whether libStem is an absolute path or resolved
   ///               from a previous call to DynamicLibraryManager::lookupLibrary
+  ///\param [out] errMsg - If non-null, receives the loader's error text on
+  ///               kLoadLibLoadError instead of it going to stderr.
   ///
   ///\returns kLoadLibSuccess on success, kLoadLibAlreadyLoaded if the library
   /// was already loaded, kLoadLibError if the library cannot be found or any
   /// other error was encountered.
   ///
   LoadLibResult loadLibrary(llvm::StringRef, bool permanent,
-                            bool resolved = false);
+                            bool resolved = false,
+                            std::string* errMsg = nullptr);
 
   void unloadLibrary(llvm::StringRef libStem);
 

--- a/unittests/CppInterOp/CAPITest.cpp
+++ b/unittests/CppInterOp/CAPITest.cpp
@@ -18,6 +18,12 @@ TYPED_TEST(CppInterOpTest, CAPI_DeclareAndProcess) {
   EXPECT_EQ(0, cppinterop_Process("capi_var++;"));
 }
 
+TYPED_TEST(CppInterOpTest, CAPI_LoadLibrary) {
+  TestFixture::CreateInterpreter();
+  // The hand-written two-argument wrapper still exists and forwards.
+  EXPECT_FALSE(cppinterop_LoadLibrary("no-such-cppinterop-lib", true));
+}
+
 TYPED_TEST(CppInterOpTest, CAPI_ScopeQueries) {
   TestFixture::CreateInterpreter();
   Cpp::Declare("namespace CAPINs { class Foo {}; }");

--- a/unittests/CppInterOp/DynamicLibraryManagerTest.cpp
+++ b/unittests/CppInterOp/DynamicLibraryManagerTest.cpp
@@ -3,8 +3,11 @@
 
 #include "clang/Basic/Version.h"
 
+#include "llvm/ADT/SmallString.h"
+
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/Path.h"
+#include "llvm/Support/raw_ostream.h"
 
 #include "gtest/gtest.h"
 
@@ -67,6 +70,36 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, DynamicLibraryManager_Sanity) {
   // require the library to be actually unloaded but just the handle to be
   // invalidated...
   // EXPECT_FALSE(Cpp::GetFunctionAddress("ret_zero"));
+}
+
+// A failed dlopen must report the dlerror() text on stderr.
+TYPED_TEST(CPPINTEROP_TEST_MODE, DynamicLibraryManager_LoadFailureReason) {
+#if defined(EMSCRIPTEN) || defined(_WIN32)
+  GTEST_SKIP() << "Test checks dlerror-style messages";
+#endif
+  if (TypeParam::isOutOfProcess)
+    GTEST_SKIP() << "Test fails for OOP JIT builds";
+
+  EXPECT_TRUE(TestFixture::CreateInterpreter());
+
+  // A file that exists but is not a shared library makes dlopen fail.
+  int FD = -1;
+  llvm::SmallString<256> BadLib;
+  ASSERT_FALSE(llvm::sys::fs::createTemporaryFile("bad-lib", "so", FD, BadLib));
+  {
+    llvm::raw_fd_ostream OS(FD, /*shouldClose=*/true);
+    OS << "not a shared library";
+  }
+
+  testing::internal::CaptureStderr();
+  EXPECT_FALSE(Cpp::LoadLibrary(BadLib.c_str(), /*lookup=*/false));
+  std::string Err = testing::internal::GetCapturedStderr();
+  // dlerror() names the failing file.
+  EXPECT_NE(Err.find(llvm::sys::path::filename(BadLib).str()),
+            std::string::npos)
+      << "stderr was: '" << Err << "'";
+
+  EXPECT_FALSE(llvm::sys::fs::remove(BadLib));
 }
 
 TYPED_TEST(CPPINTEROP_TEST_MODE, DynamicLibraryManager_BasicSymbolLookup) {

--- a/unittests/CppInterOp/DynamicLibraryManagerTest.cpp
+++ b/unittests/CppInterOp/DynamicLibraryManagerTest.cpp
@@ -99,6 +99,33 @@ TYPED_TEST(CPPINTEROP_TEST_MODE, DynamicLibraryManager_LoadFailureReason) {
             std::string::npos)
       << "stderr was: '" << Err << "'";
 
+  // With an out-parameter the reason goes there and not to stderr.
+  std::string Reason = "stale";
+  testing::internal::CaptureStderr();
+  EXPECT_FALSE(Cpp::LoadLibrary(BadLib.c_str(), /*lookup=*/false, &Reason));
+#ifdef CPPINTEROP_USE_CLING
+  testing::internal::GetCapturedStderr(); // cling still prints its own text
+#else
+  EXPECT_EQ(testing::internal::GetCapturedStderr(), "");
+#endif
+  EXPECT_NE(Reason.find(llvm::sys::path::filename(BadLib).str()),
+            std::string::npos)
+      << "reason was: '" << Reason << "'";
+
+  // A failed lookup reports that too.
+  EXPECT_FALSE(
+      Cpp::LoadLibrary("no-such-cppinterop-lib", /*lookup=*/true, &Reason));
+  EXPECT_NE(Reason.find("no-such-cppinterop-lib"), std::string::npos)
+      << "reason was: '" << Reason << "'";
+
+  // Success clears a stale reason.
+  std::string BinaryPath = GetExecutablePath(/*Argv0=*/nullptr);
+  Cpp::AddSearchPath(llvm::sys::path::parent_path(BinaryPath).str().c_str());
+  Reason = "stale";
+  EXPECT_TRUE(Cpp::LoadLibrary("TestSharedLib", /*lookup=*/true, &Reason))
+      << "reason was: '" << Reason << "'";
+  EXPECT_EQ(Reason, "");
+
   EXPECT_FALSE(llvm::sys::fs::remove(BadLib));
 }
 


### PR DESCRIPTION
Follow-up to #1101 from the discussion on compiler-research/cppjit#63; this branch is stacked on #1101.

`Cpp::LoadLibrary(lib_stem, lookup, std::string* error = nullptr)`. When `error` is set it receives the dlerror() text, or `<stem>: library not found` when the search-path lookup fails, and the reason is not also printed to stderr. The two-argument form keeps the #1101 behaviour.

- `std::string*` cannot cross the C ABI, so the .td entry is `NoCWrapper` and `cppinterop_LoadLibrary(const char*, bool)` is kept by hand in CXCppInterOp.cpp, with a test.
- `DynamicLibraryManager_LoadFailureReason` now covers a dlopen failure, a failed lookup, and that success clears a stale reason.

Once this lands, cppjit#63 bumps its pin and reads the reason from here instead of the ctypes probe.



Coverage: the wasm branch of `Interpreter::loadLibrary` is wrapped in `LCOV_EXCL_START/STOP`, since no coverage lane runs it.


